### PR TITLE
fix(web): add startup migrations for glutton_action_json and counterfactual_json columns

### DIFF
--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -564,3 +564,104 @@ class TestPlayStrategyVersionMigration:
             cols = [c["name"] for c in sa_inspect(engine).get_columns("matches")]
             # Column should exist exactly once (no duplicate)
             assert cols.count("play_strategy_version") == 1
+
+
+class TestDecisionColumnMigrations:
+    """Tests for the counterfactual_json and glutton_action_json startup
+    migrations (lifespan steps 1d and 1e).
+
+    Both columns are nullable TEXT columns on the ``decisions`` table,
+    added in PRs #2616 and #2618 respectively.  The startup migrations
+    ensure existing deployed databases without these columns are upgraded
+    automatically on the next deployment.
+    """
+
+    def test_fresh_db_already_has_counterfactual_json(self, tmp_path):
+        """On a brand-new DB, create_tables includes counterfactual_json;
+        migration is a no-op and no errors occur."""
+        app = _make_app(tmp_path)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("decisions")}
+            assert "counterfactual_json" in cols
+
+    def test_fresh_db_already_has_glutton_action_json(self, tmp_path):
+        """On a brand-new DB, create_tables includes glutton_action_json;
+        migration is a no-op and no errors occur."""
+        app = _make_app(tmp_path)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("decisions")}
+            assert "glutton_action_json" in cols
+
+    def test_migration_adds_counterfactual_json_to_legacy_db(self, tmp_path):
+        """Starting the app against a legacy DB (no counterfactual_json column
+        on decisions) adds the column via ALTER TABLE."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # Sanity: legacy fixture must not already have the column
+        pre_engine = create_engine(db_url)
+        pre_cols = {c["name"] for c in sa_inspect(pre_engine).get_columns("decisions")}
+        assert "counterfactual_json" not in pre_cols
+        pre_engine.dispose()
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("decisions")}
+            assert "counterfactual_json" in cols
+
+    def test_migration_adds_glutton_action_json_to_legacy_db(self, tmp_path):
+        """Starting the app against a legacy DB (no glutton_action_json column
+        on decisions) adds the column via ALTER TABLE."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # Sanity: legacy fixture must not already have the column
+        pre_engine = create_engine(db_url)
+        pre_cols = {c["name"] for c in sa_inspect(pre_engine).get_columns("decisions")}
+        assert "glutton_action_json" not in pre_cols
+        pre_engine.dispose()
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("decisions")}
+            assert "glutton_action_json" in cols
+
+    def test_both_columns_added_in_single_startup(self, tmp_path):
+        """A single startup on a legacy DB adds both new columns."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with TestClient(app):
+            engine = app.state.engine
+            cols = {c["name"] for c in sa_inspect(engine).get_columns("decisions")}
+            assert "counterfactual_json" in cols
+            assert "glutton_action_json" in cols
+
+    def test_migrations_idempotent_on_second_startup(self, tmp_path):
+        """Running the app twice on the same DB does not fail or duplicate
+        either column (second run is a no-op)."""
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        # First startup — triggers both migrations
+        config1 = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app1 = create_app(config=config1)
+        with TestClient(app1):
+            pass  # lifespan runs migrations
+
+        # Second startup — columns already present, migrations skipped
+        config2 = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app2 = create_app(config=config2)
+        with TestClient(app2):
+            engine = app2.state.engine
+            cols = [c["name"] for c in sa_inspect(engine).get_columns("decisions")]
+            assert cols.count("counterfactual_json") == 1
+            assert cols.count("glutton_action_json") == 1

--- a/web/app.py
+++ b/web/app.py
@@ -171,6 +171,22 @@ async def lifespan(app: FastAPI):
                 "Migration: counterfactual_json column already present (concurrent)"
             )
 
+    # 1e. Migrate: add glutton_action_json column to decisions table.
+    # Stores the GBT bidder's recommended loner/glutton action alongside
+    # human decisions for divergence analysis (#2616).
+    # NULL for existing rows and non-glutton turns.
+    if "glutton_action_json" not in decision_cols:
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    text("ALTER TABLE decisions ADD COLUMN glutton_action_json TEXT")
+                )
+            logger.info("Migration: added glutton_action_json column to decisions")
+        except OperationalError:
+            logger.info(
+                "Migration: glutton_action_json column already present (concurrent)"
+            )
+
     # 2. Auto-seed invite code on fresh database (atomic: skip if another
     #    instance already seeded between our check and insert)
     seed_session = session_factory()


### PR DESCRIPTION
## Summary

- Add startup migration block 1e in `web/app.py` lifespan to `ALTER TABLE decisions ADD COLUMN glutton_action_json TEXT` (following idempotent try/except OperationalError pattern)
- PR #2616 added `glutton_action_json` to the Decision ORM model but omitted the startup migration, causing a production outage on 2026-04-08
- `counterfactual_json` migration (PR #2618) was already present in `web/app.py`; this PR adds the missing `glutton_action_json` counterpart
- Add `TestDecisionColumnMigrations` (6 tests) covering fresh DB, legacy DB migration, combined startup migration, and idempotency for both columns

## Why

PRs #2616 and #2618 added `glutton_action_json` and `counterfactual_json` columns to the Decision ORM model. The `counterfactual_json` migration was included in #2618. The `glutton_action_json` migration was not included in #2616. On 2026-04-08, the Render deployment tried to write to `glutton_action_json` on an existing DB that didn't have the column — this was fixed by running ALTER TABLE directly in production, but the startup migration must be present for durability on future deployments.

## Repro / Validation

```bash
# Tier 1
uv run python -m pytest tests/unit/hosted_play/test_app.py -v
# Result: 32 passed

# Tier 2
make check-gated
# Result: ✓ All checks passed
```

## Tests

- `TestDecisionColumnMigrations::test_fresh_db_already_has_counterfactual_json` — fresh DB no-op
- `TestDecisionColumnMigrations::test_fresh_db_already_has_glutton_action_json` — fresh DB no-op
- `TestDecisionColumnMigrations::test_migration_adds_counterfactual_json_to_legacy_db` — legacy DB gets column
- `TestDecisionColumnMigrations::test_migration_adds_glutton_action_json_to_legacy_db` — legacy DB gets column
- `TestDecisionColumnMigrations::test_both_columns_added_in_single_startup` — both columns added together
- `TestDecisionColumnMigrations::test_migrations_idempotent_on_second_startup` — second startup is a no-op

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-b
worktree: Bid-Euchre-steward-brws-author-b  d9bf9261 [fix/web-startup-migrations-glutton-counterfactual]
```

Refs #2616, Refs #2618