### PR TITLE
fix(convention): isolate get_suggested_play() from shared strategy state

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -7,6 +7,7 @@ turns.  Delegates **all** rule evaluation to existing ``core/``, ``sim/``,
 
 from __future__ import annotations
 
+import copy
 import logging
 import random
 from dataclasses import dataclass
@@ -465,8 +466,12 @@ class MatchEngine:
     def get_suggested_play(self, state: MatchState) -> int | None:
         """Return the AI's recommended card index for the human player.
 
-        Uses the same ``play_strategy.choose_card()`` that AI opponents use
-        to pick the card the AI would play in the human's position.
+        Uses a **deep copy** of ``play_strategy`` so the suggestion call
+        cannot mutate the shared strategy's tracking state (``_seen_counts``,
+        ``_void_suits_by_seat``, ``_player_index``, etc.).  Without this
+        isolation, ``choose_card()``'s defensive resets and state writes
+        would corrupt the instance used for subsequent AI turns.  See #2644.
+
         Returns ``None`` if it's not the human's turn to play.
         """
         hand = state.current_hand
@@ -477,7 +482,11 @@ class MatchEngine:
         if hand.current_trick is None or hand.contract_type is None:
             return None
         try:
-            return self.play_strategy.choose_card(
+            # Deep-copy preserves accumulated tracking state (seen cards,
+            # void inferences) for an informed suggestion while isolating
+            # all mutations from the shared instance.
+            snapshot = copy.deepcopy(self.play_strategy)
+            return snapshot.choose_card(
                 hand.hands[HUMAN_SEAT],
                 hand.current_trick.plays,
                 hand.contract_type,

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -3052,6 +3052,63 @@ class TestGetSuggestedPlay:
         state = MatchState(seed=SEED, ai_model="heuristic")
         assert engine.get_suggested_play(state) is None
 
+    def test_no_state_leakage_between_calls(self):
+        """Calling get_suggested_play() must not mutate the shared strategy.
+
+        GluttonStrategy has mutable tracking state (_seen_counts,
+        _void_suits_by_seat, _player_index, etc.).  The suggestion path
+        must use an isolated copy so repeated calls don't corrupt the
+        strategy instance used for AI play.  Regression lock for #2644.
+        """
+        glutton = GluttonStrategy()
+        engine = MatchEngine(
+            bidding_policy=FixedBidder(n=5, contract="S"),
+            play_strategy=glutton,
+        )
+
+        # Find a seed where the human gets a play turn
+        for seed in range(200):
+            state = engine.start_match(seed, "heuristic")
+            state = _advance_to_human_play(engine, state)
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "trick_play"
+                and hand.current_seat == HUMAN_SEAT
+            ):
+                break
+        else:
+            pytest.skip("No human play turn found in 200 seeds")
+
+        # Snapshot strategy state before suggestion
+        seen_before = dict(glutton._seen_counts)
+        voids_before = {s: set(v) for s, v in glutton._void_suits_by_seat.items()}
+        player_idx_before = glutton._player_index
+        contract_before = glutton._contract_type
+        trump_before = glutton._trump_suit
+        last_lead_suit_before = glutton._last_won_lead_suit
+        last_lead_seat_before = glutton._last_won_lead_seat
+
+        # Call suggestion multiple times
+        for _ in range(3):
+            result = engine.get_suggested_play(state)
+            assert result is not None
+
+        # Strategy state must be unchanged
+        assert (
+            glutton._seen_counts == seen_before
+        ), "get_suggested_play() leaked _seen_counts into shared strategy"
+        assert (
+            glutton._void_suits_by_seat == voids_before
+        ), "get_suggested_play() leaked _void_suits_by_seat into shared strategy"
+        assert (
+            glutton._player_index == player_idx_before
+        ), "get_suggested_play() leaked _player_index into shared strategy"
+        assert glutton._contract_type == contract_before
+        assert glutton._trump_suit == trump_before
+        assert glutton._last_won_lead_suit == last_lead_suit_before
+        assert glutton._last_won_lead_seat == last_lead_seat_before
+
 
 class TestGetSuggestedBid:
     """Tests for MatchEngine.get_suggested_bid()."""


### PR DESCRIPTION
## Summary

- `get_suggested_play()` now uses `copy.deepcopy(self.play_strategy)` so suggestion calls cannot mutate the shared GluttonStrategy instance
- Adds a regression test proving no state leakage (`_seen_counts`, `_void_suits_by_seat`, `_player_index`, etc.) across repeated `get_suggested_play()` calls

## Why

`GluttonStrategy.choose_card()` reads **and writes** significant mutable tracking state (`_seen_counts`, `_void_suits_by_seat`, `_player_index`, `_last_won_lead_suit`, `_last_won_lead_seat`). Calling it directly on the engine's shared strategy instance for human suggestions corrupts state that subsequent AI turns depend on. The defensive-reset logic in `choose_card()` (lines 687-705) partially masks this in practice, but any future change to GluttonStrategy's state management could cause silent AI play quality degradation.

The deep-copy approach preserves accumulated tracking state (for informed suggestions) while isolating all mutations from the shared instance — same principle as `_compute_glutton_counterfactual()` in `web/routes.py` (PR #2616).

Fixes #2644

## Repro / Validation

```bash
# Targeted test (Tier 1)
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestGetSuggestedPlay -v

# Full engine suite
uv run python -m pytest tests/unit/hosted_play/test_engine.py -v

# Full validation (Tier 2)
make check-gated
```

## Tests

- `tests/unit/hosted_play/test_engine.py::TestGetSuggestedPlay::test_no_state_leakage_between_calls` — new test, uses GluttonStrategy, verifies all 7 mutable state fields are unchanged after 3 suggestion calls
- Full suite: 11501 passed, 60 skipped (3 unrelated `test_cpu_gate` flakes from system load)

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: fix/suggested-play-shared-state-2644
```

## Files Changed

- `src/bid_euchre/hosted_play/engine.py` — added `import copy`, changed `get_suggested_play()` to use deepcopy
- `tests/unit/hosted_play/test_engine.py` — added `test_no_state_leakage_between_calls`