### PR TITLE
feat(ops): delivery-policy helper outside send_message() (PR-MSG-2)

### DIFF
--- a/src/bid_euchre/ops/attention.py
+++ b/src/bid_euchre/ops/attention.py
@@ -1,0 +1,186 @@
+"""Delivery-policy helper for high-value bus messages (PR-MSG-2).
+
+The ``message_bus`` layer is intentionally durable-only: it writes audit
+trails and per-lane inboxes and emits events, but it does not actively
+push to tmux panes or otherwise try to wake recipients.  That boundary
+exists to keep the bus free of tmux coupling and to avoid circular
+imports between ``message_bus`` and ``worker_pool``.
+
+Most messages should ride the durable path alone — the recipient's
+prompt-boundary surfacing (``.claude/hooks/inbox-completion-inject.py``)
+and periodic cron polling (``/fleet-check``) are sufficient for
+``assignment``, ``progress``, ``ack``, and low/normal ``supervisor_alert``.
+
+A small set of message types, however, are attention-worthy enough that
+the extra 3–10 seconds of nudge latency is worth the best-effort tmux
+poke.  This module provides:
+
+- :func:`should_nudge_for_message` — policy decision: does this
+  ``(message_type, priority)`` combination warrant a nudge?
+- :func:`send_with_attention` — convenience wrapper that writes the
+  durable message via ``message_bus.send_message`` and then, on success,
+  optionally calls ``worker_pool.nudge_inbox`` when the policy allows.
+
+The policy explicitly nudges on:
+
+- ``blocker``
+- ``escalation``
+- ``supervisor_alert`` with priority ``high`` or ``urgent``
+
+Everything else returns the durable message_id without poking the
+recipient pane.
+
+Architectural invariant:
+    ``message_bus.send_message`` must NOT grow a ``nudge_recipient``
+    parameter or any other tmux side effect.  All delivery-policy
+    decisions live here or in higher-level adapters.
+
+See ``plans/sessions/2026-04-20_messaging-revamp-execution-plan.md``
+§ PR-MSG-2 for the full design rationale.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bid_euchre.ops.message_bus import send_message
+from bid_euchre.ops.worker_pool import nudge_inbox
+
+if TYPE_CHECKING:
+    from bid_euchre.ops.message_bus import BusMessage
+
+logger = logging.getLogger("ops.attention")
+
+# Message types that always warrant a best-effort nudge regardless of priority.
+_ALWAYS_NUDGE_TYPES: frozenset[str] = frozenset({"blocker", "escalation"})
+
+# supervisor_alert priorities that warrant a nudge.  Low/normal/info alerts
+# ride the durable-only path and surface via prompt-boundary hooks or cron.
+_SUPERVISOR_NUDGE_PRIORITIES: frozenset[str] = frozenset({"high", "urgent"})
+
+
+def should_nudge_for_message(
+    message_type: str,
+    priority: str,
+) -> bool:
+    """Return ``True`` when this message warrants a best-effort pane nudge.
+
+    Policy (must match the PR-MSG-2 task packet):
+
+    - ``blocker`` — always nudge.  By definition the sender cannot proceed
+      without attention; waiting a full fleet-check cycle would stall the
+      fleet.
+    - ``escalation`` — always nudge.  Escalations are already second-order
+      signals (unacked-message amplification, approval stalls) and must
+      reach the recipient promptly.
+    - ``supervisor_alert`` — nudge only when priority is ``high`` or
+      ``urgent``.  Routine ``normal``/``low``/``info`` alerts are noise
+      when nudged.
+    - All other message types (``assignment``, ``progress``, ``ack``,
+      ``completion``, ``recovery``) — durable-only.  Completion has its
+      own fast path in ``post-merge-notify.sh`` (see PR-MSG-1).
+
+    Args:
+        message_type: The ``BusMessage.message_type`` value.
+        priority: The ``BusMessage.priority`` value.
+
+    Returns:
+        ``True`` if the policy mandates a pane nudge, else ``False``.
+    """
+    if message_type in _ALWAYS_NUDGE_TYPES:
+        return True
+    if message_type == "supervisor_alert" and priority in _SUPERVISOR_NUDGE_PRIORITIES:
+        return True
+    return False
+
+
+def send_with_attention(
+    msg: "BusMessage",
+    bus_root: Path | None = None,
+    *,
+    events_dir: Path | None = None,
+    deduplicate: bool = False,
+    tmux_session: str | None = None,
+    runtime_dir: Path | None = None,
+) -> str:
+    """Send a durable message, then optionally nudge the recipient.
+
+    Writes the message to the bus via :func:`message_bus.send_message` and,
+    if :func:`should_nudge_for_message` returns ``True`` for this message's
+    ``(message_type, priority)``, calls
+    :func:`worker_pool.nudge_inbox` as a best-effort tmux poke.
+
+    The nudge is strictly best-effort: any failure is logged and swallowed.
+    It never propagates back to the caller and never affects the returned
+    message_id.  If ``send_message`` fails, the nudge is never attempted —
+    there is no inbox entry to look at, so poking the pane would just be
+    noise.
+
+    Args:
+        msg: The :class:`BusMessage` to send.
+        bus_root: Override for the message bus root directory.
+        events_dir: Override for the events directory (for testing).
+        deduplicate: Forwarded to :func:`send_message`.
+        tmux_session: Override for the tmux session name used by the nudge.
+        runtime_dir: Override for the runtime directory used by the nudge.
+
+    Returns:
+        The ``message_id`` returned by :func:`send_message`.
+
+    Raises:
+        ValueError: Propagated from :func:`send_message` on duplicate IDs.
+        OSError: Propagated from :func:`send_message` on audit-trail IO errors.
+    """
+    # Durable write first.  Any exception here skips the nudge entirely.
+    message_id = send_message(
+        msg,
+        bus_root,
+        events_dir=events_dir,
+        deduplicate=deduplicate,
+    )
+
+    if not should_nudge_for_message(msg.message_type, msg.priority):
+        return message_id
+
+    # nudge_inbox is imported at module top level so test suites can patch
+    # the name on this module; the worker_pool -> message_bus dependency
+    # is lazy-only, so there is no import cycle.
+    try:
+        if tmux_session is not None and runtime_dir is not None:
+            action = nudge_inbox(
+                msg.to_lane,
+                tmux_session=tmux_session,
+                runtime_dir=runtime_dir,
+            )
+        elif tmux_session is not None:
+            action = nudge_inbox(msg.to_lane, tmux_session=tmux_session)
+        elif runtime_dir is not None:
+            action = nudge_inbox(msg.to_lane, runtime_dir=runtime_dir)
+        else:
+            action = nudge_inbox(msg.to_lane)
+
+        if not action.executed:
+            logger.debug(
+                "Best-effort nudge for %s (%s) did not execute: %s",
+                msg.to_lane,
+                msg.message_type,
+                action.reason,
+            )
+    except Exception:
+        # Best-effort only — the durable send already succeeded.
+        logger.warning(
+            "Best-effort nudge_inbox raised for %s (%s); durable send is intact",
+            msg.to_lane,
+            msg.message_type,
+            exc_info=True,
+        )
+
+    return message_id
+
+
+__all__ = [
+    "send_with_attention",
+    "should_nudge_for_message",
+]

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -1495,7 +1495,8 @@ def _notify_approval_stall(
         The message_id if sent, or None on failure.
     """
     try:
-        from bid_euchre.ops.message_bus import create_message, send_message
+        from bid_euchre.ops.attention import send_with_attention
+        from bid_euchre.ops.message_bus import create_message
 
         msg = create_message(
             from_lane="ops-monitor",
@@ -1509,7 +1510,8 @@ def _notify_approval_stall(
                 "action": "User must navigate to tmux pane and approve/deny",
             },
         )
-        return send_message(msg)
+        # escalation → always nudges recipient per PR-MSG-2 policy.
+        return send_with_attention(msg)
     except Exception as exc:
         logger.warning(
             "Failed to notify orchestrator about approval stall for %r: %s",
@@ -1853,7 +1855,8 @@ def _send_findings_to_orchestrator(
     if not findings:
         return None
 
-    from bid_euchre.ops.message_bus import create_message, send_message
+    from bid_euchre.ops.attention import send_with_attention
+    from bid_euchre.ops.message_bus import create_message
 
     has_high = any(f.severity == SEVERITY_HIGH for f in findings)
     high_count = sum(1 for f in findings if f.severity == SEVERITY_HIGH)
@@ -1890,7 +1893,11 @@ def _send_findings_to_orchestrator(
     )
 
     try:
-        return send_message(msg, bus_root)
+        # supervisor_alert: send_with_attention nudges only when priority is
+        # "high" (or "urgent") per PR-MSG-2 policy.  Normal-priority info
+        # rollups ride the durable-only path and surface via prompt-boundary
+        # hooks or cron.
+        return send_with_attention(msg, bus_root)
     except (ValueError, OSError) as exc:
         logger.warning("Failed to send monitor summary: %s", exc)
         return None

--- a/tests/unit/test_ops_attention.py
+++ b/tests/unit/test_ops_attention.py
@@ -1,0 +1,508 @@
+"""Tests for the PR-MSG-2 delivery-policy helper.
+
+Proves the nudge policy in :mod:`bid_euchre.ops.attention`:
+
+- Low/normal ``progress`` messages: **no nudge**
+- ``blocker``: **nudge**
+- ``escalation``: **nudge**
+- ``supervisor_alert`` at priority ``high``: **nudge**
+- ``supervisor_alert`` at priority ``urgent``: **nudge**
+- ``supervisor_alert`` at priority ``normal`` / ``low``: **no nudge**
+- ``send_message`` failure: **no nudge attempted**
+
+The architectural invariant is that ``send_with_attention`` wraps (not
+replaces) ``send_message``, so all durability guarantees still hold and
+no tmux coupling leaks into the bus layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bid_euchre.ops.attention import send_with_attention, should_nudge_for_message
+from bid_euchre.ops.message_bus import create_message, shared_bus_root
+from bid_euchre.ops.worker_pool import PoolAction
+
+_ATTENTION = "bid_euchre.ops.attention"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def bus_root(tmp_path: Path) -> Path:
+    """Isolated bus root for each test."""
+    return shared_bus_root(tmp_path / "message_bus")
+
+
+@pytest.fixture()
+def events_dir(tmp_path: Path) -> Path:
+    """Isolated events directory for each test."""
+    d = tmp_path / "events"
+    d.mkdir()
+    return d
+
+
+def _nudge_ok(lane_id: str) -> PoolAction:
+    return PoolAction(
+        action="inbox_nudge",
+        lane_id=lane_id,
+        reason=f"Sent /inbox-poll to {lane_id}",
+        executed=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# should_nudge_for_message — pure policy table
+# ---------------------------------------------------------------------------
+
+
+class TestShouldNudgeForMessage:
+    """Cover the policy decision function directly, no IO."""
+
+    @pytest.mark.parametrize("priority", ["low", "normal", "high", "urgent"])
+    def test_blocker_always_nudges(self, priority: str) -> None:
+        assert should_nudge_for_message("blocker", priority) is True
+
+    @pytest.mark.parametrize("priority", ["low", "normal", "high", "urgent"])
+    def test_escalation_always_nudges(self, priority: str) -> None:
+        assert should_nudge_for_message("escalation", priority) is True
+
+    def test_supervisor_alert_high_nudges(self) -> None:
+        assert should_nudge_for_message("supervisor_alert", "high") is True
+
+    def test_supervisor_alert_urgent_nudges(self) -> None:
+        assert should_nudge_for_message("supervisor_alert", "urgent") is True
+
+    @pytest.mark.parametrize("priority", ["low", "normal"])
+    def test_supervisor_alert_low_normal_does_not_nudge(self, priority: str) -> None:
+        assert should_nudge_for_message("supervisor_alert", priority) is False
+
+    @pytest.mark.parametrize("priority", ["low", "normal", "high", "urgent"])
+    def test_progress_never_nudges(self, priority: str) -> None:
+        assert should_nudge_for_message("progress", priority) is False
+
+    @pytest.mark.parametrize(
+        "msg_type",
+        ["assignment", "ack", "completion", "recovery"],
+    )
+    def test_other_types_never_nudge(self, msg_type: str) -> None:
+        # All priorities — these message types never trigger a nudge.
+        for priority in ("low", "normal", "high", "urgent"):
+            assert should_nudge_for_message(msg_type, priority) is False
+
+
+# ---------------------------------------------------------------------------
+# send_with_attention — end-to-end policy wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSendWithAttentionPolicy:
+    """Prove the required 7 policy cases from the PR-MSG-2 task packet."""
+
+    def test_low_priority_progress_does_not_nudge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 1: low/normal progress — durable write, NO nudge."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="progress",
+            summary="low-prio progress heartbeat",
+            priority="low",
+        )
+        with patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge:
+            mid = send_with_attention(msg, bus_root, events_dir=events_dir)
+        assert mid == msg.message_id
+        mock_nudge.assert_not_called()
+
+    def test_normal_priority_progress_does_not_nudge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 1b: normal progress (the common path) also does NOT nudge."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="progress",
+            summary="normal-prio progress heartbeat",
+            priority="normal",
+        )
+        with patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_not_called()
+
+    def test_blocker_nudges(self, bus_root: Path, events_dir: Path) -> None:
+        """Case 2: blocker — nudges recipient."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="blocker",
+            summary="Cannot proceed — waiting on decision",
+            priority="high",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ) as mock_nudge:
+            mid = send_with_attention(msg, bus_root, events_dir=events_dir)
+        assert mid == msg.message_id
+        mock_nudge.assert_called_once_with("orchestrator")
+
+    def test_escalation_nudges(self, bus_root: Path, events_dir: Path) -> None:
+        """Case 3: escalation — nudges recipient."""
+        msg = create_message(
+            from_lane="ops-monitor",
+            to_lane="orchestrator",
+            message_type="escalation",
+            summary="Approval stall on author-b",
+            priority="urgent",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ) as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_called_once_with("orchestrator")
+
+    def test_supervisor_alert_high_nudges(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 4: supervisor_alert high — nudges recipient."""
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="Monitor: 2 HIGH findings",
+            priority="high",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ) as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_called_once_with("orchestrator")
+
+    def test_supervisor_alert_urgent_nudges(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 5: supervisor_alert urgent — nudges recipient."""
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="Fleet-wide incident",
+            priority="urgent",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ) as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_called_once_with("orchestrator")
+
+    def test_supervisor_alert_normal_does_not_nudge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 6: supervisor_alert normal priority — does NOT nudge.
+
+        This is the most important negative case: routine info rollups ride
+        the durable-only path to avoid turning every monitor cycle into a
+        pane interruption.
+        """
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="Monitor: 0 HIGH, 0 warn, 3 info findings (all nominal)",
+            priority="normal",
+        )
+        with patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_not_called()
+
+    def test_supervisor_alert_low_does_not_nudge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Case 6b: supervisor_alert low priority — does NOT nudge."""
+        msg = create_message(
+            from_lane="ops",
+            to_lane="orchestrator",
+            message_type="supervisor_alert",
+            summary="Low-priority heartbeat",
+            priority="low",
+        )
+        with patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# send_with_attention — failure semantics
+# ---------------------------------------------------------------------------
+
+
+class TestSendWithAttentionFailureSemantics:
+    """Prove: no-nudge-on-send-failure, and best-effort nudge swallows errors."""
+
+    def test_send_failure_prevents_nudge(self, bus_root: Path) -> None:
+        """Case 7: send_message raises — nudge is never attempted."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="blocker",  # would normally nudge
+            summary="Blocker that never lands",
+            priority="urgent",
+        )
+        with (
+            patch(
+                f"{_ATTENTION}.send_message",
+                side_effect=OSError("audit-trail IO failure"),
+            ) as mock_send,
+            patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge,
+        ):
+            with pytest.raises(OSError, match="audit-trail IO failure"):
+                send_with_attention(msg, bus_root)
+        mock_send.assert_called_once()
+        mock_nudge.assert_not_called()
+
+    def test_value_error_from_send_prevents_nudge(self, bus_root: Path) -> None:
+        """Duplicate-ID ValueError from send_message — no nudge."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="escalation",
+            summary="Escalation that would nudge",
+            priority="urgent",
+        )
+        with (
+            patch(
+                f"{_ATTENTION}.send_message",
+                side_effect=ValueError("Duplicate message_id"),
+            ),
+            patch(f"{_ATTENTION}.nudge_inbox") as mock_nudge,
+        ):
+            with pytest.raises(ValueError, match="Duplicate message_id"):
+                send_with_attention(msg, bus_root)
+        mock_nudge.assert_not_called()
+
+    def test_nudge_failure_is_swallowed(self, bus_root: Path, events_dir: Path) -> None:
+        """nudge_inbox raising never masks the durable send_message result."""
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="blocker",
+            summary="Blocker with flaky tmux",
+            priority="high",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            side_effect=RuntimeError("tmux exploded"),
+        ) as mock_nudge:
+            # Must NOT raise — best-effort policy.
+            mid = send_with_attention(msg, bus_root, events_dir=events_dir)
+        assert mid == msg.message_id
+        mock_nudge.assert_called_once_with("orchestrator")
+
+    def test_nudge_not_executed_is_logged_but_returned(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """If nudge_inbox returns executed=False, send_with_attention still
+        returns the durable message_id without raising.
+        """
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="escalation",
+            summary="Escalation when pane is missing",
+            priority="urgent",
+        )
+        failed_nudge = PoolAction(
+            action="inbox_nudge",
+            lane_id="orchestrator",
+            reason="pane not found",
+            executed=False,
+            error="nudge_failed",
+        )
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=failed_nudge,
+        ) as mock_nudge:
+            mid = send_with_attention(msg, bus_root, events_dir=events_dir)
+        assert mid == msg.message_id
+        mock_nudge.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# send_with_attention — parameter forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestSendWithAttentionForwarding:
+    """Prove kwargs are wired through to send_message and nudge_inbox."""
+
+    def test_forwards_deduplicate_flag(self, bus_root: Path, events_dir: Path) -> None:
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="progress",
+            summary="Dedupe test",
+            priority="normal",
+        )
+        with patch(
+            f"{_ATTENTION}.send_message",
+            return_value=msg.message_id,
+        ) as mock_send:
+            send_with_attention(
+                msg,
+                bus_root,
+                events_dir=events_dir,
+                deduplicate=True,
+            )
+        mock_send.assert_called_once_with(
+            msg,
+            bus_root,
+            events_dir=events_dir,
+            deduplicate=True,
+        )
+
+    def test_forwards_tmux_overrides_to_nudge(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="blocker",
+            summary="Blocker with custom tmux",
+            priority="urgent",
+        )
+        runtime = Path("/tmp/custom-runtime")
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ) as mock_nudge:
+            send_with_attention(
+                msg,
+                bus_root,
+                events_dir=events_dir,
+                tmux_session="alt-session",
+                runtime_dir=runtime,
+            )
+        mock_nudge.assert_called_once_with(
+            "orchestrator",
+            tmux_session="alt-session",
+            runtime_dir=runtime,
+        )
+
+    def test_durable_write_actually_happens(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Round-trip sanity: the message appears in the recipient inbox even
+        when the nudge is short-circuited (durable path is never skipped)."""
+        from bid_euchre.ops.message_bus import read_inbox
+
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="blocker",
+            summary="End-to-end durability check",
+            priority="high",
+        )
+
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=_nudge_ok("orchestrator"),
+        ):
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+
+        inbox = read_inbox("orchestrator", bus_root)
+        assert len(inbox) == 1
+        assert inbox[0]["message_id"] == msg.message_id
+        assert inbox[0]["message_type"] == "blocker"
+
+
+# ---------------------------------------------------------------------------
+# Module invariant: the bus layer must not grow tmux coupling
+# ---------------------------------------------------------------------------
+
+
+class TestBusBoundaryInvariant:
+    """Regression-locks on the architectural constraint from PR-MSG-2."""
+
+    def test_message_bus_send_message_has_no_nudge_parameter(self) -> None:
+        """send_message must NOT accept a nudge_recipient kwarg.
+
+        This is the core invariant from PR-MSG-2: delivery policy lives in
+        attention.py, not in the durable bus layer.
+        """
+        import inspect
+
+        from bid_euchre.ops.message_bus import send_message
+
+        sig = inspect.signature(send_message)
+        params = set(sig.parameters.keys())
+        # Explicitly forbid any "nudge"-style kwarg creeping in.
+        for forbidden in (
+            "nudge_recipient",
+            "nudge",
+            "nudge_on_send",
+            "tmux_session",
+        ):
+            assert (
+                forbidden not in params
+            ), f"send_message signature must stay tmux-free; found {forbidden!r}"
+
+    def test_attention_module_exports_both_helpers(self) -> None:
+        """Public API check — both helpers are reachable as documented."""
+        import bid_euchre.ops.attention as attention_mod
+
+        assert hasattr(attention_mod, "send_with_attention")
+        assert hasattr(attention_mod, "should_nudge_for_message")
+
+    def test_attention_module_imports_without_cycle(self) -> None:
+        """Import smoke test (also enforced by the validation shell cmd)."""
+        # A fresh import_module call would just return the cached module;
+        # the meaningful check is that our imports completed at module load.
+        import importlib
+
+        mod = importlib.import_module("bid_euchre.ops.attention")
+        assert mod.send_with_attention is send_with_attention
+        assert mod.should_nudge_for_message is should_nudge_for_message
+
+
+# ---------------------------------------------------------------------------
+# Regression: nudge target is always msg.to_lane
+# ---------------------------------------------------------------------------
+
+
+class TestNudgeTargetsRecipient:
+    def test_nudge_targets_to_lane_not_from_lane(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """The nudge must wake the recipient, not the sender.
+
+        A bug here would ping the original sender's pane and never notify
+        the lane that actually needs to react.
+        """
+        msg = create_message(
+            from_lane="author-c",
+            to_lane="review",
+            message_type="blocker",
+            summary="Review needed on stuck PR",
+            priority="urgent",
+        )
+        # Note: MagicMock returns a MagicMock (truthy) for attribute access.
+        # We only need to ensure the target is correct.
+        fake_action = MagicMock(executed=True, reason="ok")
+        with patch(
+            f"{_ATTENTION}.nudge_inbox",
+            return_value=fake_action,
+        ) as mock_nudge:
+            send_with_attention(msg, bus_root, events_dir=events_dir)
+        mock_nudge.assert_called_once()
+        called_lane = mock_nudge.call_args.args[0]
+        assert called_lane == "review"


### PR DESCRIPTION
## Summary

- Add `src/bid_euchre/ops/attention.py` with `send_with_attention()` and `should_nudge_for_message()` — the durable-write-first delivery-policy helper called for in the PR-MSG-2 task packet.
- Migrate the two high-value `send_message()` call sites in `src/bid_euchre/ops/monitor.py` to the new helper: `_notify_approval_stall` (escalation) and `_send_findings_to_orchestrator` (supervisor_alert).
- Leave the post-merge completion fast path from PR-MSG-1 (#2670) untouched, and leave low/normal progress messages on raw `send_message()`.
- Add `tests/unit/test_ops_attention.py` covering the full policy table plus the no-nudge-on-send-failure case.

## Why

PR-MSG-1 (#2670, merged) solved the post-merge completion gap. PR-MSG-3 (#2669, merged) widened prompt-boundary surfacing. PR-MSG-2 fills the remaining attention-latency gap for high-value messages without violating the durable-bus boundary.

The **critical architectural constraint** from the task packet is that `message_bus.send_message()` must stay free of tmux / nudge side effects. All delivery policy lives in `attention.py`:

```
attention.send_with_attention(msg)
    └─ message_bus.send_message(msg)   # durable-only, unchanged signature
    └─ worker_pool.nudge_inbox(...)    # best-effort pane nudge, gated by policy
```

## Policy (exactly what the task packet specified)

| message_type      | priority       | nudges? |
|-------------------|----------------|---------|
| `blocker`         | any            | yes     |
| `escalation`      | any            | yes     |
| `supervisor_alert`| `high`/`urgent`| yes     |
| `supervisor_alert`| `normal`/`low` | **no**  |
| `progress`        | any            | no      |
| `assignment`/`ack`/`completion`/`recovery` | any | no |

The nudge is strictly best-effort: if `send_message` raises, the nudge is never attempted. If `nudge_inbox` raises, the durable send result is still returned and the exception is logged and swallowed.

## Files

- `src/bid_euchre/ops/attention.py` **(NEW)** — delivery-policy helper module
- `src/bid_euchre/ops/monitor.py` — switch `_notify_approval_stall` and `_send_findings_to_orchestrator` to `send_with_attention`; leave everything else on raw `send_message`
- `tests/unit/test_ops_attention.py` **(NEW)** — 39 tests across 6 test classes

No change to `src/bid_euchre/ops/message_bus.py` — signature invariants locked in by `TestBusBoundaryInvariant.test_message_bus_send_message_has_no_nudge_parameter`.

## Repro / Validation

```bash
# Task packet validation block
uv run python -m pytest tests/unit/test_ops_attention.py tests/unit/test_ops_message_bus.py
uv run python -c 'from bid_euchre.ops import attention'  # cycle check
make lint

# Full pre-PR validation
git fetch origin main && git rebase origin/main
make check-gated
```

Results:
- `uv run python -m pytest tests/unit/test_ops_attention.py tests/unit/test_ops_message_bus.py` → **197 passed** (39 new + 158 existing)
- `uv run python -c 'from bid_euchre.ops import attention'` → no cycle
- `uv run python -m pytest tests/unit/test_ops_monitor.py -q` → **175 passed**
- `make lint` → clean
- `make check-gated` → ✓ All checks passed

## Tests

### Policy table (`TestShouldNudgeForMessage` — 20 parametrised cases)
Pure-function coverage of `should_nudge_for_message()` across every message type × priority combination.

### End-to-end policy wiring (`TestSendWithAttentionPolicy` — 8 cases)
The 7 cases explicitly required by the task packet, plus the explicit low-priority supervisor_alert negative case.

### Failure semantics (`TestSendWithAttentionFailureSemantics` — 4 cases)
- `send_message` → `OSError`: nudge never attempted, exception propagates.
- `send_message` → `ValueError` (duplicate ID): nudge never attempted.
- `nudge_inbox` → `RuntimeError`: swallowed, durable message_id returned.
- `nudge_inbox` returns `executed=False`: durable write still returned.

### Parameter forwarding (`TestSendWithAttentionForwarding` — 3 cases)
`deduplicate`, `tmux_session`, `runtime_dir` kwargs wire through correctly; durable round-trip via `read_inbox` confirms the bus write actually happens.

### Architectural invariants (`TestBusBoundaryInvariant` — 3 cases)
Regression lock: `message_bus.send_message` signature must never grow `nudge_recipient` / `tmux_session` / similar kwargs.

### Target correctness (`TestNudgeTargetsRecipient` — 1 case)
Nudge targets `msg.to_lane`, not `msg.from_lane`.

## Definition of Done (task packet)

- [x] attention.py exists with both helpers and clear docstrings
- [x] monitor.py migrates only the right call sites (blocker/escalation/high/urgent)
- [x] message_bus.py public signatures unchanged (asserted in tests)
- [x] Tests prove the nudge policy (7 cases above) AND the send-failure no-nudge case
- [x] No import cycle on the attention module
- [x] PR opened with exact repro command + test evidence

## Worktree proof

```
pwd                          : /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch                       : ops/msg-revamp-pr2-attention-helper
```

## Plan reference

`plans/sessions/2026-04-20_messaging-revamp-execution-plan.md` § PR-MSG-2

Follows merged PRs #2669 (PR-MSG-3) and #2670 (PR-MSG-1). PR-MSG-4 (attention broker daemon) is intentionally out of scope and will only be dispatched if residual latency remains after this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)