### PR TITLE
feat(web): log GBT bidding counterfactual alongside human bids

### DIFF
--- a/tests/unit/hosted_play/test_routes.py
+++ b/tests/unit/hosted_play/test_routes.py
@@ -1190,6 +1190,109 @@ class TestGluttonCounterfactual:
 
 
 # ---------------------------------------------------------------------------
+# GBT counterfactual logging (#2469)
+# ---------------------------------------------------------------------------
+
+
+class TestBidCounterfactual:
+    """Human bid decisions should include a GBT counterfactual."""
+
+    def test_human_bid_has_counterfactual(self, client, app):
+        """After a human bid, the Decision row stores the GBT recommendation."""
+        link_uuid = _setup_game(client)
+
+        # Find and submit a human bid
+        for _ in range(10):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                break
+            else:
+                break
+
+        # Query the human bid decision row
+        session = app.state.session_factory()
+        human_bids = (
+            session.query(Decision)
+            .filter(Decision.actor_type == "human", Decision.phase == "bid")
+            .all()
+        )
+        assert len(human_bids) > 0, "Expected at least one human bid decision"
+
+        for d in human_bids:
+            assert (
+                d.counterfactual_json is not None
+            ), f"Human bid turn={d.turn_number} missing counterfactual"
+            cf = json.loads(d.counterfactual_json)
+            assert cf["source"] == "bud_bot"
+            assert "n" in cf
+            assert "contract" in cf
+            assert "bid_type" in cf
+
+        session.close()
+
+    def test_ai_bid_no_counterfactual(self, client, app):
+        """AI bid decision rows should NOT have a counterfactual."""
+        link_uuid = _setup_game(client)
+
+        # Play until we get at least one AI bid
+        for _ in range(10):
+            advance_pending_reveals(client, app, link_uuid)
+            result = get_match_state(app, link_uuid)
+            assert result is not None
+            state, _, session = result
+            session.close()
+
+            hand = state.current_hand
+            if hand is None:
+                break
+
+            if hand.phase == "auction" and hand.current_seat == HUMAN_SEAT:
+                client.post(
+                    f"/play/{link_uuid}/bid",
+                    data={
+                        "turn_number": hand.turn_number,
+                        "bid_n": 0,
+                        "bid_contract": "",
+                    },
+                )
+                break
+            else:
+                break
+
+        # AI decisions should not have counterfactuals
+        session = app.state.session_factory()
+        ai_bids = (
+            session.query(Decision)
+            .filter(Decision.actor_type == "ai", Decision.phase == "bid")
+            .all()
+        )
+
+        for d in ai_bids:
+            assert (
+                d.counterfactual_json is None
+            ), f"AI bid turn={d.turn_number} should not have counterfactual"
+
+        session.close()
+
+
+# ---------------------------------------------------------------------------
 # Landing page
 # ---------------------------------------------------------------------------
 

--- a/web/app.py
+++ b/web/app.py
@@ -146,13 +146,29 @@ async def lifespan(app: FastAPI):
         try:
             with engine.begin() as conn:
                 conn.execute(
-                    text("ALTER TABLE matches " "ADD COLUMN play_strategy_version TEXT")
+                    text("ALTER TABLE matches ADD COLUMN play_strategy_version TEXT")
                 )
             logger.info("Migration: added play_strategy_version column to matches")
         except OperationalError:
             # Column already exists — concurrent startup or stale inspector cache (#2532)
             logger.info(
                 "Migration: play_strategy_version column already present (concurrent)"
+            )
+
+    # 1d. Migrate: add counterfactual_json column to decisions table.
+    # Stores the GBT bidder's recommendation alongside human bid decisions
+    # for divergence analysis (#2469).  NULL for existing rows and AI turns.
+    decision_cols = {c["name"] for c in inspector.get_columns("decisions")}
+    if "counterfactual_json" not in decision_cols:
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    text("ALTER TABLE decisions ADD COLUMN counterfactual_json TEXT")
+                )
+            logger.info("Migration: added counterfactual_json column to decisions")
+        except OperationalError:
+            logger.info(
+                "Migration: counterfactual_json column already present (concurrent)"
             )
 
     # 2. Auto-seed invite code on fresh database (atomic: skip if another

--- a/web/db.py
+++ b/web/db.py
@@ -238,6 +238,7 @@ class Decision(Base):
     # What the glutton strategy would have played in the same situation.
     # Only populated for human play-phase decisions (counterfactual logging).
     glutton_action_json = Column(Text, nullable=True)
+    counterfactual_json = Column(Text, nullable=True)
     decision_time_ms = Column(
         Integer,
         CheckConstraint("decision_time_ms IS NULL OR decision_time_ms >= 0"),

--- a/web/export.py
+++ b/web/export.py
@@ -50,6 +50,7 @@ REQUIRED_FIELDS: frozenset[str] = frozenset(
         "legal_actions",
         "chosen_action",
         "game_state",
+        "counterfactual",
         "decision_time_ms",
         "timestamp",
     }
@@ -125,6 +126,11 @@ def decision_to_jsonl(
         "legal_actions": legal_actions,
         "chosen_action": chosen_action,
         "game_state": game_state,
+        "counterfactual": (
+            json.loads(decision_row.counterfactual_json)
+            if decision_row.counterfactual_json
+            else None
+        ),
         "decision_time_ms": decision_row.decision_time_ms,
         "timestamp": timestamp,
     }

--- a/web/routes.py
+++ b/web/routes.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 from bid_euchre.core.rules import trick_winner
 from bid_euchre.hosted_play.engine import HUMAN_SEAT, MatchEngine, sort_hand_for_display
-from bid_euchre.strategy.bidding import BidAction
+from bid_euchre.strategy.bidding import BidAction, BiddingObservation
 from bid_euchre.strategy.glutton import GluttonStrategy
 
 from .ai_manager import AIManager
@@ -246,6 +246,7 @@ def _log_decision(
     game_state: Any,
     decision_time_ms: int | None = None,
     glutton_action: Any | None = None,
+    counterfactual: dict[str, Any] | None = None,
 ) -> None:
     """Insert a decision row (idempotent — skips if turn already logged)."""
     exists = (
@@ -270,8 +271,49 @@ def _log_decision(
         glutton_action_json=json.dumps(glutton_action)
         if glutton_action is not None
         else None,
+        counterfactual_json=(
+            json.dumps(counterfactual) if counterfactual is not None else None
+        ),
     )
     session.add(decision)
+
+
+def _compute_bid_counterfactual(
+    ai_manager: AIManager,
+    hand,
+    seat: int,
+) -> dict[str, Any] | None:
+    """Run the GBT bidder on the same hand state and return its recommendation.
+
+    Purely observational — does not modify game state.  Returns ``None`` if
+    the ``bud_bot`` model is unavailable (should not happen in production
+    since the startup roster check ensures it).
+    """
+    try:
+        bud_bot = ai_manager.get_model_info("bud_bot")
+    except KeyError:
+        logger.warning("counterfactual: bud_bot model not available, skipping")
+        return None
+
+    obs = BiddingObservation(
+        hand=hand.hands[seat],
+        seat=seat,
+        dealer_seat=hand.dealer_seat,
+        current_high_bid=hand.current_high_bid,
+        auction_transcript=tuple(hand.auction),
+    )
+    try:
+        gbt_bid = bud_bot.bidding_policy.choose_bid(obs)
+    except Exception:
+        logger.warning("counterfactual: GBT bidder failed, skipping", exc_info=True)
+        return None
+
+    return {
+        "source": "bud_bot",
+        "n": gbt_bid.n,
+        "contract": gbt_bid.contract,
+        "bid_type": gbt_bid.bid_type,
+    }
 
 
 def _has_hidden_auction(hand) -> bool:
@@ -1562,10 +1604,14 @@ async def submit_bid(
         # Record pre-action state for decision logging
         pre_turn = hand.turn_number
 
+        # Compute GBT counterfactual before mutating state (#2469).
+        # Purely observational — does not affect gameplay.
+        counterfactual = _compute_bid_counterfactual(ai_manager, hand, HUMAN_SEAT)
+
         # Ensure hand row exists (keyed by deal_id for redeal-safe uniqueness)
         hand_row = _ensure_hand_row(session, match_row, hand, hand.deal_id)
 
-        # Log human decision
+        # Log human decision (with GBT counterfactual)
         _log_decision(
             session,
             match_row,
@@ -1585,6 +1631,7 @@ async def submit_bid(
                 "bid_type": bid.bid_type,
             },
             game_state=engine.get_visible_state(state),
+            counterfactual=counterfactual,
         )
 
         pre_auction_count = len(hand.auction)

--- a/web/schema.sql
+++ b/web/schema.sql
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS decisions (
     chosen_action_json TEXT NOT NULL,
     game_state_json TEXT NOT NULL,
     glutton_action_json TEXT,
+    counterfactual_json TEXT,
     decision_time_ms INTEGER CHECK (
         decision_time_ms IS NULL OR decision_time_ms >= 0
     ),


### PR DESCRIPTION
## Summary

- Log what the GBT (Bud Bot) bidder would have bid alongside each human bid/pass decision
- Purely observational — does NOT affect gameplay
- Stores counterfactual in new nullable `counterfactual_json` column on `decisions` table
- Includes startup migration for existing databases (follows same pattern as prior migrations)

Refs #2469

## Changes

| File | Change |
|------|--------|
| `web/db.py` | Add `counterfactual_json` nullable Text column to Decision model |
| `web/schema.sql` | Add column to reference schema |
| `web/app.py` | Add 1d migration block for existing databases |
| `web/routes.py` | Add `_compute_bid_counterfactual()` + wire into `submit_bid` handler |
| `web/export.py` | Include `counterfactual` field in JSONL export |
| `tests/unit/hosted_play/test_routes.py` | Add `TestBidCounterfactual` class (2 tests) |

## How it works

In the `submit_bid` POST handler, after the human submits their bid but before
applying the action to the engine:

1. Construct a `BiddingObservation` from the current hand state (same hand the human saw)
2. Call `bud_bot.bidding_policy.choose_bid(obs)` to get the GBT recommendation
3. Store the result as `{"source": "bud_bot", "n": ..., "contract": ..., "bid_type": ...}`
   in the decision row's `counterfactual_json` column

The counterfactual is only computed for human bid decisions. AI decisions have
`counterfactual_json = NULL`.

## Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_routes.py -k TestBidCounterfactual -v

# Tier 2 — full validation
make check-gated  # ✓ All checks passed
```

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
branch: feat/web-gbt-counterfactual-2469
```

## Test plan

- [x] Human bid decisions include counterfactual with correct structure
- [x] AI bid decisions do NOT include counterfactual
- [x] Export includes counterfactual field (schema compliance test passes)
- [x] All 3533 hosted_play unit tests pass
- [x] All 36 hosted_play integration tests pass
- [x] `make check-gated` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)