### PR TITLE
feat(ops): migrate hook callers to ServiceProvider (SP-5-01 PR4)

### DIFF
--- a/.claude/hooks/inbound-channel-audit.py
+++ b/.claude/hooks/inbound-channel-audit.py
@@ -102,6 +102,11 @@ def _route_ack(body: str, tag_text: str) -> str | None:
 
     This function performs lazy imports to avoid loading project modules on the
     fast path.
+
+    Note: ``process_inbound_ack`` is a module-level utility without an ABC
+    counterpart on ``AbstractMonitor``.  It remains a direct import until
+    Platform-13 determines whether it should be promoted to the adapter
+    surface.  (SP-5-01 PR4)
     """
     from bid_euchre.ops.monitor import process_inbound_ack  # noqa: E402
 
@@ -144,6 +149,8 @@ def main() -> int:
 
     # Import only when we actually need to audit — keeps the fast-exit path
     # free of project imports.
+    # Note: audit_channel_tag is a module-level utility without an ABC
+    # counterpart.  Remains a direct import until Platform-13.  (SP-5-01 PR4)
     from bid_euchre.ops.audit_trail import audit_channel_tag  # noqa: E402
 
     ack_replies: list[str] = []

--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -125,10 +125,12 @@ _transition_failed = False
 # 1. Find and complete the active dispatched task packet
 #    Primary (Gap B): look up by PR number in metadata
 #    Fallback: look up by lane owner
+#    Uses ServiceProvider for task_queue operations (SP-5-01 PR4).
 packet_id = None
 try:
-    from bid_euchre.ops.task_queue import list_packets, transition_status
-    dispatched = list_packets(status_filter='dispatched')
+    from bid_euchre.ops.core.provider import ServiceProvider
+    _provider = ServiceProvider.default()
+    dispatched = _provider.task_queue.list_packets(status='dispatched')
 
     # Primary: match by PR number in metadata
     if pr_num and pr_num != 'unknown':
@@ -147,7 +149,7 @@ try:
                 break
 
     if packet_id:
-        transition_status(packet_id, 'completed')
+        _provider.task_queue.transition_status(packet_id, 'completed')
 except Exception as exc:
     print(f'post-merge-notify: task transition failed: {exc}', file=sys.stderr)
     _transition_failed = True

--- a/.claude/skills/park/SKILL.md
+++ b/.claude/skills/park/SKILL.md
@@ -33,6 +33,10 @@ and exhaust system memory if not cleaned up.
 
 ```bash
 uv run python -c "
+from bid_euchre.ops.core.provider import ServiceProvider
+provider = ServiceProvider.default()
+# cleanup_lane_processes is a module-level utility (not on AbstractWorkerPool);
+# access via the concrete worker_pool module until Platform-13 adds it to the ABC.
 from bid_euchre.ops.worker_pool import cleanup_lane_processes
 killed = cleanup_lane_processes('<lane_id>')
 print(f'Killed {len(killed)} orphaned process(es)')

--- a/tests/unit/test_ops_core_provider.py
+++ b/tests/unit/test_ops_core_provider.py
@@ -10,6 +10,8 @@ Test categories:
 4. **Diagnostics** — to_dict and repr expose adapter types.
 5. **Package exports** — provider is importable from expected locations.
 6. **Convenience factory** — adapters.create_provider() shortcut works.
+7. **Hook import resolution** — hook callers can resolve imports through
+   the provider/adapter layer (SP-5-01 PR4 regression guard).
 """
 
 from __future__ import annotations
@@ -349,3 +351,84 @@ class TestCreateProviderFactory:
 
         provider = create_provider(tmux_session="custom")
         assert provider.worker_pool._tmux_session == "custom"
+
+
+# =========================================================================
+# Hook import resolution (SP-5-01 PR4 regression guard)
+# =========================================================================
+
+
+class TestHookImportResolution:
+    """Verify that all hook-level imports resolve through provider or direct paths.
+
+    Hook files (.claude/hooks/) use inline Python with deferred imports.
+    These tests ensure the import paths remain valid after the SP-5-01 PR4
+    migration.  They test import resolution only — functional correctness
+    of hooks requires a live steward session.
+    """
+
+    def test_post_merge_notify_provider_import(self) -> None:
+        """post-merge-notify.sh: ServiceProvider is importable and constructs."""
+        from bid_euchre.ops.core.provider import ServiceProvider
+
+        provider = ServiceProvider.default()
+        # The hook uses provider.task_queue.list_packets and .transition_status
+        assert hasattr(provider.task_queue, "list_packets")
+        assert hasattr(provider.task_queue, "transition_status")
+
+    def test_post_merge_notify_list_packets_via_provider(self) -> None:
+        """post-merge-notify.sh: list_packets through provider returns a list."""
+        from bid_euchre.ops.core.provider import ServiceProvider
+
+        provider = ServiceProvider.default()
+        # Should not raise; returns a list (may be empty in test env)
+        result = provider.task_queue.list_packets(status="dispatched")
+        assert isinstance(result, list)
+
+    def test_post_merge_notify_worker_pool_import(self) -> None:
+        """post-merge-notify.sh: cleanup_lane_processes is importable directly.
+
+        This function is a module-level utility without an ABC counterpart.
+        It remains a direct import until Platform-13.
+        """
+        from bid_euchre.ops.worker_pool import cleanup_lane_processes
+
+        assert callable(cleanup_lane_processes)
+
+    def test_post_merge_notify_message_bus_import(self) -> None:
+        """post-merge-notify.sh: message_bus functions are importable directly.
+
+        message_bus has no ABC — these remain direct imports.
+        """
+        from bid_euchre.ops.message_bus import create_message, send_message
+
+        assert callable(create_message)
+        assert callable(send_message)
+
+    def test_inbound_channel_audit_monitor_import(self) -> None:
+        """inbound-channel-audit.py: process_inbound_ack is importable.
+
+        This is a module-level utility without an ABC counterpart on
+        AbstractMonitor.  Remains a direct import until Platform-13.
+        """
+        from bid_euchre.ops.monitor import process_inbound_ack
+
+        assert callable(process_inbound_ack)
+
+    def test_inbound_channel_audit_audit_trail_import(self) -> None:
+        """inbound-channel-audit.py: audit_channel_tag is importable.
+
+        audit_trail has no ABC — remains a direct import.
+        """
+        from bid_euchre.ops.audit_trail import audit_channel_tag
+
+        assert callable(audit_channel_tag)
+
+    def test_park_skill_worker_pool_import(self) -> None:
+        """park/SKILL.md: cleanup_lane_processes is importable via worker_pool.
+
+        The SKILL.md code example uses this function directly.
+        """
+        from bid_euchre.ops.worker_pool import cleanup_lane_processes
+
+        assert callable(cleanup_lane_processes)


### PR DESCRIPTION
## Summary

- Route `post-merge-notify.sh` task_queue operations (`list_packets`, `transition_status`) through `ServiceProvider.default()` instead of direct `bid_euchre.ops.task_queue` imports
- Document remaining direct imports in `inbound-channel-audit.py` and `park/SKILL.md` that lack ABC counterparts as Platform-13 gaps
- Add 7 regression tests verifying all hook import paths resolve correctly through provider or direct paths

## Why

SP-5-01 PR4 completes the Platform-10 portability layer by migrating hook-level callers to the ServiceProvider where ABCs exist. Functions without ABC counterparts (`cleanup_lane_processes`, `process_inbound_ack`, `audit_channel_tag`, `message_bus`) are documented as Platform-13 gaps — kept as direct imports until the extraction proof determines whether they need adapter wrappers.

Refs SP-5-01 sub-plan: `plans/agent_ops/5_portability_and_learning/sub/2026-04-01_platform-10-portability-completion.md`

## Files Changed

| File | Change |
|------|--------|
| `.claude/hooks/post-merge-notify.sh` | Replace `from bid_euchre.ops.task_queue import list_packets, transition_status` with `ServiceProvider.default().task_queue` |
| `.claude/hooks/inbound-channel-audit.py` | Add SP-5-01 PR4 gap documentation for `process_inbound_ack` and `audit_channel_tag` |
| `.claude/skills/park/SKILL.md` | Update code example to show provider import alongside direct utility import |
| `tests/unit/test_ops_core_provider.py` | Add `TestHookImportResolution` class with 7 regression tests |

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_ops_core_provider.py -v

# Tier 2 — full validation
make check-gated
```

## Tests

- `make check-gated` — all checks passed
- 37/37 tests pass in `test_ops_core_provider.py` (30 pre-existing + 7 new)
- New tests cover: provider import resolution, list_packets via provider, cleanup_lane_processes, message_bus, process_inbound_ack, audit_channel_tag, park skill imports

## Worktree Proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/platform10-sp501-pr4-hook-migration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)