### PR TITLE
feat(ops): extract lane topology into adapter config (SP-5-01 PR1)

### DIFF
--- a/src/bid_euchre/ops/adapters/__init__.py
+++ b/src/bid_euchre/ops/adapters/__init__.py
@@ -35,7 +35,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from bid_euchre.ops.adapters.bid_euchre import TaskQueueService, WorkerPoolService
+from bid_euchre.ops.adapters.bid_euchre import (
+    BidEuchreLaneConfig,
+    TaskQueueService,
+    WorkerPoolService,
+    get_lane_config,
+)
 from bid_euchre.ops.core.controller import ControlPlaneController
 from bid_euchre.ops.core.monitor import MonitorService
 
@@ -73,9 +78,11 @@ def create_provider(
 
 
 __all__ = [
+    "BidEuchreLaneConfig",
     "ControlPlaneController",
     "MonitorService",
     "TaskQueueService",
     "WorkerPoolService",
     "create_provider",
+    "get_lane_config",
 ]

--- a/src/bid_euchre/ops/adapters/bid_euchre.py
+++ b/src/bid_euchre/ops/adapters/bid_euchre.py
@@ -33,7 +33,124 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from bid_euchre.ops.core.interfaces import AbstractTaskQueue, AbstractWorkerPool
+from bid_euchre.ops.core.interfaces import (
+    AbstractLaneConfig,
+    AbstractTaskQueue,
+    AbstractWorkerPool,
+)
+
+
+class BidEuchreLaneConfig(AbstractLaneConfig):
+    """Bid Euchre repo-specific lane topology.
+
+    Provides the canonical set of author/worker lanes, their domain
+    assignments, and tmux pane resolution for the Bid Euchre steward fleet.
+
+    This is the single source of truth for lane topology — replacing the
+    former ``KNOWN_AUTHOR_LANES`` module-level constant in ``task_queue.py``
+    and the ``LANE_DOMAINS`` constant in ``worker_pool.py``.
+    """
+
+    #: All known author/worker lanes that can receive dispatched work.
+    _KNOWN_LANES: frozenset[str] = frozenset(
+        {
+            # Platform pool
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            # Browser-game pool
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            # Analyst pool (shaping, triage, plan review, investigation)
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
+            # Flex pool (domain-agnostic overflow)
+            "flex-a",
+            "flex-b",
+            "flex-c",
+            "flex-d",
+        }
+    )
+
+    #: Retired lane identifiers kept for backward compatibility.
+    _LEGACY_LANES: frozenset[str] = frozenset({"author-scratch"})
+
+    #: Domain assignment for each managed lane.
+    #: Lanes with ``None`` are "flex" — available to any domain.
+    _LANE_DOMAINS: dict[str, str | None] = {
+        # Platform pool
+        "author-a": "platform",
+        "author-b": "platform",
+        "author-c": "platform",
+        "author-d": "platform",
+        # Browser-game pool
+        "brws-author-a": "browser-game",
+        "brws-author-b": "browser-game",
+        "brws-author-c": "browser-game",
+        "brws-author-d": "browser-game",
+        # Analyst pool (flex — accepts any domain)
+        "analyst-a": None,
+        "analyst-b": None,
+        "analyst-c": None,
+        "analyst-d": None,
+        # Flex pool (domain-agnostic overflow)
+        "flex-a": None,
+        "flex-b": None,
+        "flex-c": None,
+        "flex-d": None,
+    }
+
+    def known_lanes(self) -> frozenset[str]:
+        """Return the 16 known Bid Euchre worker lanes."""
+        return self._KNOWN_LANES
+
+    def lane_domains(self) -> dict[str, str | None]:
+        """Return domain assignments for all known lanes."""
+        return dict(self._LANE_DOMAINS)
+
+    def pane_name_for_lane(self, lane_id: str) -> str | None:
+        """Resolve tmux pane name for a Bid Euchre lane.
+
+        Pane resolution in the Bid Euchre fleet is handled dynamically
+        by ``worker_pool._resolve_tmux_target()`` using live tmux queries
+        and registry fallback.  This method returns the lane_id itself
+        as the logical pane identifier, since the actual pane index is
+        resolved at dispatch time.
+
+        Returns ``None`` for unknown lanes.
+        """
+        if lane_id in self._KNOWN_LANES:
+            return lane_id
+        return None
+
+    def legacy_lanes(self) -> frozenset[str]:
+        """Return retired Bid Euchre lane identifiers."""
+        return self._LEGACY_LANES
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor for lane config
+# ---------------------------------------------------------------------------
+
+_lane_config_instance: BidEuchreLaneConfig | None = None
+
+
+def get_lane_config() -> BidEuchreLaneConfig:
+    """Return the singleton BidEuchreLaneConfig instance.
+
+    Provides a module-level accessor so that callers in ``task_queue.py``
+    and ``worker_pool.py`` can retrieve lane topology without constructing
+    a full ServiceProvider.
+    """
+    global _lane_config_instance
+    if _lane_config_instance is None:
+        _lane_config_instance = BidEuchreLaneConfig()
+    return _lane_config_instance
 
 
 class TaskQueueService(AbstractTaskQueue):

--- a/src/bid_euchre/ops/core/__init__.py
+++ b/src/bid_euchre/ops/core/__init__.py
@@ -42,6 +42,7 @@ Usage::
 from bid_euchre.ops.core.controller import ControlPlaneController
 from bid_euchre.ops.core.interfaces import (
     AbstractController,
+    AbstractLaneConfig,
     AbstractMonitor,
     AbstractTaskQueue,
     AbstractWorkerPool,
@@ -51,6 +52,7 @@ from bid_euchre.ops.core.provider import ServiceProvider
 
 __all__ = [
     "AbstractController",
+    "AbstractLaneConfig",
     "AbstractMonitor",
     "AbstractTaskQueue",
     "AbstractWorkerPool",

--- a/src/bid_euchre/ops/core/interfaces.py
+++ b/src/bid_euchre/ops/core/interfaces.py
@@ -452,3 +452,69 @@ class AbstractWorkerPool(ABC):
             ``True`` if the nudge was sent successfully, ``False``
             otherwise.
         """
+
+
+# ---------------------------------------------------------------------------
+# AbstractLaneConfig
+# ---------------------------------------------------------------------------
+
+
+class AbstractLaneConfig(ABC):
+    """Provides lane topology information for an orchestrated project.
+
+    Lane topology defines which lanes exist, their domain assignments,
+    and how lane identifiers map to tmux pane targets.  This contract
+    decouples the orchestration loop from project-specific lane naming
+    conventions.
+
+    Concrete implementations:
+        ``bid_euchre.ops.adapters.bid_euchre.BidEuchreLaneConfig``
+    """
+
+    @abstractmethod
+    def known_lanes(self) -> frozenset[str]:
+        """Return the set of all known author/worker lane identifiers.
+
+        These are the lanes eligible to receive dispatched work via
+        the task queue.
+
+        Returns:
+            A frozenset of lane identifier strings.
+        """
+
+    @abstractmethod
+    def lane_domains(self) -> dict[str, str | None]:
+        """Return the domain assignment for each known lane.
+
+        Lanes with a ``None`` domain are "flex" — available to any
+        execution domain when same-domain lanes are exhausted.
+
+        Returns:
+            A dict mapping lane identifier to domain string (or None).
+        """
+
+    @abstractmethod
+    def pane_name_for_lane(self, lane_id: str) -> str | None:
+        """Resolve the tmux pane target for a given lane.
+
+        Used by the worker pool to address lanes when sending nudges
+        or checking pane health.  Returns ``None`` if the lane is
+        unknown or has no configured pane.
+
+        Args:
+            lane_id: The lane identifier to resolve.
+
+        Returns:
+            The tmux pane target string, or ``None`` if not resolvable.
+        """
+
+    @abstractmethod
+    def legacy_lanes(self) -> frozenset[str]:
+        """Return the set of retired/legacy lane identifiers.
+
+        Legacy lanes are recognized for backward compatibility (e.g.,
+        reading old task packets) but are not eligible for new dispatch.
+
+        Returns:
+            A frozenset of legacy lane identifier strings.
+        """

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -55,34 +55,37 @@ VALID_ACK_ACTIONS = frozenset({"approve", "edit", "redirect", "reject"})
 
 VALID_RESULT_STATUSES = frozenset({"completed", "failed", "blocked"})
 
-# Known author lanes that can receive dispatched work.
-# Platform pool, browser-game pool, analyst pool, and flex lanes.
-KNOWN_AUTHOR_LANES = frozenset(
-    {
-        # Platform pool
-        "author-a",
-        "author-b",
-        "author-c",
-        "author-d",
-        # Browser-game pool
-        "brws-author-a",
-        "brws-author-b",
-        "brws-author-c",
-        "brws-author-d",
-        # Analyst pool (shaping, triage, plan review, investigation)
-        "analyst-a",
-        "analyst-b",
-        "analyst-c",
-        "analyst-d",
-        # Flex pool (domain-agnostic overflow)
-        "flex-a",
-        "flex-b",
-        "flex-c",
-        "flex-d",
-    }
-)
+# ---------------------------------------------------------------------------
+# Lane topology — provided by the adapter layer
+# ---------------------------------------------------------------------------
 
-_LEGACY_AUTHOR_LANES = frozenset({"author-scratch"})
+
+def get_known_lanes() -> frozenset[str]:
+    """Return the set of known author lanes from the lane config adapter.
+
+    This replaces the former module-level ``KNOWN_AUTHOR_LANES`` constant.
+    Lane topology is now owned by
+    :class:`~bid_euchre.ops.adapters.bid_euchre.BidEuchreLaneConfig`
+    and accessed via the singleton accessor.
+    """
+    from bid_euchre.ops.adapters.bid_euchre import get_lane_config
+
+    return get_lane_config().known_lanes()
+
+
+def _get_legacy_lanes() -> frozenset[str]:
+    """Return the set of legacy/retired lane identifiers."""
+    from bid_euchre.ops.adapters.bid_euchre import get_lane_config
+
+    return get_lane_config().legacy_lanes()
+
+
+# Backward-compatible re-export.  External callers that imported
+# ``KNOWN_AUTHOR_LANES`` from this module will continue to work, but
+# should migrate to ``get_known_lanes()`` for future portability.
+KNOWN_AUTHOR_LANES: frozenset[str] = get_known_lanes()
+
+_LEGACY_AUTHOR_LANES: frozenset[str] = _get_legacy_lanes()
 
 # Valid state transitions for the task packet lifecycle.
 # Enforced by transition_status() to prevent incoherent state from
@@ -136,9 +139,10 @@ class TaskPacket:
             raise ValueError(
                 f"Invalid priority {self.priority!r}; expected one of {sorted(VALID_PRIORITIES)}"
             )
-        if self.owner is not None and self.owner not in KNOWN_AUTHOR_LANES:
+        _lanes = get_known_lanes()
+        if self.owner is not None and self.owner not in _lanes:
             raise ValueError(
-                f"Unknown owner lane {self.owner!r}; expected one of {sorted(KNOWN_AUTHOR_LANES)}"
+                f"Unknown owner lane {self.owner!r}; expected one of {sorted(_lanes)}"
             )
         if self.domain is not None and self.domain not in KNOWN_DOMAINS:
             raise ValueError(
@@ -167,10 +171,11 @@ class TaskAck:
             )
         if self.action == "redirect" and not self.redirect_to:
             raise ValueError("redirect_to is required when action is 'redirect'")
-        if self.redirect_to and self.redirect_to not in KNOWN_AUTHOR_LANES:
+        _ack_lanes = get_known_lanes()
+        if self.redirect_to and self.redirect_to not in _ack_lanes:
             raise ValueError(
                 f"Unknown redirect target {self.redirect_to!r}; "
-                f"expected one of {sorted(KNOWN_AUTHOR_LANES)}"
+                f"expected one of {sorted(_ack_lanes)}"
             )
 
 

--- a/src/bid_euchre/ops/worker_pool.py
+++ b/src/bid_euchre/ops/worker_pool.py
@@ -82,46 +82,39 @@ _PASTE_BRACKET_DELAY: float = 0.1
 #: injected messages from corrupting the current input buffer.  See #2352.
 _ESCAPE_CANCEL_DELAY: float = 0.1
 
-#: Default domain assignment for each managed lane.
-#: Lanes with ``None`` are "flex" — available to any domain when same-domain
-#: lanes are exhausted.
-LANE_DOMAINS: dict[str, str | None] = {
-    # Platform pool
-    "author-a": "platform",
-    "author-b": "platform",
-    "author-c": "platform",
-    "author-d": "platform",
-    # Browser-game pool
-    "brws-author-a": "browser-game",
-    "brws-author-b": "browser-game",
-    "brws-author-c": "browser-game",
-    "brws-author-d": "browser-game",
-    # Analyst pool (flex — accepts any domain)
-    "analyst-a": None,
-    "analyst-b": None,
-    "analyst-c": None,
-    "analyst-d": None,
-    # Flex pool (domain-agnostic overflow)
-    "flex-a": None,
-    "flex-b": None,
-    "flex-c": None,
-    "flex-d": None,
-}
+# ---------------------------------------------------------------------------
+# Lane topology — provided by the adapter layer
+# ---------------------------------------------------------------------------
+
+
+def _get_lane_domains() -> dict[str, str | None]:
+    """Return lane domain assignments from the adapter.
+
+    Replaces the former module-level ``LANE_DOMAINS`` constant.
+    """
+    from bid_euchre.ops.adapters.bid_euchre import get_lane_config
+
+    return get_lane_config().lane_domains()
 
 
 def _managed_lanes() -> frozenset[str]:
     """Return the set of lane IDs managed by the worker pool.
 
-    Imports KNOWN_AUTHOR_LANES from task_queue to avoid duplication.
+    Delegates to the lane config adapter instead of importing from
+    task_queue.
     """
-    from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
+    from bid_euchre.ops.adapters.bid_euchre import get_lane_config
 
-    return KNOWN_AUTHOR_LANES
+    return get_lane_config().known_lanes()
 
 
 def get_lane_domain(lane_id: str) -> str | None:
     """Return the configured domain for a lane, or None if flex/unknown."""
-    return LANE_DOMAINS.get(lane_id)
+    return _get_lane_domains().get(lane_id)
+
+
+# Backward-compatible re-export of LANE_DOMAINS for existing callers.
+LANE_DOMAINS: dict[str, str | None] = _get_lane_domains()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ops_adapter_migration.py
+++ b/tests/unit/test_ops_adapter_migration.py
@@ -18,9 +18,174 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bid_euchre.ops.core.interfaces import (
+    AbstractLaneConfig,
     AbstractTaskQueue,
     AbstractWorkerPool,
 )
+
+# =========================================================================
+# BidEuchreLaneConfig
+# =========================================================================
+
+
+class TestBidEuchreLaneConfigABCCompliance:
+    """BidEuchreLaneConfig properly implements AbstractLaneConfig."""
+
+    def test_is_subclass(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        assert issubclass(BidEuchreLaneConfig, AbstractLaneConfig)
+
+    def test_can_instantiate(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        assert isinstance(lc, AbstractLaneConfig)
+
+
+class TestBidEuchreLaneConfigTopology:
+    """BidEuchreLaneConfig provides correct Bid Euchre lane topology."""
+
+    def test_known_lanes_count(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        lanes = lc.known_lanes()
+        assert len(lanes) == 16  # 4 platform + 4 browser + 4 analyst + 4 flex
+
+    def test_known_lanes_contains_all_pools(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        lanes = lc.known_lanes()
+        # Platform pool
+        assert "author-a" in lanes
+        assert "author-d" in lanes
+        # Browser-game pool
+        assert "brws-author-a" in lanes
+        assert "brws-author-d" in lanes
+        # Analyst pool
+        assert "analyst-a" in lanes
+        assert "analyst-d" in lanes
+        # Flex pool
+        assert "flex-a" in lanes
+        assert "flex-d" in lanes
+
+    def test_known_lanes_returns_frozenset(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        lanes = lc.known_lanes()
+        assert isinstance(lanes, frozenset)
+
+    def test_lane_domains_covers_all_lanes(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        domains = lc.lane_domains()
+        assert set(domains.keys()) == set(lc.known_lanes())
+
+    def test_lane_domains_platform(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        domains = lc.lane_domains()
+        assert domains["author-a"] == "platform"
+        assert domains["author-b"] == "platform"
+
+    def test_lane_domains_browser_game(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        domains = lc.lane_domains()
+        assert domains["brws-author-a"] == "browser-game"
+
+    def test_lane_domains_flex_is_none(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        domains = lc.lane_domains()
+        assert domains["analyst-a"] is None
+        assert domains["flex-a"] is None
+
+    def test_pane_name_for_known_lane(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        assert lc.pane_name_for_lane("author-a") == "author-a"
+
+    def test_pane_name_for_unknown_lane(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        assert lc.pane_name_for_lane("nonexistent-lane") is None
+
+    def test_legacy_lanes(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+
+        lc = BidEuchreLaneConfig()
+        legacy = lc.legacy_lanes()
+        assert "author-scratch" in legacy
+        assert isinstance(legacy, frozenset)
+
+
+class TestGetLaneConfigSingleton:
+    """get_lane_config() returns a singleton instance."""
+
+    def test_returns_same_instance(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import get_lane_config
+
+        config1 = get_lane_config()
+        config2 = get_lane_config()
+        assert config1 is config2
+
+    def test_returns_correct_type(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import (
+            BidEuchreLaneConfig,
+            get_lane_config,
+        )
+
+        config = get_lane_config()
+        assert isinstance(config, BidEuchreLaneConfig)
+
+
+class TestLaneTopologyBackwardCompat:
+    """Backward-compatible imports from task_queue and worker_pool still work."""
+
+    def test_task_queue_known_author_lanes(self) -> None:
+        from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
+
+        assert len(KNOWN_AUTHOR_LANES) == 16
+        assert "author-a" in KNOWN_AUTHOR_LANES
+        assert "flex-d" in KNOWN_AUTHOR_LANES
+
+    def test_task_queue_get_known_lanes(self) -> None:
+        from bid_euchre.ops.task_queue import get_known_lanes
+
+        lanes = get_known_lanes()
+        assert len(lanes) == 16
+        assert isinstance(lanes, frozenset)
+
+    def test_known_lanes_match_adapter(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+        from bid_euchre.ops.task_queue import KNOWN_AUTHOR_LANES
+
+        adapter_lanes = BidEuchreLaneConfig().known_lanes()
+        assert set(KNOWN_AUTHOR_LANES) == set(adapter_lanes)
+
+    def test_worker_pool_lane_domains(self) -> None:
+        from bid_euchre.ops.worker_pool import LANE_DOMAINS
+
+        assert len(LANE_DOMAINS) == 16
+        assert LANE_DOMAINS["author-a"] == "platform"
+
+    def test_lane_domains_match_adapter(self) -> None:
+        from bid_euchre.ops.adapters.bid_euchre import BidEuchreLaneConfig
+        from bid_euchre.ops.worker_pool import LANE_DOMAINS
+
+        adapter_domains = BidEuchreLaneConfig().lane_domains()
+        assert LANE_DOMAINS == adapter_domains
+
 
 # =========================================================================
 # TaskQueueService
@@ -410,15 +575,17 @@ class TestWorkerPoolServiceDelegation:
 class TestAdapterPackageExports:
     """Verify adapters/__init__.py re-exports all four adapter classes."""
 
-    def test_all_four_adapters_exported(self) -> None:
+    def test_all_adapters_exported(self) -> None:
         import bid_euchre.ops.adapters as adapters
 
         expected = {
+            "BidEuchreLaneConfig",
             "ControlPlaneController",
             "MonitorService",
             "TaskQueueService",
             "WorkerPoolService",
             "create_provider",
+            "get_lane_config",
         }
         assert expected == set(adapters.__all__)
 
@@ -459,10 +626,11 @@ class TestAdapterPackageExports:
 
 
 class TestAllAdaptersImplementABCs:
-    """All four adapters are instances of their respective ABCs."""
+    """All five adapters are instances of their respective ABCs."""
 
-    def test_all_four_are_abc_subclasses(self) -> None:
+    def test_all_five_are_abc_subclasses(self) -> None:
         from bid_euchre.ops.adapters import (
+            BidEuchreLaneConfig,
             ControlPlaneController,
             MonitorService,
             TaskQueueService,
@@ -470,18 +638,21 @@ class TestAllAdaptersImplementABCs:
         )
         from bid_euchre.ops.core import (
             AbstractController,
+            AbstractLaneConfig,
             AbstractMonitor,
             AbstractTaskQueue,
             AbstractWorkerPool,
         )
 
+        assert issubclass(BidEuchreLaneConfig, AbstractLaneConfig)
         assert issubclass(ControlPlaneController, AbstractController)
         assert issubclass(MonitorService, AbstractMonitor)
         assert issubclass(TaskQueueService, AbstractTaskQueue)
         assert issubclass(WorkerPoolService, AbstractWorkerPool)
 
-    def test_all_four_can_instantiate(self) -> None:
+    def test_all_five_can_instantiate(self) -> None:
         from bid_euchre.ops.adapters import (
+            BidEuchreLaneConfig,
             ControlPlaneController,
             MonitorService,
             TaskQueueService,
@@ -489,11 +660,13 @@ class TestAllAdaptersImplementABCs:
         )
 
         # All should instantiate without error
+        lc = BidEuchreLaneConfig()
         ctrl = ControlPlaneController()
         mon = MonitorService()
         tq = TaskQueueService()
         wp = WorkerPoolService()
 
+        assert lc is not None
         assert ctrl is not None
         assert mon is not None
         assert tq is not None

--- a/tests/unit/test_ops_core_interfaces.py
+++ b/tests/unit/test_ops_core_interfaces.py
@@ -18,12 +18,16 @@ import pytest
 
 from bid_euchre.ops.core import (
     AbstractController,
+    AbstractLaneConfig,
     AbstractMonitor,
     AbstractTaskQueue,
     AbstractWorkerPool,
 )
 from bid_euchre.ops.core.interfaces import (
     AbstractController as DirectController,
+)
+from bid_euchre.ops.core.interfaces import (
+    AbstractLaneConfig as DirectLaneConfig,
 )
 from bid_euchre.ops.core.interfaces import (
     AbstractMonitor as DirectMonitor,
@@ -71,6 +75,17 @@ class TestAbstractTaskQueueNotInstantiable:
 
     def test_re_export_matches_direct(self) -> None:
         assert AbstractTaskQueue is DirectTaskQueue
+
+
+class TestAbstractLaneConfigNotInstantiable:
+    """AbstractLaneConfig raises TypeError on direct instantiation."""
+
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError, match="abstract method"):
+            AbstractLaneConfig()  # type: ignore[abstract]
+
+    def test_re_export_matches_direct(self) -> None:
+        assert AbstractLaneConfig is DirectLaneConfig
 
 
 class TestAbstractWorkerPoolNotInstantiable:
@@ -155,6 +170,24 @@ class _StubTaskQueue(AbstractTaskQueue):
         return {"total": 0}
 
 
+class _StubLaneConfig(AbstractLaneConfig):
+    """Minimal concrete implementation for testing."""
+
+    def known_lanes(self) -> frozenset[str]:
+        return frozenset({"test-lane-a", "test-lane-b"})
+
+    def lane_domains(self) -> dict[str, str | None]:
+        return {"test-lane-a": "domain-x", "test-lane-b": None}
+
+    def pane_name_for_lane(self, lane_id: str) -> str | None:
+        if lane_id in ("test-lane-a", "test-lane-b"):
+            return lane_id
+        return None
+
+    def legacy_lanes(self) -> frozenset[str]:
+        return frozenset({"old-lane"})
+
+
 class _StubWorkerPool(AbstractWorkerPool):
     """Minimal concrete implementation for testing."""
 
@@ -209,6 +242,20 @@ class TestConcreteSubclasses:
         assert tq.list_packets() == []
         assert tq.archive_packet("test") is True
         assert tq.queue_summary()["total"] == 0
+
+    def test_stub_lane_config(self) -> None:
+        lc = _StubLaneConfig()
+        assert isinstance(lc, AbstractLaneConfig)
+        lanes = lc.known_lanes()
+        assert isinstance(lanes, frozenset)
+        assert "test-lane-a" in lanes
+        assert "test-lane-b" in lanes
+        domains = lc.lane_domains()
+        assert domains["test-lane-a"] == "domain-x"
+        assert domains["test-lane-b"] is None
+        assert lc.pane_name_for_lane("test-lane-a") == "test-lane-a"
+        assert lc.pane_name_for_lane("unknown") is None
+        assert "old-lane" in lc.legacy_lanes()
 
     def test_stub_worker_pool(self) -> None:
         wp = _StubWorkerPool()
@@ -289,6 +336,21 @@ class _PartialTaskQueue(AbstractTaskQueue):
     # queue_summary intentionally omitted
 
 
+class _PartialLaneConfig(AbstractLaneConfig):
+    """Missing legacy_lanes — should fail to instantiate."""
+
+    def known_lanes(self) -> frozenset[str]:
+        return frozenset()
+
+    def lane_domains(self) -> dict[str, str | None]:
+        return {}
+
+    def pane_name_for_lane(self, lane_id: str) -> str | None:
+        return None
+
+    # legacy_lanes intentionally omitted
+
+
 class _PartialWorkerPool(AbstractWorkerPool):
     """Missing nudge_pane — should fail to instantiate."""
 
@@ -325,6 +387,10 @@ class TestPartialSubclasses:
         with pytest.raises(TypeError, match="abstract method"):
             _PartialTaskQueue()  # type: ignore[abstract]
 
+    def test_partial_lane_config(self) -> None:
+        with pytest.raises(TypeError, match="abstract method"):
+            _PartialLaneConfig()  # type: ignore[abstract]
+
     def test_partial_worker_pool(self) -> None:
         with pytest.raises(TypeError, match="abstract method"):
             _PartialWorkerPool()  # type: ignore[abstract]
@@ -343,6 +409,7 @@ class TestModuleExports:
 
         expected_abcs = {
             "AbstractController",
+            "AbstractLaneConfig",
             "AbstractMonitor",
             "AbstractTaskQueue",
             "AbstractWorkerPool",
@@ -355,6 +422,7 @@ class TestModuleExports:
 
         abc_names = [
             "AbstractController",
+            "AbstractLaneConfig",
             "AbstractMonitor",
             "AbstractTaskQueue",
             "AbstractWorkerPool",


### PR DESCRIPTION
## Plan
`plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md` — PR1

## Summary
- Add `AbstractLaneConfig` ABC to `core/interfaces.py` with `known_lanes()`, `lane_domains()`, `pane_name_for_lane()`, and `legacy_lanes()` methods
- Implement `BidEuchreLaneConfig` adapter in `adapters/bid_euchre.py` with singleton accessor `get_lane_config()`
- Replace hardcoded `KNOWN_AUTHOR_LANES` in `task_queue.py` with `get_known_lanes()` function delegating to adapter
- Replace hardcoded `LANE_DOMAINS` in `worker_pool.py` with adapter-backed `_get_lane_domains()` function
- Maintain backward-compatible re-exports (`KNOWN_AUTHOR_LANES`, `LANE_DOMAINS`) for existing callers

## Why
Platform-10 portability layer requires lane topology to be provided by the adapter contract rather than hardcoded in task_queue.py and worker_pool.py. This decouples the orchestration loop from project-specific lane naming conventions, enabling reuse across projects.

## Repro / Validation
**Command(s) run:**
```bash
uv run python -m pytest tests/unit/test_ops_core_interfaces.py tests/unit/test_ops_adapter_migration.py tests/unit/test_ops_task_queue.py tests/unit/test_ops_worker_pool.py -v
make check-gated
```

## Test Criteria
- **Pass condition:** `KNOWN_AUTHOR_LANES` is no longer a module-level constant in task_queue.py — it is a backward-compat re-export from the adapter
- **Verification command:** `grep -n "def get_known_lanes" src/bid_euchre/ops/task_queue.py`
- **Expected result:** Function exists, delegating to `get_lane_config().known_lanes()`

## Tests
- [x] `uv run python -m pytest tests/unit/test_ops_core_interfaces.py tests/unit/test_ops_adapter_migration.py tests/unit/test_ops_task_queue.py tests/unit/test_ops_worker_pool.py -v` — 348 passed
- [x] `make check-gated` — all checks passed

## Expected impact
- Metrics impact: None — behavioral no-op; same lane topology, now from adapter
- Runtime impact: Negligible — singleton accessor, one-time deferred import

## Risk level
- [x] Medium (ops platform infrastructure)

## Worktree proof (required)

`pwd`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git rev-parse --show-toplevel`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

`git worktree list`:
```
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  8ea12868 [ops/sp5-01-lane-topology-adapter]
```

## Review Loop
- [ ] Autonomous review loop completed (Codex CLI)
- [ ] Blocking findings addressed
- [ ] Non-blocking findings captured as follow-up issues (if any)

## Checklist
- [x] No generated artifacts committed (`data/runs`, `data/reports`)
- [x] If behavior changed, tests updated/added to lock it
- [x] PR is focused (one concept)
- [x] Issue linkage uses correct keyword (`Fixes` vs `Refs`) per closure policy