### PR TITLE
fix(web): filter suggested bids against auction legality + suppress phantom hints

### DIFF
--- a/src/bid_euchre/hosted_play/engine.py
+++ b/src/bid_euchre/hosted_play/engine.py
@@ -510,6 +510,11 @@ class MatchEngine:
                 auction_transcript=tuple(hand.auction),
             )
             bid = self.bidding_policy.choose_bid(obs)
+            # Filter against auction legality — the policy may suggest
+            # a bid that is not legal given the current auction state.
+            legal_bids = self.get_legal_bids(state)
+            if bid not in legal_bids:
+                return None
             return {
                 "n": bid.n,
                 "contract": bid.contract,

--- a/tests/unit/hosted_play/test_engine.py
+++ b/tests/unit/hosted_play/test_engine.py
@@ -3100,6 +3100,80 @@ class TestGetSuggestedBid:
         state = MatchState(seed=SEED, ai_model="heuristic")
         assert engine.get_suggested_bid(state) is None
 
+    def test_suggested_bid_always_subset_of_legal_bids(self, engine: MatchEngine):
+        """Suggested bid must be a member of the legal bids set (#2620)."""
+        found = False
+        for seed in range(200):
+            state = engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "auction"
+                and hand.current_seat == HUMAN_SEAT
+            ):
+                suggestion = engine.get_suggested_bid(state)
+                if suggestion is not None:
+                    legal_bids = engine.get_legal_bids(state)
+                    # Build the set of (n, contract, bid_type) tuples from legal bids
+                    legal_set = {(b.n, b.contract, b.bid_type) for b in legal_bids}
+                    suggested_tuple = (
+                        suggestion["n"],
+                        suggestion["contract"],
+                        suggestion["bid_type"],
+                    )
+                    assert suggested_tuple in legal_set, (
+                        f"Suggested bid {suggested_tuple} not in legal bids "
+                        f"{legal_set} (seed={seed})"
+                    )
+                    found = True
+        if not found:
+            pytest.skip("No seed produced a human auction turn with suggestion")
+
+    def test_filters_illegal_suggestion(self):
+        """Engine returns None when bidding policy suggests an illegal bid (#2620).
+
+        Uses the standard FixedBidder(5S) engine to create a state where the
+        high bid is already 5, then swaps in a policy that always suggests 3S
+        to verify the legality filter rejects it.
+        """
+
+        class AlwaysBid3S(BiddingPolicy):
+            """Always suggests 3 Spades regardless of auction state."""
+
+            def __init__(self) -> None:
+                super().__init__(name="always_3s")
+
+            def choose_bid(self, obs: BiddingObservation) -> BidAction:
+                return BidAction.bid(3, "S")
+
+        # Use standard engine to get a state where high bid > 3 and
+        # it's the human's turn.
+        setup_engine = MatchEngine(
+            bidding_policy=FixedBidder(n=5, contract="S"),
+            play_strategy=FirstLegalPlay(),
+        )
+        for seed in range(500):
+            state = setup_engine.start_match(seed, "heuristic")
+            hand = state.current_hand
+            if (
+                hand is not None
+                and hand.phase == "auction"
+                and hand.current_seat == HUMAN_SEAT
+                and hand.current_high_bid > 3
+            ):
+                # Now use an engine with AlwaysBid3S for the suggestion
+                illegal_engine = MatchEngine(
+                    bidding_policy=AlwaysBid3S(),
+                    play_strategy=FirstLegalPlay(),
+                )
+                suggestion = illegal_engine.get_suggested_bid(state)
+                assert suggestion is None, (
+                    f"Expected None for illegal suggestion 3S when "
+                    f"high_bid={hand.current_high_bid} (seed={seed})"
+                )
+                return
+        pytest.skip("No seed produced a human turn with high bid > 3")
+
 
 def _advance_to_human_play(engine: MatchEngine, state: MatchState) -> MatchState:
     """Advance state until the human has a play turn (trick_play phase)."""

--- a/tests/unit/hosted_play/test_partials.py
+++ b/tests/unit/hosted_play/test_partials.py
@@ -2907,6 +2907,47 @@ class TestAccessibilityHand:
         assert "2 cards in your hand" in html
 
 
+class TestHintAnnouncementSuppression:
+    """Hint text must not leak into aria-label when hints are off (#2620).
+
+    The ``data-ai-hints`` toggle is client-side (CSS), so the server-rendered
+    HTML must not embed "(AI suggestion)" in the button's ``aria-label``.
+    The visual hint badge (💡) is CSS-toggled separately.
+    """
+
+    def test_suggested_card_aria_label_omits_hint_text(self, env):
+        """aria-label on a suggested card should NOT contain 'AI suggestion'."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["S", "A"], ["H", "K"]],
+            legal_plays=[0, 1],
+            phase="trick_play",
+            suggested_card_index=0,
+        )
+        # The card at index 0 is the suggested card.  Its aria-label should
+        # describe the card normally, without leaking hint text.
+        assert "(AI suggestion)" not in html
+        # The hint badge emoji should still be rendered (CSS controls visibility)
+        assert "💡" in html
+
+    def test_non_suggested_card_aria_label_unchanged(self, env):
+        """Non-suggested legal card should have clean aria-label too."""
+        tmpl = env.get_template("partials/hand.html")
+        html = tmpl.render(
+            link_uuid="x",
+            turn_number=0,
+            human_hand=[["D", "Q"]],
+            legal_plays=[0],
+            phase="trick_play",
+            suggested_card_index=None,
+        )
+        assert 'aria-label="Play Q of Diamonds"' in html
+        assert "(AI suggestion)" not in html
+        assert "💡" not in html
+
+
 class TestAccessibilityBidPanel:
     """Verify ARIA attributes on bid panel controls."""
 

--- a/web/templates/partials/hand.html
+++ b/web/templates/partials/hand.html
@@ -45,7 +45,7 @@
                         id="hand-card-{{ idx }}"
                         class="card card--{{ suit_class }} card--legal{% if bower %} card--bower{% endif %}{% if suggested_card_index is defined and suggested_card_index is not none and idx == suggested_card_index %} card--suggested{% endif %}"
                         title="{{ rank|display_rank }}{{ suit_sym }}{% if bower %} ({{ bower }} bower){% endif %} (tap to play)"
-                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}{{ copy_suffix }}{% if bower %} ({{ bower }} bower){% endif %}{% if suggested_card_index is defined and suggested_card_index is not none and idx == suggested_card_index %} (AI suggestion){% endif %}"
+                        aria-label="Play {{ rank|display_rank }} of {{ suit_name }}{{ copy_suffix }}{% if bower %} ({{ bower }} bower){% endif %}"
                         data-card-index="{{ idx }}">
                     <span class="card__rank" aria-hidden="true">{{ rank|display_rank }}</span>
                     <span class="card__suit" aria-hidden="true">{{ suit_sym }}</span>


### PR DESCRIPTION
## Summary
- Filter AI bid suggestions through `get_legal_bids()` before displaying — the bidding policy could suggest bids not legal in the current auction state
- Remove `(AI suggestion)` text from card button `aria-label` in `hand.html` — the hint toggle is CSS-driven (`data-ai-hints`), but the aria-label leaked hint text regardless of toggle state

## Why
Follow-up from PR #2617 review (issue #2620). Two findings:
1. `get_suggested_bid()` returned whatever the bidding policy suggested without checking if that bid was actually legal given the current auction (e.g., suggesting a 3-level bid when the high bid was already 5)
2. The `aria-label` on suggested cards always included "(AI suggestion)" text, defeating the opt-in hints toggle for screen reader users

## Changes
- `src/bid_euchre/hosted_play/engine.py`: Added legality filter — after `choose_bid()`, validate the suggestion is in `get_legal_bids()` before returning it
- `web/templates/partials/hand.html`: Removed `(AI suggestion)` from the button's `aria-label`. The visual hint badge (💡) remains CSS-toggled correctly via `.card__hint-badge`

## Repro / Validation
```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/hosted_play/test_engine.py::TestGetSuggestedBid -v
uv run python -m pytest tests/unit/hosted_play/test_partials.py::TestHintAnnouncementSuppression -v

# Tier 2 — full validation
make check-gated
```

## Tests
- `test_suggested_bid_always_subset_of_legal_bids`: Verifies across 200 seeds that every suggestion is in the legal bid set
- `test_filters_illegal_suggestion`: Uses a policy that always suggests 3S against a 5S high bid — proves the filter returns None
- `test_suggested_card_aria_label_omits_hint_text`: Renders hand.html with a suggested card, asserts "(AI suggestion)" is absent from HTML
- `test_non_suggested_card_aria_label_unchanged`: Verifies clean aria-label when no card is suggested

**Test criteria:** All 4 new tests pass. The `test_filters_illegal_suggestion` proves the filter catches an illegal bid (3S when high bid is 5). 11505 tests pass; 3 pre-existing flaky failures in `test_cpu_gate.py` (unrelated, pass individually).

## Worktree proof
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-brws-author-a
branch: fix/2620-bid-legality-hint-toggle
```

Fixes #2620