### PR TITLE
feat(web): AI suggested plays and bid recommendations

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -462,6 +462,63 @@ class MatchEngine:
             hand.trump,
         )
 
+    def get_suggested_play(self, state: MatchState) -> int | None:
+        """Return the AI's recommended card index for the human player.
+
+        Uses the same ``play_strategy.choose_card()`` that AI opponents use
+        to pick the card the AI would play in the human's position.
+        Returns ``None`` if it's not the human's turn to play.
+        """
+        hand = state.current_hand
+        if hand is None or hand.phase != "trick_play":
+            return None
+        if hand.current_seat != HUMAN_SEAT:
+            return None
+        if hand.current_trick is None or hand.contract_type is None:
+            return None
+        try:
+            return self.play_strategy.choose_card(
+                hand.hands[HUMAN_SEAT],
+                hand.current_trick.plays,
+                hand.contract_type,
+                hand.trump,
+                HUMAN_SEAT,
+            )
+        except Exception:
+            logger.debug("AI suggestion for play failed", exc_info=True)
+            return None
+
+    def get_suggested_bid(self, state: MatchState) -> dict[str, Any] | None:
+        """Return the AI's recommended bid for the human player.
+
+        Uses the same ``bidding_policy.choose_bid()`` that AI opponents use
+        to pick the bid the AI would make in the human's position.
+        Returns a dict with ``n``, ``contract``, ``bid_type`` keys, or
+        ``None`` if it's not the human's turn to bid.
+        """
+        hand = state.current_hand
+        if hand is None or hand.phase != "auction":
+            return None
+        if hand.current_seat != HUMAN_SEAT:
+            return None
+        try:
+            obs = BiddingObservation(
+                hand=hand.hands[HUMAN_SEAT],
+                seat=HUMAN_SEAT,
+                dealer_seat=hand.dealer_seat,
+                current_high_bid=hand.current_high_bid,
+                auction_transcript=tuple(hand.auction),
+            )
+            bid = self.bidding_policy.choose_bid(obs)
+            return {
+                "n": bid.n,
+                "contract": bid.contract,
+                "bid_type": bid.bid_type,
+            }
+        except Exception:
+            logger.debug("AI suggestion for bid failed", exc_info=True)
+            return None
+
     def get_visible_state(self, state: MatchState) -> dict[str, Any]:
         """Return state visible to the human player.
 

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -3004,3 +3004,141 @@ class TestFinalTrickPause:
                 return  # Test passed
 
         pytest.skip("No seed produced a complete hand with paused_after_trick")
+
+
+# ---------------------------------------------------------------------------
+# AI Suggestions (#2185)
+# ---------------------------------------------------------------------------
+
+
+class TestGetSuggestedPlay:
+    """Tests for MatchEngine.get_suggested_play()."""
+
+    def test_returns_legal_card_index_on_human_turn(self, engine: MatchEngine):
+        """Suggested play should be a valid legal card index."""
+        state = engine.start_match(SEED, "heuristic")
+        # Advance to human play turn
+        state = _advance_to_human_play(engine, state)
+        hand = state.current_hand
+        if hand is None or hand.phase != "trick_play":
+            pytest.skip("No human play turn reached with this seed")
+
+        suggestion = engine.get_suggested_play(state)
+        assert suggestion is not None
+        legal = engine.get_legal_plays(state)
+        assert suggestion in legal
+
+    def test_returns_none_during_auction(self, engine: MatchEngine):
+        """Suggested play should be None when in auction phase."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        if (
+            hand is not None
+            and hand.phase == "auction"
+            and hand.current_seat == HUMAN_SEAT
+        ):
+            assert engine.get_suggested_play(state) is None
+
+    def test_returns_none_when_not_human_turn(self, engine: MatchEngine):
+        """Suggested play should be None when it's not the human's turn."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        # After start_match, AI has advanced — if it's not human's turn, should be None
+        if hand is not None and hand.current_seat != HUMAN_SEAT:
+            assert engine.get_suggested_play(state) is None
+
+    def test_returns_none_when_no_hand(self, engine: MatchEngine):
+        """Suggested play should be None when current_hand is None."""
+        state = MatchState(seed=SEED, ai_model="heuristic")
+        assert engine.get_suggested_play(state) is None
+
+
+class TestGetSuggestedBid:
+    """Tests for MatchEngine.get_suggested_bid()."""
+
+    def test_returns_bid_dict_on_human_auction_turn(self, engine: MatchEngine):
+        """Suggested bid should return a dict with n, contract, bid_type."""
+        for seed in range(100):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "auction"
+                and hand.current_seat == HUMAN_SEAT
+            ):
+                suggestion = engine.get_suggested_bid(state)
+                assert suggestion is not None
+                assert "n" in suggestion
+                assert "contract" in suggestion
+                assert "bid_type" in suggestion
+                assert isinstance(suggestion["n"], int)
+                assert 0 <= suggestion["n"] <= 10
+                return
+        pytest.skip("No seed produced a human auction turn")
+
+    def test_returns_none_during_trick_play(self, engine: MatchEngine):
+        """Suggested bid should be None during trick play."""
+        state = engine.start_match(SEED, "heuristic")
+        state = _advance_to_human_play(engine, state)
+        hand = state.current_hand
+        if hand is not None and hand.phase == "trick_play":
+            assert engine.get_suggested_bid(state) is None
+
+    def test_returns_none_when_not_human_turn(self, engine: MatchEngine):
+        """Suggested bid should be None when it's not the human's turn."""
+        state = engine.start_match(SEED, "heuristic")
+        hand = state.current_hand
+        if (
+            hand is not None
+            and hand.phase == "auction"
+            and hand.current_seat != HUMAN_SEAT
+        ):
+            assert engine.get_suggested_bid(state) is None
+
+    def test_returns_none_when_no_hand(self, engine: MatchEngine):
+        """Suggested bid should be None when current_hand is None."""
+        state = MatchState(seed=SEED, ai_model="heuristic")
+        assert engine.get_suggested_bid(state) is None
+
+
+def _advance_to_human_play(engine: MatchEngine, state: MatchState) -> MatchState:
+    """Advance state until the human has a play turn (trick_play phase)."""
+    hand = state.current_hand
+    if hand is None:
+        return state
+
+    # If auction, submit a bid for human
+    if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+        state = engine.submit_human_bid(state, BidAction.pass_bid())
+        hand = state.current_hand
+
+    # Handle exchange
+    if (
+        hand is not None
+        and hand.phase == "moon_exchange"
+        and hand.exchange_phase == "selecting"
+    ):
+        state = engine.submit_exchange_selection(state, [0, 1])
+        hand = state.current_hand
+
+    # Advance through next steps to reach trick play
+    for _ in range(50):
+        hand = state.current_hand
+        if hand is None:
+            break
+        if hand.phase == "trick_play" and hand.current_seat == HUMAN_SEAT:
+            if not hand.paused_after_play and not hand.paused_after_trick:
+                return state
+        if hand.paused_after_play or hand.paused_after_trick:
+            hand.paused_after_play = False
+            hand.paused_after_trick = False
+            state = engine.resume_ai(state)
+            continue
+        if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+            state = engine.submit_human_bid(state, BidAction.pass_bid())
+            continue
+        if hand.phase in ("complete", "redeal"):
+            break
+        break
+
+    return state

--- a/web/routes.py
+++ b/web/routes.py
@@ -662,8 +662,17 @@ def _build_game_context(
             and not show_next
         ):
             ctx["legal_plays"] = engine.get_legal_plays(state)
+            # AI suggested play — the card index the AI recommends
+            ctx["suggested_card_index"] = engine.get_suggested_play(state)
         else:
             ctx["legal_plays"] = None
+            ctx["suggested_card_index"] = None
+
+        # AI suggested bid — shown during the human's bid turn
+        if ctx["show_bid_panel"]:
+            ctx["suggested_bid"] = engine.get_suggested_bid(state)
+        else:
+            ctx["suggested_bid"] = None
 
         # Currently winning seat in the active trick (for highlight).
         trick = hand.current_trick if hand.current_trick is not None else None
@@ -708,6 +717,8 @@ def _build_game_context(
         ctx["points_team0"] = 0
         ctx["points_team1"] = 0
         ctx["legal_plays"] = None
+        ctx["suggested_card_index"] = None
+        ctx["suggested_bid"] = None
         ctx["trick_winning_seat"] = None
         ctx["opp_left_count"] = 0
         ctx["partner_count"] = 0

--- a/web/static/game.js
+++ b/web/static/game.js
@@ -433,6 +433,55 @@
     }
 
     /* ---------------------------------------------------------------
+     * AI hints toggle — off by default, opt-in via header button (#2185).
+     * Persisted in sessionStorage (per-tab, resets on close).
+     * The inline <script> in base.html applies the attribute before
+     * first paint to avoid FOUC.
+     * --------------------------------------------------------------- */
+
+    var AI_HINTS_KEY = 'aiHints';
+
+    function isAiHintsOn() {
+        try {
+            return sessionStorage.getItem(AI_HINTS_KEY) === 'on';
+        } catch (_) {
+            return document.documentElement.getAttribute('data-ai-hints') === 'on';
+        }
+    }
+
+    function setAiHints(on) {
+        try {
+            if (on) {
+                sessionStorage.setItem(AI_HINTS_KEY, 'on');
+                document.documentElement.setAttribute('data-ai-hints', 'on');
+            } else {
+                sessionStorage.removeItem(AI_HINTS_KEY);
+                document.documentElement.removeAttribute('data-ai-hints');
+            }
+        } catch (_) {
+            if (on) {
+                document.documentElement.setAttribute('data-ai-hints', 'on');
+            } else {
+                document.documentElement.removeAttribute('data-ai-hints');
+            }
+        }
+    }
+
+    function toggleAiHints() {
+        setAiHints(!isAiHintsOn());
+    }
+
+    function attachAiHintsToggle() {
+        document.addEventListener('click', function (event) {
+            var btn = event.target.closest('#ai-hints-toggle');
+            if (btn) {
+                event.preventDefault();
+                toggleAiHints();
+            }
+        });
+    }
+
+    /* ---------------------------------------------------------------
      * Error handling — show user-friendly toast when HTMX requests
      * fail (network error, server error, timeout).
      * --------------------------------------------------------------- */
@@ -790,6 +839,7 @@
         attachTrickHistoryToggle();
         attachAuctionLogToggle();
         attachTextSizeToggle();
+        attachAiHintsToggle();
         attachErrorHandlers();
         attachAutoAdvanceHandler();
         var form = getCardPlayForm();

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -3674,3 +3674,90 @@ main {
     white-space: nowrap;
     border: 0;
 }
+
+/* --------------------------------------------------------------------------
+   23. AI Hints (#2185)
+   --------------------------------------------------------------------------
+   Hints are opt-in: hidden by default, visible when the user toggles
+   data-ai-hints="on" on <html> via the header toggle button.
+   -------------------------------------------------------------------------- */
+
+/* Toggle button — styled like the text-size toggle */
+.ai-hints-toggle {
+    background: var(--color-surface-light);
+    color: var(--color-text);
+    border: 1px solid var(--color-felt);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.ai-hints-toggle:hover {
+    background: var(--color-felt);
+}
+
+/* Active state when hints are on */
+html[data-ai-hints="on"] .ai-hints-toggle {
+    background: var(--color-legal-glow);
+    color: var(--color-black);
+    border-color: var(--color-legal-border);
+}
+
+/* --- Card hint badge --- */
+.card__hint-badge {
+    display: none;
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    font-size: 0.65rem;
+    line-height: 1;
+    z-index: 10;
+}
+
+html[data-ai-hints="on"] .card__hint-badge {
+    display: block;
+}
+
+/* --- Suggested card glow --- */
+/* The card--suggested class is always rendered but the visual treatment
+   is only applied when hints are enabled. */
+html[data-ai-hints="on"] .card--suggested {
+    border-color: #ffd54f;
+    box-shadow: 0 0 8px rgba(255, 213, 79, 0.7), 0 0 16px rgba(255, 213, 79, 0.35);
+}
+
+/* --- Bid suggestion hint --- */
+.ai-hint {
+    display: none;
+    margin-top: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    background: rgba(255, 213, 79, 0.15);
+    border: 1px solid rgba(255, 213, 79, 0.4);
+    border-radius: 6px;
+    font-size: 0.85rem;
+    line-height: 1.3;
+}
+
+.ai-hint__icon {
+    margin-right: 0.25rem;
+}
+
+html[data-ai-hints="on"] .ai-hint {
+    display: flex;
+    align-items: center;
+}
+
+/* Mobile adjustments */
+@media (max-width: 480px) {
+    .ai-hints-toggle {
+        padding: 0.2rem 0.4rem;
+        font-size: 0.7rem;
+    }
+
+    .ai-hint {
+        font-size: 0.8rem;
+        padding: 0.3rem 0.5rem;
+    }
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -38,6 +38,10 @@
     <script>
         (function(){try{var s=localStorage.getItem('textSize');if(s!=='default'){document.documentElement.setAttribute('data-text-size','large');}}catch(e){document.documentElement.setAttribute('data-text-size','large');}})();
     </script>
+    <!-- Apply AI hints preference before first paint (#2185). Off by default — opt-in. -->
+    <script>
+        (function(){try{var h=sessionStorage.getItem('aiHints');if(h==='on'){document.documentElement.setAttribute('data-ai-hints','on');}}catch(e){}})();
+    </script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>
     <script src="/static/game.js" defer></script>
@@ -105,6 +109,11 @@
                    data-tab="guide">Help / Guide</a>
             </nav>
             {% endif %}
+            <button id="ai-hints-toggle"
+                    class="ai-hints-toggle"
+                    type="button"
+                    aria-label="Toggle AI hints"
+                    title="Toggle AI hints">Hints</button>
             <button id="text-size-toggle"
                     class="text-size-toggle"
                     type="button"

--- a/web/templates/partials/bid_panel.html
+++ b/web/templates/partials/bid_panel.html
@@ -105,6 +105,23 @@
     </p>
     {% endif %}
     <p class="bid-info">Dealer: {% if dealer_seat != 0 %}<span class="ai-name player-name--{{ 'human' if dealer_seat == 2 else 'ai' }}">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% else %}<span class="player-name--human">{{ seat_labels.get(dealer_seat, "Seat " ~ dealer_seat) }}</span>{% endif %}</p>
+
+    {# AI bid suggestion — visible only when hints are enabled (data-ai-hints="on" on <html>) #}
+    {% if suggested_bid is defined and suggested_bid is not none %}
+        {% set sb = suggested_bid %}
+        {% set suit_labels_map = {"S": "♠ Spades", "H": "♥ Hearts", "D": "♦ Diamonds", "C": "♣ Clubs", "HIGH": "High", "LOW": "Low"} %}
+        <div class="ai-hint ai-hint--bid" role="note" aria-label="AI bid suggestion">
+            <span class="ai-hint__icon" aria-hidden="true">💡</span>
+            {% if sb.n == 0 %}
+                <span class="ai-hint__text">AI suggests: <strong>Pass</strong></span>
+            {% else %}
+                <span class="ai-hint__text">AI suggests: <strong>{{ sb.n }} {{ suit_labels_map.get(sb.contract, sb.contract) }}</strong>
+                    {% if sb.bid_type == "moon" %}<span class="bid-type-badge bid-type-badge--moon">Moon</span>{% endif %}
+                    {% if sb.bid_type == "loner" %}<span class="bid-type-badge bid-type-badge--loner">Loner</span>{% endif %}
+                </span>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>
 
 <script>

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -43,14 +43,17 @@
             {% if phase == "trick_play" and legal_plays is not none and idx in legal_plays %}
                 <button type="button"
                         id="hand-card-{{ idx }}"
-                        class="card card--{{ suit_class }} card--legal{% if bower %} card--bower{% endif %}"
+                        class="card card--{{ suit_class }} card--legal{% if bower %} card--bower{% endif %}{% if suggested_card_index is defined and suggested_card_index is not none and idx == suggested_card_index %} card--suggested{% endif %}"
                         title="{{ rank|display_rank }}{{ suit_sym }}{% if bower %} ({{ bower }} bower){% endif %} (tap to play)"
-                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}{{ copy_suffix }}{% if bower %} ({{ bower }} bower){% endif %}"
+                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}{{ copy_suffix }}{% if bower %} ({{ bower }} bower){% endif %}{% if suggested_card_index is defined and suggested_card_index is not none and idx == suggested_card_index %} (AI suggestion){% endif %}"
                         data-card-index="{{ idx }}">
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>
                     {% if bower %}
                         <span class="card__bower-badge" title="{{ bower|capitalize }} bower" aria-label="{{ bower }} bower">{{ "RB" if bower == "right" else "LB" }}</span>
+                    {% endif %}
+                    {% if suggested_card_index is defined and suggested_card_index is not none and idx == suggested_card_index %}
+                        <span class="card__hint-badge" title="AI suggestion" aria-label="AI suggested play">💡</span>
                     {% endif %}
                 </button>
             {% else %}


### PR DESCRIPTION
## Summary

- Add opt-in AI hints toggle ("Hints" button in header) that shows the AI's recommended card during trick play and recommended bid during auction
- Compute suggestions using the same `GluttonStrategy.choose_card()` and bidding policy that AI opponents use
- Gate all hint visuals behind `data-ai-hints="on"` on `<html>` — zero visual impact when off, persisted per-tab via sessionStorage

## Why

Players learning the game benefit from seeing what the AI would do in their position. This is a low-cost way to provide guidance without changing game mechanics. Suggestions are opt-in (off by default) so experienced players are unaffected.

## Implementation

### Backend (engine + routes)
- `MatchEngine.get_suggested_play()` — returns AI's recommended card index for the human's trick play turn
- `MatchEngine.get_suggested_bid()` — returns AI's recommended bid dict for the human's auction turn
- Both methods are wrapped in try/except so suggestion failures never break gameplay
- `_build_game_context()` passes `suggested_card_index` and `suggested_bid` to templates

### Frontend (templates + CSS + JS)
- **Card hints:** `card--suggested` class (gold glow) + `card__hint-badge` (lightbulb emoji) on the recommended card
- **Bid hints:** `ai-hint` panel below bid controls showing formatted bid recommendation
- **Toggle:** Header button + sessionStorage persistence + early-init script to prevent FOUC
- **CSS gating:** All hint styles gated on `html[data-ai-hints="on"]` — completely invisible when hints are off

## Repro / Validation

```bash
# Tier 1 — impacted tests
uv run python -m pytest tests/unit/hosted_play/test_engine.py -x -q

# Tier 2 — full validation
make check-gated
```

Visual verification: Start a game, click "Hints" toggle in header, observe gold glow on AI's recommended card during trick play and bid suggestion panel during auction.

## Tests

8 new unit tests:
- `TestGetSuggestedPlay` (4 tests): legal card index on human turn, None during auction, None when not human turn, None when no hand
- `TestGetSuggestedBid` (4 tests): bid dict on human auction turn, None during trick play, None when not human turn, None when no hand

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-c
branch: feat/ai-suggestions-2185
```

Refs #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)