### PR TITLE
fix(strategy): void-backed winner leads for loner LOW (#2627)

### DIFF
--- a/src/bid_euchre/strategy/glutton.py
+++ b/src/bid_euchre/strategy/glutton.py
@@ -21,7 +21,7 @@ from .base import Strategy, card_value_for_dump
 # GluttonStrategy or GluttonIsolatedStrategy. See
 # docs/02_agent/STRATEGY_VERSIONING.md for the semver rules and PR
 # changelog template.
-GLUTTON_STRATEGY_VERSION = "0.10.0"
+GLUTTON_STRATEGY_VERSION = "0.11.0"
 """Changelog:
 
 - 0.7.0 — Initial versioned baseline (PR #2529)
@@ -38,6 +38,12 @@ GLUTTON_STRATEGY_VERSION = "0.10.0"
 - 0.10.0 — Suit continuity: after winning a trick as leader, prefer
   continuing the same suit if cards remain (#2506).
   Always-on (no feature flag). Category: MINOR.
+- 0.11.0 — Void-backed winner leads: when both opponents are void
+  in a suit, any card in that suit is a guaranteed winner
+  regardless of rank (#2627). Also fixes ``observe_play``
+  trick-completion detection for 3-player loner/moon tricks.
+  Gated behind ``cash_winners_on_lead`` for high/low.
+  Category: MINOR.
 """
 
 
@@ -231,7 +237,9 @@ class GluttonStrategy(Strategy):
 
         # Suit continuity: detect trick completion and track whether
         # the leader won their own trick (#2506).
-        if len(trick_plays) == 4:
+        # Use 3 or 4 to handle both loner/moon (3-player) and normal
+        # (4-player) tricks (#2627).
+        if len(trick_plays) in (3, 4):
             winner = trick_winner(
                 trick_plays,
                 contract_type=contract_type,
@@ -247,6 +255,23 @@ class GluttonStrategy(Strategy):
                 # Leader lost — clear continuity
                 self._last_won_lead_suit = None
                 self._last_won_lead_seat = None
+
+    def _opponents_void_in_suit(self, suit: str, player_index: int) -> bool:
+        """Return True if both logical opponents are void in the given suit.
+
+        When both opponents have demonstrated a void (via failed follow-suit
+        in ``observe_play``), any card in that suit is a guaranteed winner
+        regardless of rank — opponents cannot follow suit and therefore
+        cannot beat the lead (#2627).
+
+        Works correctly for both loner (only 2 active opponents) and regular
+        hands (partner winning = team wins, so leading into a voided suit
+        is safe).
+        """
+        opp_seats = ((player_index + 1) % 4, (player_index + 3) % 4)
+        return all(
+            suit in self._void_suits_by_seat.get(opp, set()) for opp in opp_seats
+        )
 
     def _threat_copies_remaining(
         self,
@@ -530,6 +555,19 @@ class GluttonStrategy(Strategy):
                 ]
                 if cont_indices:
                     return select(cont_indices, key=card_value)
+
+            # Void-backed winners (#2627): if both opponents are void in
+            # a suit, any card in that suit wins regardless of rank.
+            # Gated behind Cash-A (high/low only). Picks the highest-
+            # value card from the voided suit to maximize trick value.
+            if cash_a_active:
+                void_backed = [
+                    idx
+                    for idx in legal_indices
+                    if self._opponents_void_in_suit(hand[idx].suit, player_index)
+                ]
+                if void_backed:
+                    return select(void_backed, key=card_value)
 
             if suit_counts:
                 longest_suit = max(
@@ -1009,7 +1047,8 @@ class GluttonIsolatedStrategy(Strategy):
                 self._void_suits_by_seat[player_index].add(led_suit)
 
         # Suit continuity: detect trick completion (#2506).
-        if self._suit_continuity and len(trick_plays) == 4:
+        # Use 3 or 4 to handle loner/moon (3-player) tricks (#2627).
+        if self._suit_continuity and len(trick_plays) in (3, 4):
             winner = trick_winner(
                 trick_plays,
                 contract_type=contract_type,
@@ -1067,6 +1106,16 @@ class GluttonIsolatedStrategy(Strategy):
             if remaining > 0:
                 return False
         return True
+
+    def _opponents_void_in_suit(self, suit: str, player_index: int) -> bool:
+        """Return True if both logical opponents are void in the given suit.
+
+        Mirror of :meth:`GluttonStrategy._opponents_void_in_suit` (#2627).
+        """
+        opp_seats = ((player_index + 1) % 4, (player_index + 3) % 4)
+        return all(
+            suit in self._void_suits_by_seat.get(opp, set()) for opp in opp_seats
+        )
 
     def _count_effective_suit(self, hand: List[Card], suit: str) -> int:
         """Count cards in hand that belong to the given effective suit."""
@@ -1265,6 +1314,16 @@ class GluttonIsolatedStrategy(Strategy):
                 ]
                 if cont_indices:
                     return max(cont_indices, key=card_value)
+
+            # Void-backed winners (#2627): mirror of GluttonStrategy.
+            if cash_a_active:
+                void_backed = [
+                    idx
+                    for idx in legal_indices
+                    if self._opponents_void_in_suit(hand[idx].suit, player_index)
+                ]
+                if void_backed:
+                    return max(void_backed, key=card_value)
 
             if suit_counts:
                 longest_suit = max(

--- a/tests/unit/test_greedy.py
+++ b/tests/unit/test_greedy.py
@@ -386,13 +386,13 @@ class TestCashWinnersOnLead:
             f"must lead A♥ (gating suppresses Cash-A) — got {hand[choice]}"
         )
 
-    def test_version_bumped_to_0_10_0(self):
-        """Suit continuity (#2506) bumps version to 0.10.0."""
+    def test_version_bumped_to_0_11_0(self):
+        """Void-backed winner leads (#2627) bumps version to 0.11.0."""
         from bid_euchre.strategy.glutton import GLUTTON_STRATEGY_VERSION
 
-        assert GLUTTON_STRATEGY_VERSION == "0.10.0"
-        assert GluttonStrategy.VERSION == "0.10.0"
-        assert GluttonIsolatedStrategy.VERSION == "0.10.0"
+        assert GLUTTON_STRATEGY_VERSION == "0.11.0"
+        assert GluttonStrategy.VERSION == "0.11.0"
+        assert GluttonIsolatedStrategy.VERSION == "0.11.0"
 
     # ---- Contract-type gating tests (Cash-A.1 → 0.9.0 update) ----
 
@@ -554,3 +554,259 @@ class TestCashWinnersOnLead:
             f"{cls.__name__} in low: Cash-A should fire, "
             f"leading T♠ — got {hand[choice]}"
         )
+
+
+class TestVoidBackedWinnerLeads:
+    """Void-backed winner leads (#2627): when both opponents are void in
+    a suit, any card in that suit is a guaranteed winner regardless of rank.
+
+    This fixes the loner LOW scenario where the AI held cards in suits where
+    opponents had already shown voids, but led from non-voided suits instead
+    because ``_is_sure_winner`` couldn't account for void-backed guarantees.
+    """
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_void_backed_lead_low_contract(self, cls, kwargs):
+        """Core scenario from #2627: in loner LOW, both opponents void in
+        spades. Hold ♠J (not a sure-winner by rank) and ♣K (in a suit
+        opponents still hold). Void-backed logic should prefer ♠J."""
+        hand = [
+            Card("S", "J"),  # idx 0 - spade J, opponents void in S
+            Card("C", "K"),  # idx 1 - club K, opponents NOT void in C
+            Card("C", "Q"),  # idx 2 - club Q
+        ]
+
+        strat = cls(**kwargs)
+        strat.on_hand_start(hand, "low", None, player_index=0)
+        # Simulate: both opponents are void in spades
+        strat._void_suits_by_seat[1].add("S")
+        strat._void_suits_by_seat[3].add("S")
+
+        choice = strat.choose_card(hand, [], "low", None, 0)
+        assert hand[choice] == Card("S", "J"), (
+            f"{cls.__name__}: void-backed lead should pick ♠J (opponents "
+            f"void in S), got {hand[choice]}"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_void_backed_lead_high_contract(self, cls, kwargs):
+        """In high contract, void-backed leads also fire: ♠J (opponents
+        void in S) is preferred over ♣A (opponents can follow clubs)."""
+        hand = [
+            Card("S", "J"),  # idx 0 - spade J, opponents void in S
+            Card("C", "A"),  # idx 1 - club A, opponents NOT void in C
+            Card("D", "K"),  # idx 2 - diamond K
+        ]
+
+        strat = cls(**kwargs)
+        strat.on_hand_start(hand, "high", None, player_index=0)
+        # Both opponents void in spades
+        strat._void_suits_by_seat[1].add("S")
+        strat._void_suits_by_seat[3].add("S")
+
+        choice = strat.choose_card(hand, [], "high", None, 0)
+        assert hand[choice] == Card(
+            "S", "J"
+        ), f"{cls.__name__}: void-backed lead should pick ♠J, got {hand[choice]}"
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_void_backed_picks_highest_value_card(self, cls, kwargs):
+        """When multiple void-backed cards exist, pick the highest-value one
+        (which in low = lowest rank, in high = highest rank)."""
+        hand = [
+            Card("S", "J"),  # idx 0 - spade J
+            Card("S", "Q"),  # idx 1 - spade Q
+            Card("C", "K"),  # idx 2 - club K (opponents not void)
+        ]
+
+        strat = cls(**kwargs)
+        strat.on_hand_start(hand, "low", None, player_index=0)
+        strat._void_suits_by_seat[1].add("S")
+        strat._void_suits_by_seat[3].add("S")
+
+        choice = strat.choose_card(hand, [], "low", None, 0)
+        # In low, J has higher value than Q (inverted ranks), so J is best
+        assert hand[choice] == Card("S", "J"), (
+            f"{cls.__name__}: should pick highest-value void-backed card "
+            f"(♠J in low), got {hand[choice]}"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_no_void_backed_when_only_one_opponent_void(self, cls, kwargs):
+        """Void-backed requires BOTH opponents void. If only one is void,
+        the other can still follow suit and potentially win."""
+        hand = [
+            Card("S", "J"),  # idx 0 - spade J
+            Card("C", "K"),  # idx 1 - club K
+            Card("C", "Q"),  # idx 2 - club Q
+            Card("C", "T"),  # idx 3 - club T
+        ]
+
+        strat = cls(**kwargs)
+        strat.on_hand_start(hand, "low", None, player_index=0)
+        # Only opponent seat 1 is void in spades, seat 3 is not
+        strat._void_suits_by_seat[1].add("S")
+
+        choice = strat.choose_card(hand, [], "low", None, 0)
+        # Should fall through to longest-suit or sure-winner, not void-backed
+        # ♠J is NOT a sure winner (♠T not accounted for), so longest-suit
+        # (clubs) should be used
+        assert hand[choice].suit == "C", (
+            f"{cls.__name__}: with only one opponent void, should NOT use "
+            f"void-backed logic — got {hand[choice]}"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": False}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": False},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_void_backed_requires_cash_a_flag(self, cls, kwargs):
+        """Void-backed leads are gated behind cash_winners_on_lead. With the
+        flag off, the void-backed path does not fire."""
+        hand = [
+            Card("S", "J"),  # idx 0 - spade J, opponents void in S
+            Card("C", "K"),  # idx 1 - club K
+            Card("C", "Q"),  # idx 2
+            Card("C", "T"),  # idx 3
+        ]
+
+        strat = cls(**kwargs)
+        strat.on_hand_start(hand, "low", None, player_index=0)
+        strat._void_suits_by_seat[1].add("S")
+        strat._void_suits_by_seat[3].add("S")
+
+        choice = strat.choose_card(hand, [], "low", None, 0)
+        # With flag off, falls through to longest-suit heuristic (clubs)
+        assert hand[choice].suit == "C", (
+            f"{cls.__name__}: with Cash-A off, void-backed should not fire "
+            f"— got {hand[choice]}"
+        )
+
+
+class TestObservePlayLonerTricks:
+    """Fix observe_play suit-continuity for 3-player loner/moon tricks (#2627).
+
+    The original code used ``len(trick_plays) == 4`` to detect trick
+    completion, which never fires for loner/moon hands (3 active players).
+    """
+
+    def test_glutton_observe_play_3player_trick(self):
+        """GluttonStrategy.observe_play sets _last_won_lead_suit after
+        a 3-play trick (loner/moon)."""
+        strat = GluttonStrategy()
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+
+        # Simulate a 3-player trick: seat 0 leads ♠T, seat 1 plays ♠J,
+        # seat 3 plays ♠Q. In low, ♠T wins (lowest rank is best).
+        trick_plays = [
+            (0, Card("S", "T")),
+            (1, Card("S", "J")),
+            (3, Card("S", "Q")),
+        ]
+        # Observe each play
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._last_won_lead_suit == "S", (
+            "After 3-player trick where leader won, _last_won_lead_suit "
+            f"should be 'S', got {strat._last_won_lead_suit}"
+        )
+        assert strat._last_won_lead_seat == 0
+
+    def test_glutton_observe_play_3player_leader_lost(self):
+        """When the leader loses a 3-player trick, continuity is cleared."""
+        strat = GluttonStrategy()
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+
+        # Seat 0 leads ♠Q, seat 1 plays ♠J, seat 3 plays ♠T.
+        # In low, ♠T wins (seat 3), not the leader (seat 0).
+        trick_plays = [
+            (0, Card("S", "Q")),
+            (1, Card("S", "J")),
+            (3, Card("S", "T")),
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._last_won_lead_suit is None
+        assert strat._last_won_lead_seat is None
+
+    def test_isolated_observe_play_3player_trick(self):
+        """GluttonIsolatedStrategy.observe_play handles 3-play tricks
+        when suit_continuity is enabled."""
+        strat = GluttonIsolatedStrategy(suit_continuity=True)
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+
+        trick_plays = [
+            (0, Card("S", "T")),
+            (1, Card("S", "J")),
+            (3, Card("S", "Q")),
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._last_won_lead_suit == "S"
+        assert strat._last_won_lead_seat == 0
+
+    def test_isolated_observe_play_no_continuity_flag(self):
+        """With suit_continuity=False, _last_won_lead_suit stays None
+        even after trick completion."""
+        strat = GluttonIsolatedStrategy(suit_continuity=False)
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+
+        trick_plays = [
+            (0, Card("S", "T")),
+            (1, Card("S", "J")),
+            (3, Card("S", "Q")),
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._last_won_lead_suit is None


### PR DESCRIPTION
## Summary

- Add void-backed winner lead logic: when both opponents have demonstrated voids in a suit, any card in that suit is a guaranteed winner regardless of rank
- Fix `observe_play` trick-completion detection for 3-player loner/moon tricks (was hardcoded to `len==4`, now accepts 3 or 4)
- Bump `GLUTTON_STRATEGY_VERSION` to 0.11.0

## Why

In loner LOW contracts, after opponents void out of suits mid-hand, the AI failed to recognize that remaining cards in those suits were guaranteed winners. The `_is_sure_winner` check was void-blind — it only checked whether higher-ranked cards had been seen in play. This caused the AI to lead from non-voided suits (where opponents could still follow and win) instead of cashing guaranteed winners. Live game 2026-04-08: AI bid loner LOW, won tricks 1–7, then lost tricks 8–10 by leading into suits opponents still held.

Fixes #2627

## Changes

| File | Change |
|------|--------|
| `src/bid_euchre/strategy/glutton.py` | Add `_opponents_void_in_suit()` helper to both `GluttonStrategy` and `GluttonIsolatedStrategy`. Add void-backed winner lead check in HIGH/LOW `_choose_lead` path (gated behind `cash_winners_on_lead`). Fix `observe_play` to detect 3-player trick completion. Version bump. |
| `tests/unit/test_greedy.py` | 14 new tests: void-backed lead selection (low, high, value ordering, single-void negative, flag-off negative) for both strategy classes, plus 4 tests for 3-player `observe_play` trick completion. |

## Repro / Validation

```bash
# Tier 1: targeted tests (14 new + 28 existing = 42 total)
uv run python -m pytest tests/unit/test_greedy.py -v

# Tier 2: full validation
make check-gated
```

## Tests

- `tests/unit/test_greedy.py::TestVoidBackedWinnerLeads` — 10 parametrized tests covering:
  - Core void-backed lead in LOW contract (both strategy classes)
  - Core void-backed lead in HIGH contract (both strategy classes)
  - Highest-value card selection among void-backed candidates
  - Negative: only one opponent void → void-backed does NOT fire
  - Negative: `cash_winners_on_lead=False` → void-backed does NOT fire
- `tests/unit/test_greedy.py::TestObservePlayLonerTricks` — 4 tests covering:
  - 3-player trick sets `_last_won_lead_suit` (GluttonStrategy)
  - 3-player trick clears continuity when leader loses (GluttonStrategy)
  - 3-player trick with `suit_continuity=True` (GluttonIsolatedStrategy)
  - 3-player trick with `suit_continuity=False` stays None

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
worktree: Bid-Euchre-steward-author (author-a lane)
branch: fix/void-backed-winner-leads-2627
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)