### PR TITLE
feat(ops): nudge orchestrator after post-merge completion send (PR-MSG-1)

### DIFF
--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -5,6 +5,9 @@
 #   1. Finds the active dispatched task packet by PR number (Gap B)
 #   2. Transitions it to "completed" status
 #   3. Sends a completion message to the orchestrator via message bus
+#   4. Best-effort tmux nudge ("/inbox-poll") to wake the orchestrator
+#      immediately so it processes the completion without waiting for
+#      the next /fleet-check cron tick (PR-MSG-1).
 #
 # Handles two merge modes:
 #   - Direct merge (`gh pr merge <N> --squash`): completes immediately
@@ -171,6 +174,7 @@ suffix = ' (auto-merge)' if auto_merge else ''
 payload = {'pr_number': pr_num, 'packet_id': packet_id}
 if auto_merge:
     payload['auto_merge'] = True
+_send_succeeded = False
 try:
     from bid_euchre.ops.message_bus import create_message, send_message
     msg = create_message(
@@ -182,12 +186,31 @@ try:
         payload=payload,
     )
     send_message(msg)
+    _send_succeeded = True
 except Exception as exc:
     print(f'post-merge-notify: message send failed: {exc}', file=sys.stderr)
 
+# 4. Best-effort nudge: wake the orchestrator so it processes the
+#    completion message immediately instead of waiting for the next
+#    /fleet-check cron tick.  This is the PR-MSG-1 attention fast path.
+#
+#    Delivery-policy boundary (see
+#    plans/sessions/2026-04-20_messaging-revamp-execution-plan.md):
+#    the durable send happens via message_bus.send_message(); the
+#    tmux-layer nudge lives in worker_pool.nudge_inbox().  Only nudge
+#    after a successful send — nudging on failure would surface stale
+#    inbox state without the new message.
+if _send_succeeded:
+    try:
+        from bid_euchre.ops.worker_pool import nudge_inbox
+        nudge_inbox('orchestrator')
+    except Exception as exc:
+        print(f'post-merge-notify: nudge failed: {exc}', file=sys.stderr)
+
 # Exit non-zero only when the task transition itself failed — this
 # prevents sentinel creation so the next hook invocation can retry.
-# Message send failures are logged but do not block the sentinel.
+# Message send and nudge failures are logged but do not block the
+# sentinel.
 if _transition_failed:
     sys.exit(1)
 " 2>/dev/null

--- a/tests/unit/test_post_merge_notify_hook.py
+++ b/tests/unit/test_post_merge_notify_hook.py
@@ -7,6 +7,11 @@ Validates key behaviors (issue #1461):
 4. Non-merge commands are ignored (guard check)
 5. Failed commands are ignored (exit code guard)
 6. Dedupe sentinel prevents double-firing
+
+PR-MSG-1 additions (completion fast-path nudge):
+7. Direct merge sends completion AND attempts best-effort tmux nudge
+8. Message send failure skips the nudge (no stale inbox-poll)
+9. Auto-merge initial path does not nudge (background watcher handles it)
 """
 
 from __future__ import annotations
@@ -20,6 +25,26 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_PATH = REPO_ROOT / ".claude" / "hooks" / "post-merge-notify.sh"
+
+
+def _make_tmux_stub(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a fake ``tmux`` binary that logs every invocation.
+
+    Returns ``(stub_bin_dir, tmux_log_path)``.  Prepend ``stub_bin_dir`` to
+    ``PATH`` in ``env_overrides`` so the hook's ``nudge_inbox()`` call hits
+    the stub instead of the system tmux.  The log captures one line per
+    invocation (newline-separated argv), letting tests assert whether a
+    ``send-keys`` nudge was attempted.
+    """
+    stub_dir = tmp_path / "stub_bin"
+    stub_dir.mkdir(exist_ok=True)
+    tmux_log = tmp_path / "tmux_calls.log"
+    stub = stub_dir / "tmux"
+    # Use printf to preserve argv boundaries; exit 0 so send-keys appears to
+    # succeed from nudge_inbox()'s perspective.
+    stub.write_text(f'#!/bin/sh\nprintf "%s\\n" "$*" >> "{tmux_log}"\nexit 0\n')
+    stub.chmod(0o755)
+    return stub_dir, tmux_log
 
 
 def _run_hook(
@@ -301,5 +326,142 @@ class TestLaneIdResolution:
             )
             assert result.returncode == 0
             assert sentinel.exists()
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+
+class TestCompletionNudge:
+    """Test the PR-MSG-1 completion-fast-path nudge behavior.
+
+    The hook must (a) fire ``nudge_inbox('orchestrator')`` after a successful
+    message send, (b) skip the nudge when the send failed, and (c) not fire
+    any nudge on the initial auto-merge dispatch (the background watcher
+    reuses ``run_completion`` and will nudge when the PR actually merges).
+
+    Assertions use a tmux stub script that records each invocation to a
+    log file.  A nudge is detected when the log contains a ``send-keys``
+    line — the first subprocess call inside ``nudge_inbox()`` is
+    ``tmux send-keys -t <target> Escape``.
+    """
+
+    def test_direct_merge_nudges_after_successful_send(self, tmp_path: Path) -> None:
+        """Direct merge should send completion then attempt a best-effort nudge."""
+        pr_num = "7001"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        stub_dir, tmux_log = _make_tmux_stub(tmp_path)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --squash",
+                tmp_path=tmp_path,
+                env_overrides={
+                    # Prepend stub so nudge_inbox()'s tmux call hits our stub.
+                    "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                    "CLAUDE_AGENT_NAME": "steward-author-a",
+                },
+            )
+            assert result.returncode == 0
+            assert sentinel.exists(), "Direct merge should create sentinel"
+            assert (
+                tmux_log.exists()
+            ), "tmux stub was never invoked — nudge path did not fire"
+            log_contents = tmux_log.read_text()
+            assert "send-keys" in log_contents, (
+                f"Expected a tmux send-keys call from nudge_inbox(), got:\n"
+                f"{log_contents!r}"
+            )
+        finally:
+            sentinel.unlink(missing_ok=True)
+
+    def test_send_failure_skips_nudge(self, tmp_path: Path) -> None:
+        """If message send fails, no nudge should be attempted.
+
+        We force ``send_message()`` to raise by pointing ``BID_EUCHRE_BUS_DIR``
+        at a path under a read-only parent directory — ``shared_bus_root()``
+        will fail to ``mkdir`` and propagate ``PermissionError``.  In that
+        case, nudging would surface a stale inbox state without the new
+        completion message, so the hook must skip it.
+        """
+        pr_num = "7002"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        stub_dir, tmux_log = _make_tmux_stub(tmp_path)
+        # Build a bus path that cannot be created (read-only parent).
+        ro_parent = tmp_path / "ro_parent"
+        ro_parent.mkdir()
+        ro_parent.chmod(0o555)
+        broken_bus = ro_parent / "bus"
+        try:
+            # Bypass _run_hook's default BUS dir — we need the broken path.
+            env = {
+                "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                "HOME": os.environ.get("HOME", "/tmp"),
+                "BID_EUCHRE_BUS_DIR": str(broken_bus),
+                "CLAUDE_AGENT_NAME": "steward-author-a",
+            }
+            hook_input = json.dumps(
+                {
+                    "tool_input": {
+                        "command": f"gh pr merge {pr_num} --squash",
+                    },
+                    "tool_response": {
+                        "stdout": "",
+                        "stderr": "",
+                        "exit_code": 0,
+                    },
+                }
+            )
+            result = subprocess.run(
+                ["bash", str(HOOK_PATH)],
+                input=hook_input,
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            assert result.returncode == 0
+            # Task transition does not depend on the bus, so sentinel can
+            # still be created.  The critical assertion is: no tmux calls.
+            log_text = tmux_log.read_text() if tmux_log.exists() else ""
+            assert log_text == "", (
+                "tmux should not be invoked when message send failed; "
+                f"got log:\n{log_text!r}"
+            )
+        finally:
+            sentinel.unlink(missing_ok=True)
+            # Restore writable perms so pytest can clean the tmp_path.
+            ro_parent.chmod(0o755)
+
+    def test_auto_merge_initial_path_does_not_nudge(self, tmp_path: Path) -> None:
+        """The initial --auto dispatch must not nudge (PR is not merged yet).
+
+        The background watcher reuses ``run_completion`` and will nudge when
+        the PR actually reaches MERGED state; that inner behavior is
+        covered by ``test_direct_merge_nudges_after_successful_send`` since
+        both paths share the same Python completion block.
+        """
+        pr_num = "7003"
+        sentinel = Path(f"/tmp/.claude-post-merge-notify-{pr_num}")
+        sentinel.unlink(missing_ok=True)
+        stub_dir, tmux_log = _make_tmux_stub(tmp_path)
+        try:
+            result = _run_hook(
+                command=f"gh pr merge {pr_num} --auto --squash",
+                stdout=f"✓ Auto-merge enabled for pull request #{pr_num}",
+                tmp_path=tmp_path,
+                env_overrides={
+                    "PATH": f"{stub_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                    "CLAUDE_AGENT_NAME": "steward-author-a",
+                },
+            )
+            assert result.returncode == 0
+            assert (
+                not sentinel.exists()
+            ), "Auto-merge initial dispatch should not create sentinel"
+            log_text = tmux_log.read_text() if tmux_log.exists() else ""
+            assert (
+                log_text == ""
+            ), f"Auto-merge initial dispatch should not nudge; got log:\n{log_text!r}"
         finally:
             sentinel.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- After `.claude/hooks/post-merge-notify.sh` successfully sends a `completion` message, best-effort invoke `nudge_inbox('orchestrator')` so the orchestrator reacts in seconds instead of waiting for the next `/fleet-check` cron tick.
- Cron path is retained as fallback; nudge failures are logged but do not block sentinel creation or the merge.
- **Preserves the delivery-policy boundary:** durable writes stay in `message_bus.send_message()`; tmux-layer wake-up remains in `worker_pool.nudge_inbox()`. `message_bus.py` is unchanged. This is the adjustment specified in the plan — not the naive `nudge_recipient` injection into `send_message()`.
- Nudge only fires when the send succeeded — nudging on failure would surface a stale inbox without the new message.

## Why

Messaging revamp plan (`plans/sessions/2026-04-20_messaging-revamp-execution-plan.md`) § PR-MSG-1. Cuts the most common idle gap on the fleet: the 3–10s stretch between a merge and the orchestrator noticing the completion message.

## Scope

- `.claude/hooks/post-merge-notify.sh` — add nudge call after successful completion send (both direct-merge and auto-merge watcher paths, since they share `run_completion`).
- `tests/unit/test_post_merge_notify_hook.py` — extend with a `TestCompletionNudge` class covering the three required scenarios.

No changes to `src/bid_euchre/ops/message_bus.py`, `worker_pool.py`, or any other code path.

## Repro / Validation

Primary repro (Tier 1):

```
uv run python -m pytest tests/unit/test_post_merge_notify_hook.py -v
```

Tier 2:

```
git fetch origin main && git rebase origin/main
make check-gated
```

### Validation Performed

- `uv run python -m pytest tests/unit/test_post_merge_notify_hook.py -v` → **20 passed in 2.37s** (all 17 pre-existing + 3 new nudge tests)
- `make check-gated` → **✓ All checks passed** (logs `/tmp/make-check-EGejwR`)
- `make lint` → clean

## Tests

The new `TestCompletionNudge` class asserts via a tmux stub script on PATH that logs every invocation to a temp file, so tests can check whether `send-keys` was called:

| Test | Scenario | Assertion |
|------|----------|-----------|
| `test_direct_merge_nudges_after_successful_send` | Direct merge, writable bus | Sentinel created AND tmux log contains `send-keys` |
| `test_send_failure_skips_nudge` | Bus root under read-only parent → `PermissionError` from `send_message()` | tmux log is empty |
| `test_auto_merge_initial_path_does_not_nudge` | `gh pr merge --auto`, initial dispatch only | No sentinel, tmux log empty (background watcher reuses `run_completion` and will nudge when the PR reaches MERGED — that nudge is exercised via the direct-merge test since both paths share the same Python completion block) |

## Test Criteria

- **Pass condition:** All three new nudge tests pass, no regression in the 17 pre-existing hook tests, `message_bus.py` signatures unchanged.
- **Verification command:** `uv run python -m pytest tests/unit/test_post_merge_notify_hook.py`
- **Expected result:** `20 passed`. Hook attempts a best-effort `/inbox-poll` nudge only when the durable send succeeded; failure and auto-merge paths do not nudge.

## Worktree proof

```
pwd:        /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
toplevel:   /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch:     ops/msg-revamp-pr1-nudge-after-completion
base:       origin/main
```

## Out of scope

Deliberately deferred to subsequent PRs in the messaging revamp chain:

- Prompt-boundary surfacing of blockers/escalations → **PR-MSG-3**
- Generic delivery-policy helper outside `send_message()` → **PR-MSG-2**
- Attention-broker daemon with safe-to-poke detection → **PR-MSG-4**
- Any widening of auto-ack behavior in `inbox-completion-inject.py`

## Plan

`plans/sessions/2026-04-20_messaging-revamp-execution-plan.md` § PR-MSG-1 (task packet `deedd5347195`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)