### PR TITLE
feat(ops): attention-broker daemon tails events.jsonl and nudges safely (PR-MSG-4)

### DIFF
--- a/.claude/hooks/attention-broker-autostart.sh
+++ b/.claude/hooks/attention-broker-autostart.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SessionStart hook: launch the attention-broker daemon (PR-MSG-4).
+#
+# The broker tails .claude/runtime/events/events.jsonl and nudges
+# message recipients only when their pane looks safe to poke.  It is
+# pidfile-guarded, so repeated session starts across lanes spawn at
+# most one live broker per repo.
+#
+# Fires on all session starts (init, clear, compact).  Must NEVER exit
+# non-zero — a failing SessionStart hook leaves the session at a blank
+# prompt with 0 tokens and no context.
+#
+# Behavior:
+#   - If another live broker is already running, exit 0 silently.
+#   - If no broker is alive, spawn one in the background via nohup.
+#   - Never block the session start on daemon output; all logs go to
+#     .claude/runtime/attention_broker/daemon.log.
+#
+# Refs PR-MSG-4 plan: plans/sessions/2026-04-20_messaging-revamp-execution-plan.md
+
+trap 'exit 0' ERR
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+if [[ -z "$PROJECT_DIR" || ! -d "$PROJECT_DIR" ]]; then
+    exit 0
+fi
+
+RUNTIME_DIR="$PROJECT_DIR/.claude/runtime"
+BROKER_DIR="$RUNTIME_DIR/attention_broker"
+PIDFILE="$BROKER_DIR/pid"
+LOG_FILE="$BROKER_DIR/daemon.log"
+
+# --------------------------------------------------------------------------
+# Opt-out guard: presence of the inhibit marker suppresses autostart.
+# --------------------------------------------------------------------------
+INHIBIT_FILE="$BROKER_DIR/disabled"
+if [[ -f "$INHIBIT_FILE" ]]; then
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Single-instance check.  The broker itself enforces this via pidfile,
+# but we short-circuit here to avoid a brief window of overlapping
+# processes and to keep session starts fast.
+# --------------------------------------------------------------------------
+if [[ -f "$PIDFILE" ]]; then
+    EXISTING_PID="$(cat "$PIDFILE" 2>/dev/null | tr -d '[:space:]')"
+    if [[ -n "$EXISTING_PID" ]] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+        # Live broker already running; nothing to do.
+        exit 0
+    fi
+fi
+
+# --------------------------------------------------------------------------
+# Locate `uv` and launch the broker in the background.
+# --------------------------------------------------------------------------
+UV_BIN="$(command -v uv 2>/dev/null || true)"
+if [[ -z "$UV_BIN" ]]; then
+    # No uv on PATH — best-effort only; leave a hint and exit cleanly.
+    mkdir -p "$BROKER_DIR" 2>/dev/null || true
+    echo "attention-broker autostart skipped: uv not on PATH ($(date -u))" \
+        >> "$LOG_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+mkdir -p "$BROKER_DIR" 2>/dev/null || true
+
+# Launch detached.  The broker writes its own pidfile on startup; if
+# another instance wins the race (e.g. two sessions booted at once),
+# the loser will see acquire_pidfile() return False and exit 0.
+(
+    cd "$PROJECT_DIR" || exit 0
+    nohup "$UV_BIN" run python scripts/internal/ops.py attention run \
+        --interval 3 \
+        >> "$LOG_FILE" 2>&1 &
+) &
+
+exit 0

--- a/.claude/hooks/post-tool-daemon-notify.sh
+++ b/.claude/hooks/post-tool-daemon-notify.sh
@@ -56,6 +56,17 @@ for sentinel in "$RUNTIME_DIR"/ci_polls/pr_*/FAILED "$RUNTIME_DIR"/review_loops/
     mv "$sentinel" "${daemon_dir}/NOTIFIED" 2>/dev/null || true
 done
 
+# Attention-broker sentinel (PR-MSG-4): one top-level FAILED file, not
+# a per-PR directory.  Surface it once per failure then rename.
+ATTENTION_SENTINEL="$RUNTIME_DIR/attention_broker/FAILED"
+if [ -f "$ATTENTION_SENTINEL" ]; then
+    summary=$(head -1 "$ATTENTION_SENTINEL" 2>/dev/null | cut -c1-200 || echo "unknown failure")
+    log_file="$RUNTIME_DIR/attention_broker/daemon.log"
+    MESSAGES="${MESSAGES}Attention broker FAILED: ${summary}. Log: ${log_file}
+"
+    mv "$ATTENTION_SENTINEL" "$RUNTIME_DIR/attention_broker/NOTIFIED" 2>/dev/null || true
+fi
+
 # If we found any failures, emit them as additionalContext
 if [ -n "$MESSAGES" ]; then
     FULL_MSG="WARNING — Background daemon failure(s) detected:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/attention-broker-autostart.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -15,6 +15,9 @@ Usage:
     uv run python scripts/internal/ops.py ci [--json]
     uv run python scripts/internal/ops.py ci --pr N [--json]
     uv run python scripts/internal/ops.py daemon [--interval N] [--max-ticks N] [--json]
+    uv run python scripts/internal/ops.py attention once [--json]
+    uv run python scripts/internal/ops.py attention run [--interval N] [--max-cycles N]
+    uv run python scripts/internal/ops.py attention status [--json]
     uv run python scripts/internal/ops.py retry --task TASK_ID [--json]
     uv run python scripts/internal/ops.py index [--rebuild] [--json]
     uv run python scripts/internal/ops.py query --text TEXT [--type TYPE] [--limit N] [--json]
@@ -736,6 +739,94 @@ def cmd_ci(args: argparse.Namespace) -> int:
         print(format_ci_text(report))
 
     return 1 if report.overall == "failure" else 0
+
+
+def cmd_attention(args: argparse.Namespace) -> int:
+    """Run the attention-broker daemon (PR-MSG-4).
+
+    Subcommands:
+        once   — run exactly one broker cycle and exit
+        run    — long-running daemon (pidfile-guarded, single-instance)
+        status — print broker PID / last cycle / pending ticket count
+    """
+    from bid_euchre.ops.attention import (
+        MAX_ATTEMPTS,
+        get_status,
+        run_daemon,
+        run_once,
+    )
+
+    action = getattr(args, "attention_action", None)
+    if action is None:
+        print(
+            "Usage: ops.py attention {once|run|status} [options]",
+            file=sys.stderr,
+        )
+        return 1
+
+    runtime_dir: Path = args.runtime_dir
+
+    if action == "once":
+        summary = run_once(runtime_dir=runtime_dir)
+        if args.json:
+            print(json.dumps(summary.to_json(), indent=2, sort_keys=True))
+        else:
+            print("attention broker cycle:")
+            print(f"  timestamp:        {summary.timestamp}")
+            print(f"  new_events_seen:  {summary.new_events_seen}")
+            print(f"  tickets_created:  {summary.tickets_created}")
+            print(f"  nudged:           {summary.nudged}")
+            print(f"  deferred:         {summary.deferred}")
+            print(f"  abandoned:        {summary.abandoned}")
+            print(f"  pending_after:    {summary.pending_after}")
+            if summary.errors:
+                print(f"  errors:           {summary.errors}")
+        return 0
+
+    if action == "run":
+        interval = float(getattr(args, "interval", 3.0))
+        max_cycles = getattr(args, "max_cycles", None)
+        rc = run_daemon(
+            runtime_dir=runtime_dir,
+            interval_seconds=interval,
+            max_cycles=max_cycles,
+        )
+        return rc
+
+    if action == "status":
+        status = get_status(runtime_dir=runtime_dir)
+        if args.json:
+            payload = status.to_json()
+            payload["max_attempts_per_ticket"] = MAX_ATTEMPTS
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            alive_label = "alive" if status.alive else "not running"
+            print(f"attention-broker: {alive_label}")
+            print(f"  pid:                 {status.pid if status.pid else 'n/a'}")
+            print(f"  pending tickets:     {status.pending_count}")
+            print(f"  nudged (lifetime):   {status.nudged_count}")
+            print(f"  abandoned:           {status.abandoned_count}")
+            print(f"  cursor byte offset:  {status.cursor_offset}")
+            print(f"  events file:         {status.events_file}")
+            print(f"  runtime dir:         {status.runtime_dir}")
+            print(f"  max attempts/ticket: {MAX_ATTEMPTS}")
+            if status.last_cycle:
+                lc = status.last_cycle
+                print(f"  last cycle:          {lc.get('timestamp', '?')}")
+                print(
+                    "                       "
+                    f"events={lc.get('new_events_seen', 0)} "
+                    f"nudged={lc.get('nudged', 0)} "
+                    f"deferred={lc.get('deferred', 0)} "
+                    f"abandoned={lc.get('abandoned', 0)}"
+                )
+        return 0
+
+    print(
+        f"Unknown attention action: {action!r}. Use one of: once, run, status.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def cmd_daemon(args: argparse.Namespace) -> int:
@@ -3566,6 +3657,32 @@ def build_parser() -> argparse.ArgumentParser:
         "--pr", type=int, default=None, help="PR number to check (required)"
     )
 
+    # attention (PR-MSG-4 broker)
+    attention_parser = subparsers.add_parser(
+        "attention",
+        help="Attention-broker daemon — tail message_sent events and nudge safely",
+    )
+    attention_sub = attention_parser.add_subparsers(dest="attention_action")
+    attention_sub.add_parser("once", help="Run one broker cycle then exit")
+    run_parser = attention_sub.add_parser(
+        "run", help="Long-running daemon (pidfile-guarded, single instance)"
+    )
+    run_parser.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        help="Seconds between cycles (default: 3.0)",
+    )
+    run_parser.add_argument(
+        "--max-cycles",
+        type=int,
+        default=None,
+        help="Stop after N cycles (testing/bounded runs; default: unbounded)",
+    )
+    attention_sub.add_parser(
+        "status", help="Show broker PID, last cycle, and pending ticket count"
+    )
+
     # daemon
     daemon_parser = subparsers.add_parser(
         "daemon", help="Run bounded repeating tick loop"
@@ -4444,6 +4561,7 @@ def main(argv: list[str] | None = None) -> int:
         "reviews": cmd_reviews,
         "comments": cmd_comments,
         "ci": cmd_ci,
+        "attention": cmd_attention,
         "daemon": cmd_daemon,
         "retry": cmd_retry,
         "index": cmd_index,

--- a/src/bid_euchre/ops/attention.py
+++ b/src/bid_euchre/ops/attention.py
@@ -201,26 +201,8 @@ def send_with_attention(
 
 
 # ---------------------------------------------------------------------------
-# PR-MSG-4 — attention broker daemon
+# PR-MSG-4 — attention broker daemon (see module docstring for design).
 # ---------------------------------------------------------------------------
-#
-# The broker watches events.jsonl for message_sent events, filters to the
-# types that should_nudge_for_message() flags, and poke the recipient lane
-# only when the pane looks safe.  When a pane is busy, the ticket is
-# deferred and retried on a bounded backoff.
-#
-# State layout (rooted at runtime_dir / "attention_broker"):
-#
-#     pid                    — pidfile (sentinel + liveness).  One daemon per repo.
-#     cursor.json            — {"byte_offset": N} tail position into events.jsonl
-#     deferred_tickets.jsonl — append-only ticket state transitions.  Last
-#                              entry per ticket_id wins on replay.
-#     FAILED                 — optional failure sentinel for post-tool-daemon-notify.
-#     last_cycle.json        — {"timestamp": iso, "cycle": N, "nudged": N,
-#                              "deferred": N, "abandoned": N} — status surface.
-#
-# Retry schedule: 10s, 30s, 90s → then abandon.  These are bounded so a
-# persistently-busy lane cannot pin a ticket forever.
 
 #: Default subdirectory under ``runtime_dir`` for broker state.
 _ATTENTION_DIRNAME: str = "attention_broker"

--- a/src/bid_euchre/ops/attention.py
+++ b/src/bid_euchre/ops/attention.py
@@ -1,4 +1,4 @@
-"""Delivery-policy helper for high-value bus messages (PR-MSG-2).
+"""Delivery-policy helper and attention-broker daemon (PR-MSG-2 / PR-MSG-4).
 
 The ``message_bus`` layer is intentionally durable-only: it writes audit
 trails and per-lane inboxes and emits events, but it does not actively
@@ -6,44 +6,64 @@ push to tmux panes or otherwise try to wake recipients.  That boundary
 exists to keep the bus free of tmux coupling and to avoid circular
 imports between ``message_bus`` and ``worker_pool``.
 
-Most messages should ride the durable path alone — the recipient's
-prompt-boundary surfacing (``.claude/hooks/inbox-completion-inject.py``)
-and periodic cron polling (``/fleet-check``) are sufficient for
-``assignment``, ``progress``, ``ack``, and low/normal ``supervisor_alert``.
+This module provides two layered attention primitives:
 
-A small set of message types, however, are attention-worthy enough that
-the extra 3–10 seconds of nudge latency is worth the best-effort tmux
-poke.  This module provides:
+**PR-MSG-2 — immediate-send policy helpers**
 
-- :func:`should_nudge_for_message` — policy decision: does this
+- :func:`should_nudge_for_message` — pure policy decision: does this
   ``(message_type, priority)`` combination warrant a nudge?
 - :func:`send_with_attention` — convenience wrapper that writes the
   durable message via ``message_bus.send_message`` and then, on success,
   optionally calls ``worker_pool.nudge_inbox`` when the policy allows.
 
-The policy explicitly nudges on:
+**PR-MSG-4 — attention-broker daemon**
 
-- ``blocker``
-- ``escalation``
-- ``supervisor_alert`` with priority ``high`` or ``urgent``
+A long-running helper that watches ``.claude/runtime/events/events.jsonl``
+and nudges recipients only when they appear safe to poke:
 
-Everything else returns the durable message_id without poking the
-recipient pane.
+- :func:`run_once` — tail new events, evaluate pending tickets, and write
+  durable state.  Intended for both one-shot CLI use and as the inner
+  loop of :func:`run_daemon`.
+- :func:`run_daemon` — pidfile-guarded long-running loop over
+  :func:`run_once`.
+- :func:`get_status` — operator/status summary (PID, last cycle,
+  pending ticket count).
+- :class:`AttentionState` — filesystem layout (pidfile, cursor,
+  deferred tickets, failure sentinel) rooted at
+  ``.claude/runtime/attention_broker/``.
 
-Architectural invariant:
-    ``message_bus.send_message`` must NOT grow a ``nudge_recipient``
-    parameter or any other tmux side effect.  All delivery-policy
-    decisions live here or in higher-level adapters.
+The daemon closes a gap that ``send_with_attention`` alone cannot: blind
+``tmux send-keys`` nudges can collide with active work.  The broker
+inspects the recipient pane before poking and defers to a bounded retry
+schedule when the pane looks busy (spinner, validation processes,
+approval prompts).
+
+Architectural invariants:
+    - ``message_bus.send_message`` must NOT grow a ``nudge_recipient``
+      parameter or any other tmux side effect.  All delivery-policy
+      decisions live here or in higher-level adapters.
+    - Exactly one broker process per repo — enforced by pidfile at
+      ``.claude/runtime/attention_broker/pid``.
+    - The events cursor advances only after each event's nudge-or-defer
+      decision is written to the deferred-ticket log; on crash-restart
+      the broker never double-nudges.
 
 See ``plans/sessions/2026-04-20_messaging-revamp-execution-plan.md``
-§ PR-MSG-2 for the full design rationale.
+§ PR-MSG-2 and § PR-MSG-4 for the full design rationale.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import signal
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
+from uuid import uuid4
 
 from bid_euchre.ops.message_bus import send_message
 from bid_euchre.ops.worker_pool import nudge_inbox
@@ -180,7 +200,892 @@ def send_with_attention(
     return message_id
 
 
+# ---------------------------------------------------------------------------
+# PR-MSG-4 — attention broker daemon
+# ---------------------------------------------------------------------------
+#
+# The broker watches events.jsonl for message_sent events, filters to the
+# types that should_nudge_for_message() flags, and poke the recipient lane
+# only when the pane looks safe.  When a pane is busy, the ticket is
+# deferred and retried on a bounded backoff.
+#
+# State layout (rooted at runtime_dir / "attention_broker"):
+#
+#     pid                    — pidfile (sentinel + liveness).  One daemon per repo.
+#     cursor.json            — {"byte_offset": N} tail position into events.jsonl
+#     deferred_tickets.jsonl — append-only ticket state transitions.  Last
+#                              entry per ticket_id wins on replay.
+#     FAILED                 — optional failure sentinel for post-tool-daemon-notify.
+#     last_cycle.json        — {"timestamp": iso, "cycle": N, "nudged": N,
+#                              "deferred": N, "abandoned": N} — status surface.
+#
+# Retry schedule: 10s, 30s, 90s → then abandon.  These are bounded so a
+# persistently-busy lane cannot pin a ticket forever.
+
+#: Default subdirectory under ``runtime_dir`` for broker state.
+_ATTENTION_DIRNAME: str = "attention_broker"
+
+#: Retry backoff schedule (seconds from created_at).  Indexed by attempt number.
+#: Attempt 0 is the initial evaluation; attempts 1..len-1 are retries.
+_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (10.0, 30.0, 90.0)
+
+#: Max attempts (initial + retries) before a ticket is abandoned.
+#: Exposed as a module-level constant so tests and ``status`` can assert
+#: the bounded budget.  1 initial evaluation + len(backoff) retries.
+MAX_ATTEMPTS: int = len(_RETRY_BACKOFF_SECONDS) + 1
+
+#: Default sleep between daemon cycles when running in ``run`` mode.
+_DEFAULT_CYCLE_INTERVAL_SECONDS: float = 3.0
+
+#: Events that carry the (message_type, priority, to_lane) tuple we need.
+_BROKER_EVENT_TYPE: str = "message_sent"
+
+
+@dataclass
+class AttentionState:
+    """Filesystem layout for the attention-broker daemon.
+
+    All paths are rooted at ``<runtime_dir>/attention_broker/``.  The
+    directory is created on first write; readers must tolerate missing
+    files and return sensible defaults.
+
+    Attributes:
+        root: The broker state directory.
+        pidfile: Single-instance sentinel containing the running PID.
+        cursor_file: JSON file storing the events.jsonl tail position.
+        tickets_file: Append-only JSONL log of deferred-ticket transitions.
+        failure_sentinel: Optional FAILED sentinel for post-tool-daemon-notify.
+        status_file: Per-cycle summary for ``attention status``.
+        events_file: Absolute path to the events.jsonl being tailed.
+    """
+
+    root: Path
+    pidfile: Path
+    cursor_file: Path
+    tickets_file: Path
+    failure_sentinel: Path
+    status_file: Path
+    events_file: Path
+
+    @classmethod
+    def from_runtime_dir(cls, runtime_dir: Path) -> "AttentionState":
+        """Build the standard layout rooted at ``runtime_dir``."""
+        root = runtime_dir / _ATTENTION_DIRNAME
+        return cls(
+            root=root,
+            pidfile=root / "pid",
+            cursor_file=root / "cursor.json",
+            tickets_file=root / "deferred_tickets.jsonl",
+            failure_sentinel=root / "FAILED",
+            status_file=root / "last_cycle.json",
+            events_file=runtime_dir / "events" / "events.jsonl",
+        )
+
+    def ensure_dir(self) -> None:
+        """Create the broker state directory if it does not exist."""
+        self.root.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class DeferredTicket:
+    """In-memory representation of one pending attention ticket.
+
+    Each ticket corresponds to one ``message_sent`` event whose delivery
+    policy said "nudge the recipient".  The ticket advances through:
+
+        pending  — still waiting for recipient to look safe to poke
+        nudged   — terminal success; broker has sent the inbox poke
+        abandoned — terminal failure; broker gave up after max attempts
+
+    Persistence: each state transition is appended as one JSON object to
+    ``deferred_tickets.jsonl``.  On daemon startup, the file is replayed
+    and the last entry per ticket_id wins.
+    """
+
+    ticket_id: str
+    message_id: str
+    to_lane: str
+    message_type: str
+    priority: str
+    created_at: str
+    next_retry_at: str
+    attempts: int
+    last_reason: str
+    status: str  # "pending", "nudged", "abandoned"
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "DeferredTicket":
+        return cls(
+            ticket_id=data["ticket_id"],
+            message_id=data["message_id"],
+            to_lane=data["to_lane"],
+            message_type=data["message_type"],
+            priority=data["priority"],
+            created_at=data["created_at"],
+            next_retry_at=data["next_retry_at"],
+            attempts=int(data["attempts"]),
+            last_reason=str(data.get("last_reason", "")),
+            status=str(data.get("status", "pending")),
+        )
+
+
+@dataclass
+class CycleSummary:
+    """Result of one :func:`run_once` pass, for status/tests."""
+
+    timestamp: str
+    new_events_seen: int = 0
+    tickets_created: int = 0
+    nudged: int = 0
+    deferred: int = 0
+    abandoned: int = 0
+    pending_after: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Pidfile / single-instance guard
+# ---------------------------------------------------------------------------
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return True if ``pid`` is a live process (kill -0 semantics)."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but belongs to another user — still "alive".
+        return True
+    return True
+
+
+def read_pidfile(state: AttentionState) -> int | None:
+    """Return the running broker PID, or None if no live daemon exists.
+
+    The check is liveness-aware: a stale pidfile from a crashed daemon
+    reports as None so a new daemon can take over.
+    """
+    try:
+        text = state.pidfile.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        pid = int(text)
+    except ValueError:
+        return None
+    if not _pid_is_alive(pid):
+        return None
+    return pid
+
+
+def acquire_pidfile(state: AttentionState) -> bool:
+    """Write our PID to the pidfile if no live daemon exists.
+
+    Returns:
+        True if we now own the pidfile (single-instance guarantee),
+        False if another live daemon already owns it.
+    """
+    state.ensure_dir()
+    existing = read_pidfile(state)
+    if existing is not None and existing != os.getpid():
+        return False
+    # Overwrite any stale pidfile and claim ownership.
+    state.pidfile.write_text(f"{os.getpid()}\n")
+    return True
+
+
+def release_pidfile(state: AttentionState) -> None:
+    """Remove our pidfile if we still own it.  Safe to call multiple times."""
+    try:
+        text = state.pidfile.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return
+    try:
+        pid = int(text)
+    except ValueError:
+        return
+    if pid != os.getpid():
+        return
+    try:
+        state.pidfile.unlink()
+    except (FileNotFoundError, OSError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Cursor (events.jsonl tail position)
+# ---------------------------------------------------------------------------
+
+
+def read_cursor(state: AttentionState) -> int:
+    """Return the events.jsonl byte offset from which to resume tailing."""
+    try:
+        data = json.loads(state.cursor_file.read_text())
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return 0
+    try:
+        return int(data.get("byte_offset", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def write_cursor(state: AttentionState, byte_offset: int) -> None:
+    """Persist the new tail position atomically."""
+    state.ensure_dir()
+    tmp = state.cursor_file.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps({"byte_offset": int(byte_offset)}, sort_keys=True) + "\n")
+    os.replace(tmp, state.cursor_file)
+
+
+# ---------------------------------------------------------------------------
+# Ticket persistence
+# ---------------------------------------------------------------------------
+
+
+def _append_ticket(state: AttentionState, ticket: DeferredTicket) -> None:
+    """Append one ticket-state-transition line to deferred_tickets.jsonl."""
+    state.ensure_dir()
+    with open(state.tickets_file, "a") as f:
+        f.write(json.dumps(ticket.to_json(), sort_keys=True) + "\n")
+        f.flush()
+
+
+def load_tickets(state: AttentionState) -> dict[str, DeferredTicket]:
+    """Replay deferred_tickets.jsonl; last entry per ticket_id wins."""
+    tickets: dict[str, DeferredTicket] = {}
+    try:
+        lines = state.tickets_file.read_text().splitlines()
+    except (FileNotFoundError, OSError):
+        return tickets
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("Skipping malformed ticket line: %s", line[:100])
+            continue
+        try:
+            ticket = DeferredTicket.from_json(data)
+        except KeyError as exc:
+            logger.warning("Skipping ticket with missing field %s", exc)
+            continue
+        tickets[ticket.ticket_id] = ticket
+    return tickets
+
+
+def pending_tickets(state: AttentionState) -> list[DeferredTicket]:
+    """Return only tickets whose current status is ``pending``."""
+    return [t for t in load_tickets(state).values() if t.status == "pending"]
+
+
+# ---------------------------------------------------------------------------
+# Pane-state inspection (thin wrappers with injection points)
+# ---------------------------------------------------------------------------
+
+
+#: Signature of a pane-state evaluator used by the broker.
+#:
+#: Returns one of:
+#:   ("safe", reason)      — pane looks idle/prompt-safe; nudge now
+#:   ("busy", reason)      — pane is actively working; defer
+#:   ("missing", reason)   — pane does not exist; abandon ticket
+PaneStateFn = Callable[[str], tuple[str, str]]
+
+
+def default_pane_state(lane_id: str) -> tuple[str, str]:
+    """Default safe-to-poke classifier, reusing monitor helpers.
+
+    Resolution order (first truthy wins):
+
+    1. Pane alive check (``_probe_tmux_pane``).  If the pane is gone,
+       return ``("missing", ...)`` so the broker abandons the ticket.
+    2. Approval prompt visible (``_match_approval_prompt``) — defer so
+       the nudge does not collide with approval handling.
+    3. Active spinner / running indicator (``_detect_active_work``) — defer.
+    4. Validation subprocess in the pane's process tree
+       (``_detect_background_validation``) — defer.
+    5. Otherwise — safe to nudge.
+
+    The helpers live in :mod:`bid_euchre.ops.monitor` and
+    :mod:`bid_euchre.ops.worker_pool`; importing them here keeps the
+    direction of dependency (attention → monitor/worker_pool) aligned
+    with the existing layering.  There is no cycle because those modules
+    do not import ``attention`` back.
+
+    Args:
+        lane_id: Recipient lane whose pane should be classified.
+
+    Returns:
+        A ``(state, reason)`` tuple.
+    """
+    # Local imports to keep module import cheap for pure-policy callers.
+    from bid_euchre.ops.monitor import (
+        _capture_pane_content,
+        _detect_active_work,
+        _detect_background_validation,
+        _match_approval_prompt,
+    )
+    from bid_euchre.ops.worker_pool import DEFAULT_TMUX_SESSION, _probe_tmux_pane
+
+    if not _probe_tmux_pane(lane_id, DEFAULT_TMUX_SESSION):
+        return ("missing", "pane_not_found")
+
+    content = _capture_pane_content(lane_id)
+    if content is None:
+        # Capture failed but the pane is alive — safest to defer so we
+        # don't nudge into undefined state.
+        return ("busy", "capture_failed")
+
+    approval = _match_approval_prompt(content)
+    if approval:
+        return ("busy", f"approval_prompt:{approval[:60]}")
+
+    if _detect_active_work(content):
+        return ("busy", "active_work_detected")
+
+    if _detect_background_validation(lane_id):
+        return ("busy", "background_validation")
+
+    return ("safe", "idle")
+
+
+# ---------------------------------------------------------------------------
+# Core broker cycle
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.isoformat()
+
+
+def _parse_iso(text: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_self_loop(event: dict[str, Any]) -> bool:
+    """Filter out events where sender == recipient (bus audit echoes)."""
+    payload = event.get("payload") or {}
+    to_lane = payload.get("to_lane")
+    from_lane = event.get("lane_id")
+    return bool(to_lane) and to_lane == from_lane
+
+
+def _event_warrants_ticket(event: dict[str, Any]) -> bool:
+    """Return True if this message_sent event is nudge-worthy."""
+    if event.get("event_type") != _BROKER_EVENT_TYPE:
+        return False
+    payload = event.get("payload") or {}
+    msg_type = payload.get("message_type")
+    # message_sent events do not carry priority in their payload (the
+    # durable audit trail has it, but events.jsonl captures only the
+    # lightweight fingerprint).  For message types that always nudge
+    # regardless of priority — blocker, escalation — we create a ticket
+    # unconditionally.  For supervisor_alert we can't tell from the event
+    # alone, so we create a ticket and let the ticket record a conservative
+    # priority ("normal" default).  Higher-level senders should use
+    # send_with_attention for the immediate-send nudge; the broker is a
+    # best-effort safety net.
+    if not msg_type:
+        return False
+    if msg_type in ("blocker", "escalation"):
+        return True
+    # Treat supervisor_alert as ticket-worthy only when we have strong
+    # evidence; the event payload does not carry priority, so ignore.
+    # (An immediate-send caller will have already tried the nudge.)
+    return False
+
+
+def _new_ticket_for_event(
+    event: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> DeferredTicket | None:
+    """Build an initial pending ticket from a message_sent event.
+
+    Returns None for events that should not be tracked (self-loops,
+    malformed payloads, unsupported types).
+
+    ``now`` is injected by :func:`run_once` so the initial
+    ``next_retry_at`` matches the cycle's clock.  When omitted (direct
+    unit-test callers), defaults to real wall-clock.
+    """
+    if not _event_warrants_ticket(event):
+        return None
+    if _is_self_loop(event):
+        return None
+    payload = event.get("payload") or {}
+    to_lane = payload.get("to_lane")
+    message_id = payload.get("message_id")
+    message_type = payload.get("message_type")
+    if not (to_lane and message_id and message_type):
+        return None
+
+    ts = now or _now()
+    return DeferredTicket(
+        ticket_id=f"tkt-{uuid4().hex[:12]}",
+        message_id=str(message_id),
+        to_lane=str(to_lane),
+        message_type=str(message_type),
+        priority=str(payload.get("priority", "unknown")),
+        created_at=_iso(ts),
+        next_retry_at=_iso(ts),  # evaluate immediately on first cycle
+        attempts=0,
+        last_reason="new_ticket",
+        status="pending",
+    )
+
+
+def _next_retry_delay(attempts: int) -> float | None:
+    """Return the backoff delay for the next attempt, or None if exhausted.
+
+    ``attempts`` is the attempt count **just completed** (1-based after
+    the first deferral).  The first retry waits _RETRY_BACKOFF_SECONDS[0]
+    after the most recent attempt.
+    """
+    if attempts < 1 or attempts > len(_RETRY_BACKOFF_SECONDS):
+        return None
+    return _RETRY_BACKOFF_SECONDS[attempts - 1]
+
+
+def _evaluate_ticket(
+    ticket: DeferredTicket,
+    pane_state_fn: PaneStateFn,
+    nudge_fn: Callable[[str], Any],
+    *,
+    now: datetime | None = None,
+) -> DeferredTicket:
+    """Advance one pending ticket by one step.
+
+    Returns a *new* ``DeferredTicket`` with the updated status / reason /
+    attempt count / next_retry_at.  The caller is responsible for
+    persisting the transition.
+    """
+    if ticket.status != "pending":
+        return ticket
+
+    now = now or _now()
+
+    # Not yet time to retry.
+    next_retry = _parse_iso(ticket.next_retry_at)
+    if next_retry is not None and now < next_retry:
+        return ticket
+
+    state_name, reason = pane_state_fn(ticket.to_lane)
+    attempts = ticket.attempts + 1
+
+    if state_name == "missing":
+        return DeferredTicket(
+            ticket_id=ticket.ticket_id,
+            message_id=ticket.message_id,
+            to_lane=ticket.to_lane,
+            message_type=ticket.message_type,
+            priority=ticket.priority,
+            created_at=ticket.created_at,
+            next_retry_at=_iso(now),
+            attempts=attempts,
+            last_reason=f"abandoned:{reason}",
+            status="abandoned",
+        )
+
+    if state_name == "safe":
+        # Fire the nudge.  Any exception is swallowed by the caller.
+        try:
+            action = nudge_fn(ticket.to_lane)
+            executed = getattr(action, "executed", True)
+            note = getattr(action, "reason", "nudge sent")
+        except Exception as exc:  # pragma: no cover - defensive
+            executed = False
+            note = f"nudge_error:{exc}"
+        if executed:
+            return DeferredTicket(
+                ticket_id=ticket.ticket_id,
+                message_id=ticket.message_id,
+                to_lane=ticket.to_lane,
+                message_type=ticket.message_type,
+                priority=ticket.priority,
+                created_at=ticket.created_at,
+                next_retry_at=_iso(now),
+                attempts=attempts,
+                last_reason=f"nudged:{note}",
+                status="nudged",
+            )
+        # Nudge failed: treat like a deferral so we retry rather than
+        # silently drop.
+        reason = f"nudge_failed:{note}"
+
+    # state_name == "busy" OR nudge failed above.
+    delay = _next_retry_delay(attempts)
+    if delay is None:
+        return DeferredTicket(
+            ticket_id=ticket.ticket_id,
+            message_id=ticket.message_id,
+            to_lane=ticket.to_lane,
+            message_type=ticket.message_type,
+            priority=ticket.priority,
+            created_at=ticket.created_at,
+            next_retry_at=_iso(now),
+            attempts=attempts,
+            last_reason=f"abandoned:max_attempts:{reason}",
+            status="abandoned",
+        )
+
+    next_retry = now + timedelta(seconds=delay)
+    return DeferredTicket(
+        ticket_id=ticket.ticket_id,
+        message_id=ticket.message_id,
+        to_lane=ticket.to_lane,
+        message_type=ticket.message_type,
+        priority=ticket.priority,
+        created_at=ticket.created_at,
+        next_retry_at=_iso(next_retry),
+        attempts=attempts,
+        last_reason=f"deferred:{reason}",
+        status="pending",
+    )
+
+
+def _read_new_events(
+    events_file: Path,
+    cursor_offset: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Tail events.jsonl from ``cursor_offset`` and parse new lines.
+
+    Returns:
+        ``(events, new_offset)`` — a list of parsed events (malformed
+        lines are skipped with a warning) and the new tail position.
+    """
+    try:
+        size = events_file.stat().st_size
+    except (FileNotFoundError, OSError):
+        return ([], cursor_offset)
+
+    # If the file was truncated/rotated, reset to start.
+    if cursor_offset > size:
+        cursor_offset = 0
+
+    events: list[dict[str, Any]] = []
+    try:
+        with open(events_file, "rb") as f:
+            f.seek(cursor_offset)
+            data = f.read()
+            new_offset = cursor_offset + len(data)
+    except OSError:
+        return ([], cursor_offset)
+
+    for raw in data.decode("utf-8", errors="replace").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            events.append(json.loads(raw))
+        except json.JSONDecodeError:
+            logger.warning("Skipping malformed event line: %s", raw[:100])
+            continue
+
+    return (events, new_offset)
+
+
+def run_once(
+    *,
+    runtime_dir: Path | None = None,
+    pane_state_fn: PaneStateFn | None = None,
+    nudge_fn: Callable[[str], Any] | None = None,
+    now: datetime | None = None,
+) -> CycleSummary:
+    """Execute one broker cycle: ingest new events + re-evaluate pending tickets.
+
+    Safe to call from the CLI (``attention once``) and from the long-running
+    daemon (``attention run``).  The cycle order guarantees exactly-once
+    nudges per event across crash-restarts:
+
+    1. Load current ticket state from durable storage.
+    2. Tail events.jsonl from the persisted cursor.
+    3. For every new nudge-worthy event, append an initial ``pending``
+       ticket to the durable log.
+    4. Advance the cursor **after** all new tickets are persisted.
+    5. Evaluate every pending ticket (old and new) and append state
+       transitions.
+
+    Args:
+        runtime_dir: Override root for ``.claude/runtime``.
+        pane_state_fn: Injectable pane-state classifier.  Defaults to
+            :func:`default_pane_state`.
+        nudge_fn: Injectable nudge primitive.  Defaults to
+            :func:`worker_pool.nudge_inbox`.
+        now: Frozen timestamp for deterministic testing.
+
+    Returns:
+        A :class:`CycleSummary` of what happened in this cycle.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    state = AttentionState.from_runtime_dir(runtime_dir)
+    state.ensure_dir()
+
+    if pane_state_fn is None:
+        pane_state_fn = default_pane_state
+    if nudge_fn is None:
+        nudge_fn = nudge_inbox
+
+    now_dt = now or _now()
+    summary = CycleSummary(timestamp=_iso(now_dt))
+
+    # Step 1: load current tickets.
+    tickets = load_tickets(state)
+
+    # Step 2: ingest new events (cursor advance deferred until all new
+    # tickets are persisted).
+    cursor_offset = read_cursor(state)
+    new_events, new_offset = _read_new_events(state.events_file, cursor_offset)
+    summary.new_events_seen = len(new_events)
+
+    # Step 3: create initial tickets for new nudge-worthy events.
+    seen_message_ids = {t.message_id for t in tickets.values()}
+    for event in new_events:
+        ticket = _new_ticket_for_event(event, now=now_dt)
+        if ticket is None:
+            continue
+        # Duplicate-suppression: if we already have a ticket for this
+        # message_id, skip (cursor-advance race protection).
+        if ticket.message_id in seen_message_ids:
+            continue
+        _append_ticket(state, ticket)
+        tickets[ticket.ticket_id] = ticket
+        seen_message_ids.add(ticket.message_id)
+        summary.tickets_created += 1
+
+    # Step 4: advance the cursor now that tickets are durably recorded.
+    if new_offset != cursor_offset:
+        write_cursor(state, new_offset)
+
+    # Step 5: evaluate every pending ticket.
+    for ticket_id, ticket in list(tickets.items()):
+        if ticket.status != "pending":
+            continue
+        new_state = _evaluate_ticket(
+            ticket,
+            pane_state_fn,
+            nudge_fn,
+            now=now_dt,
+        )
+        if new_state is ticket:
+            # Not yet due for retry.
+            continue
+        _append_ticket(state, new_state)
+        tickets[ticket_id] = new_state
+        if new_state.status == "nudged":
+            summary.nudged += 1
+        elif new_state.status == "abandoned":
+            summary.abandoned += 1
+        else:
+            summary.deferred += 1
+
+    summary.pending_after = sum(1 for t in tickets.values() if t.status == "pending")
+
+    _write_status(state, summary)
+    return summary
+
+
+def _write_status(state: AttentionState, summary: CycleSummary) -> None:
+    """Persist the last-cycle summary for ``attention status``."""
+    state.ensure_dir()
+    tmp = state.status_file.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(summary.to_json(), sort_keys=True) + "\n")
+    os.replace(tmp, state.status_file)
+
+
+# ---------------------------------------------------------------------------
+# Daemon mode
+# ---------------------------------------------------------------------------
+
+
+def run_daemon(
+    *,
+    runtime_dir: Path | None = None,
+    interval_seconds: float = _DEFAULT_CYCLE_INTERVAL_SECONDS,
+    max_cycles: int | None = None,
+    pane_state_fn: PaneStateFn | None = None,
+    nudge_fn: Callable[[str], Any] | None = None,
+) -> int:
+    """Long-running daemon loop over :func:`run_once`.
+
+    Enforces single-instance semantics via pidfile + liveness check.  If
+    another daemon is already running, exits cleanly with return code 0
+    (the nudge surface is still covered by the other instance).
+
+    Signal handling:
+        SIGTERM / SIGINT — finish the current cycle then return cleanly.
+
+    Args:
+        runtime_dir: Override root for ``.claude/runtime``.
+        interval_seconds: Sleep between cycles.  Honors a sensible
+            minimum of 0.5s to avoid busy-spinning.
+        max_cycles: If set, return after this many cycles (testing).
+        pane_state_fn: Injectable pane-state classifier.
+        nudge_fn: Injectable nudge primitive.
+
+    Returns:
+        0 on clean shutdown (including "another daemon already running"),
+        1 on fatal error.
+    """
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    state = AttentionState.from_runtime_dir(runtime_dir)
+    state.ensure_dir()
+
+    if not acquire_pidfile(state):
+        existing = read_pidfile(state)
+        logger.info(
+            "attention-broker already running (pid=%s); exiting cleanly",
+            existing,
+        )
+        return 0
+
+    interval = max(0.5, float(interval_seconds))
+    cycles = 0
+    stop = {"value": False}
+
+    def _handle_signal(signum: int, _frame: Any) -> None:  # pragma: no cover
+        logger.info("attention-broker received signal %s; shutting down", signum)
+        stop["value"] = True
+
+    original_handlers: list[tuple[int, Any]] = []
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            original_handlers.append((sig, signal.getsignal(sig)))
+            signal.signal(sig, _handle_signal)
+        except (ValueError, OSError):  # pragma: no cover - platform dep
+            pass
+
+    try:
+        while not stop["value"]:
+            try:
+                run_once(
+                    runtime_dir=runtime_dir,
+                    pane_state_fn=pane_state_fn,
+                    nudge_fn=nudge_fn,
+                )
+            except Exception as exc:
+                logger.exception("attention-broker cycle failed: %s", exc)
+                _write_failure_sentinel(state, f"cycle_error: {exc}")
+            cycles += 1
+            if max_cycles is not None and cycles >= max_cycles:
+                break
+            # Interruptible sleep: chunk into 0.5s slices so signals are
+            # honored promptly.
+            slept = 0.0
+            while slept < interval and not stop["value"]:
+                time.sleep(min(0.5, interval - slept))
+                slept += 0.5
+    finally:
+        for sig, handler in original_handlers:  # pragma: no cover
+            try:
+                signal.signal(sig, handler)
+            except (ValueError, OSError, TypeError):
+                pass
+        release_pidfile(state)
+
+    return 0
+
+
+def _write_failure_sentinel(state: AttentionState, summary_line: str) -> None:
+    """Write a FAILED sentinel for post-tool-daemon-notify surfacing."""
+    state.ensure_dir()
+    try:
+        state.failure_sentinel.write_text(summary_line.strip() + "\n")
+    except OSError:
+        logger.warning("Could not write attention-broker FAILED sentinel")
+
+
+# ---------------------------------------------------------------------------
+# Status surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BrokerStatus:
+    """Operator-facing snapshot of broker state."""
+
+    pid: int | None
+    alive: bool
+    last_cycle: dict[str, Any] | None
+    pending_count: int
+    abandoned_count: int
+    nudged_count: int
+    cursor_offset: int
+    events_file: str
+    runtime_dir: str
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def get_status(*, runtime_dir: Path | None = None) -> BrokerStatus:
+    """Return a point-in-time snapshot of broker health for operators."""
+    if runtime_dir is None:
+        runtime_dir = Path(".claude/runtime")
+    state = AttentionState.from_runtime_dir(runtime_dir)
+
+    pid = read_pidfile(state)
+    last_cycle: dict[str, Any] | None
+    try:
+        last_cycle = json.loads(state.status_file.read_text())
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        last_cycle = None
+
+    tickets = load_tickets(state).values()
+    pending = sum(1 for t in tickets if t.status == "pending")
+    nudged = sum(1 for t in tickets if t.status == "nudged")
+    abandoned = sum(1 for t in tickets if t.status == "abandoned")
+
+    return BrokerStatus(
+        pid=pid,
+        alive=pid is not None,
+        last_cycle=last_cycle,
+        pending_count=pending,
+        abandoned_count=abandoned,
+        nudged_count=nudged,
+        cursor_offset=read_cursor(state),
+        events_file=str(state.events_file),
+        runtime_dir=str(runtime_dir),
+    )
+
+
 __all__ = [
+    "AttentionState",
+    "BrokerStatus",
+    "CycleSummary",
+    "DeferredTicket",
+    "MAX_ATTEMPTS",
+    "acquire_pidfile",
+    "default_pane_state",
+    "get_status",
+    "load_tickets",
+    "pending_tickets",
+    "read_cursor",
+    "read_pidfile",
+    "release_pidfile",
+    "run_daemon",
+    "run_once",
     "send_with_attention",
     "should_nudge_for_message",
+    "write_cursor",
 ]

--- a/tests/integration/test_attention_broker.py
+++ b/tests/integration/test_attention_broker.py
@@ -1,0 +1,503 @@
+"""Integration tests for PR-MSG-4 — attention broker daemon.
+
+End-to-end coverage of the busy-defer-idle-nudge-once invariant that
+the broker was built for:
+
+1. A blocker message is sent via :func:`message_bus.send_message`, which
+   emits a real ``message_sent`` event into ``events.jsonl``.
+2. The broker's first cycle sees the event, classifies the recipient
+   lane as busy (injected pane-state fn), and defers the ticket.
+3. After backoff, the second cycle still sees busy and defers again.
+4. A third cycle sees the lane as safe and nudges.  The nudge fires
+   exactly once even though subsequent cycles continue to run.
+
+Complements the unit suite in ``tests/unit/test_ops_attention.py`` by
+driving the full pipeline: real ``send_message`` → real ``events.jsonl``
+→ ``run_once`` → durable ticket log → injected ``nudge_fn``.
+
+The pane-state and nudge callables are injected (no live tmux), but the
+message bus, events emitter, cursor, and ticket log are all exercised
+as in production.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bid_euchre.ops.attention import (
+    MAX_ATTEMPTS,
+    AttentionState,
+    get_status,
+    load_tickets,
+    pending_tickets,
+    read_cursor,
+    run_once,
+)
+from bid_euchre.ops.message_bus import create_message, send_message
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runtime_dir(tmp_path: Path) -> Path:
+    """Fresh runtime_dir with the events/ subdirectory created."""
+    runtime = tmp_path / "runtime"
+    (runtime / "events").mkdir(parents=True)
+    return runtime
+
+
+@pytest.fixture
+def bus_root(tmp_path: Path) -> Path:
+    """Fresh, isolated message-bus root."""
+    root = tmp_path / "bus"
+    root.mkdir()
+    return root
+
+
+class _PaneStateOracle:
+    """Toggleable pane-state fn used as the broker's injection point."""
+
+    def __init__(self, state: str = "busy", reason: str = "active_work_detected"):
+        self.state = state
+        self.reason = reason
+        self.calls: list[str] = []
+
+    def set(self, state: str, reason: str = "") -> None:
+        self.state = state
+        self.reason = reason or state
+
+    def __call__(self, lane_id: str) -> tuple[str, str]:
+        self.calls.append(lane_id)
+        return (self.state, self.reason)
+
+
+class _NudgeRecorder:
+    """Injection point for :func:`worker_pool.nudge_inbox` substitute."""
+
+    def __init__(self) -> None:
+        self.nudges: list[str] = []
+
+    def __call__(self, lane_id: str) -> Any:
+        self.nudges.append(lane_id)
+
+        class _Result:
+            executed = True
+            reason = "nudge_sent"
+
+        return _Result()
+
+
+def _send_blocker(
+    *,
+    events_dir: Path,
+    bus_root: Path,
+    from_lane: str = "author-b",
+    to_lane: str = "orchestrator",
+    summary: str = "Blocked on upstream PR",
+) -> str:
+    """Factory helper — send a real blocker through the bus layer."""
+    msg = create_message(
+        from_lane=from_lane,
+        to_lane=to_lane,
+        message_type="blocker",
+        summary=summary,
+        priority="high",
+    )
+    return send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestBusyToIdleExactlyOnceNudge:
+    """The headline invariant: defer while busy, nudge once when idle."""
+
+    def test_busy_defers_then_idle_nudges_exactly_once(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        """Full pipeline: send → defer → defer → nudge — one nudge total."""
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="busy", reason="active_work_detected")
+        nudger = _NudgeRecorder()
+
+        # Step 1 — sender emits a real message_sent event into events.jsonl
+        # via send_message().
+        message_id = _send_blocker(events_dir=events_dir, bus_root=bus_root)
+
+        # Step 2 — broker cycle 1 @ t0: ingests the event, evaluates as busy,
+        # records the ticket as deferred (pending, attempts=1).
+        t0 = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        summary1 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=t0,
+        )
+        assert summary1.new_events_seen == 1
+        assert summary1.tickets_created == 1
+        assert summary1.deferred == 1
+        assert summary1.nudged == 0
+        assert summary1.abandoned == 0
+        assert summary1.pending_after == 1
+        assert nudger.nudges == []
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        tickets = list(load_tickets(state).values())
+        assert len(tickets) == 1
+        ticket_after_1 = tickets[0]
+        assert ticket_after_1.status == "pending"
+        assert ticket_after_1.attempts == 1
+        assert ticket_after_1.message_id == message_id
+        assert ticket_after_1.to_lane == "orchestrator"
+        assert ticket_after_1.message_type == "blocker"
+        assert ticket_after_1.last_reason.startswith("deferred:")
+
+        # Step 3 — broker cycle 2 @ t0+15s (> 10s first backoff): still busy.
+        t1 = t0 + timedelta(seconds=15)
+        summary2 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=t1,
+        )
+        assert summary2.new_events_seen == 0  # cursor advanced past the event
+        assert summary2.tickets_created == 0
+        assert summary2.deferred == 1
+        assert summary2.nudged == 0
+        assert nudger.nudges == []
+
+        tickets = list(load_tickets(state).values())
+        assert len(tickets) == 1
+        ticket_after_2 = tickets[0]
+        assert ticket_after_2.status == "pending"
+        assert ticket_after_2.attempts == 2
+
+        # Step 4 — lane becomes idle.  Broker cycle 3 fires the nudge.
+        pane.set("safe", "idle")
+        t2 = t1 + timedelta(seconds=35)  # > 30s second backoff
+        summary3 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=t2,
+        )
+        assert summary3.nudged == 1
+        assert summary3.deferred == 0
+        assert summary3.abandoned == 0
+        assert summary3.pending_after == 0
+        assert nudger.nudges == ["orchestrator"]
+
+        tickets = list(load_tickets(state).values())
+        assert len(tickets) == 1
+        ticket_after_3 = tickets[0]
+        assert ticket_after_3.status == "nudged"
+        assert ticket_after_3.attempts == 3
+        assert ticket_after_3.last_reason.startswith("nudged:")
+
+        # Step 5 — subsequent cycles must not re-nudge.  Terminal state.
+        t3 = t2 + timedelta(seconds=60)
+        summary4 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=t3,
+        )
+        assert summary4.nudged == 0
+        assert summary4.pending_after == 0
+        assert nudger.nudges == ["orchestrator"]  # exactly one total
+
+    def test_crash_restart_preserves_ticket_state_no_double_nudge(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        """After cycle 1 defers the ticket, a fresh broker process (simulated
+        by a new ``run_once`` call using a different injected recorder) must
+        resume from the cursor + durable ticket log and still nudge at most
+        once when the lane becomes safe.
+        """
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="busy", reason="active_work_detected")
+        nudger_before = _NudgeRecorder()
+        nudger_after = _NudgeRecorder()
+
+        _send_blocker(events_dir=events_dir, bus_root=bus_root)
+
+        # Cycle 1 with the "before crash" recorder: defers.
+        t0 = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger_before,
+            now=t0,
+        )
+        assert nudger_before.nudges == []
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        # The cursor must have advanced past the one event written.
+        events_file = events_dir / "events.jsonl"
+        assert read_cursor(state) == events_file.stat().st_size
+        assert len(pending_tickets(state)) == 1
+
+        # "Restart": subsequent run_once calls use nudger_after.  The event is
+        # no longer re-read (cursor past it), but the durable ticket log
+        # preserves the pending state.
+        pane.set("safe", "idle")
+        t1 = t0 + timedelta(seconds=15)
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger_after,
+            now=t1,
+        )
+        assert summary.new_events_seen == 0
+        assert summary.nudged == 1
+        assert nudger_after.nudges == ["orchestrator"]
+        # The pre-crash recorder must not be called a second time.
+        assert nudger_before.nudges == []
+
+
+class TestRetryBudgetEnforced:
+    """Persistently-busy panes must abandon the ticket, not pin it forever."""
+
+    def test_persistently_busy_lane_abandons_after_max_attempts(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="busy", reason="active_work_detected")
+        nudger = _NudgeRecorder()
+
+        _send_blocker(events_dir=events_dir, bus_root=bus_root)
+
+        # Walk the backoff schedule fast-forwarding time each cycle.
+        t = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=t,
+        )
+        for step in (15, 45, 120):  # > 10s, > 30s, > 90s
+            t = t + timedelta(seconds=step)
+            run_once(
+                runtime_dir=runtime_dir,
+                pane_state_fn=pane,
+                nudge_fn=nudger,
+                now=t,
+            )
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        tickets = list(load_tickets(state).values())
+        assert len(tickets) == 1
+        ticket = tickets[0]
+        assert ticket.status == "abandoned"
+        assert ticket.attempts == MAX_ATTEMPTS
+        assert ticket.last_reason.startswith("abandoned:max_attempts")
+        assert nudger.nudges == []
+
+        # get_status must surface the abandoned count.
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.abandoned_count == 1
+        assert status.pending_count == 0
+        assert status.nudged_count == 0
+
+
+class TestNonNudgeTraffic:
+    """Non-nudge-worthy events must not produce tickets."""
+
+    def test_progress_message_creates_no_ticket(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="safe", reason="idle")
+        nudger = _NudgeRecorder()
+
+        # progress messages ride the durable-only path, not the broker.
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="orchestrator",
+            message_type="progress",
+            summary="Milestone reached",
+            priority="normal",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert summary.new_events_seen == 1
+        assert summary.tickets_created == 0
+        assert summary.nudged == 0
+        assert nudger.nudges == []
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert list(load_tickets(state).values()) == []
+
+
+class TestSelfLoopFiltered:
+    """Bus audit echoes (from_lane == to_lane) must not produce tickets."""
+
+    def test_self_addressed_blocker_does_not_create_ticket(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="safe", reason="idle")
+        nudger = _NudgeRecorder()
+
+        # from_lane == to_lane: typically only seen for self-addressed
+        # audit artifacts.  The broker must skip these to avoid waking a
+        # lane about its own message.
+        msg = create_message(
+            from_lane="author-a",
+            to_lane="author-a",
+            message_type="blocker",
+            summary="self loop",
+            priority="high",
+        )
+        send_message(msg, bus_root=bus_root, events_dir=events_dir)
+
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        assert summary.new_events_seen == 1
+        assert summary.tickets_created == 0
+        assert nudger.nudges == []
+
+
+class TestMultipleRecipients:
+    """Distinct blockers to distinct lanes must produce distinct tickets."""
+
+    def test_two_blockers_two_tickets_two_nudges(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        events_dir = runtime_dir / "events"
+        pane = _PaneStateOracle(state="safe", reason="idle")
+        nudger = _NudgeRecorder()
+
+        _send_blocker(
+            events_dir=events_dir,
+            bus_root=bus_root,
+            from_lane="author-a",
+            to_lane="orchestrator",
+            summary="block 1",
+        )
+        _send_blocker(
+            events_dir=events_dir,
+            bus_root=bus_root,
+            from_lane="author-b",
+            to_lane="review",
+            summary="block 2",
+        )
+
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=pane,
+            nudge_fn=nudger,
+            now=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        assert summary.new_events_seen == 2
+        assert summary.tickets_created == 2
+        assert summary.nudged == 2
+        assert sorted(nudger.nudges) == ["orchestrator", "review"]
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        tickets = list(load_tickets(state).values())
+        assert len(tickets) == 2
+        assert {t.to_lane for t in tickets} == {"orchestrator", "review"}
+        assert all(t.status == "nudged" for t in tickets)
+
+
+class TestPidfileLifecycle:
+    """Running daemon is visible to `get_status`; stale pidfile ignored."""
+
+    def test_status_reports_live_broker_via_pidfile(
+        self,
+        runtime_dir: Path,
+    ) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        # Fake a live pidfile pointing at *this* process (guaranteed alive).
+        state.pidfile.write_text(f"{os.getpid()}\n")
+
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.pid == os.getpid()
+        assert status.alive is True
+
+    def test_status_reports_dead_broker_when_pidfile_stale(
+        self,
+        runtime_dir: Path,
+    ) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        # PID 1 on macOS/Linux is typically owned by init/launchd; we only
+        # treat it as "alive" for the purposes of `get_status`, so use a
+        # PID that's extremely unlikely to be allocated.
+        state.pidfile.write_text("999999999\n")
+
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.pid is None
+        assert status.alive is False
+
+
+class TestEventLineInspection:
+    """Sanity-check that the upstream send_message() actually writes the
+    message_sent event that the broker depends on.  Guards against a future
+    refactor silently dropping the event emission.
+    """
+
+    def test_send_message_emits_message_sent_event(
+        self,
+        runtime_dir: Path,
+        bus_root: Path,
+    ) -> None:
+        events_dir = runtime_dir / "events"
+        _send_blocker(
+            events_dir=events_dir,
+            bus_root=bus_root,
+            from_lane="author-a",
+            to_lane="orchestrator",
+        )
+        events_file = events_dir / "events.jsonl"
+        lines = [
+            json.loads(line)
+            for line in events_file.read_text().splitlines()
+            if line.strip()
+        ]
+        # We expect exactly one event for the single send.
+        assert len(lines) == 1
+        evt = lines[0]
+        assert evt["event_type"] == "message_sent"
+        assert evt["lane_id"] == "author-a"
+        assert evt["payload"]["to_lane"] == "orchestrator"
+        assert evt["payload"]["message_type"] == "blocker"

--- a/tests/unit/test_ops_attention.py
+++ b/tests/unit/test_ops_attention.py
@@ -1,6 +1,7 @@
-"""Tests for the PR-MSG-2 delivery-policy helper.
+"""Tests for the PR-MSG-2 delivery-policy helper and PR-MSG-4 broker.
 
-Proves the nudge policy in :mod:`bid_euchre.ops.attention`:
+PR-MSG-2 proves the immediate-send nudge policy in
+:mod:`bid_euchre.ops.attention`:
 
 - Low/normal ``progress`` messages: **no nudge**
 - ``blocker``: **nudge**
@@ -10,19 +11,47 @@ Proves the nudge policy in :mod:`bid_euchre.ops.attention`:
 - ``supervisor_alert`` at priority ``normal`` / ``low``: **no nudge**
 - ``send_message`` failure: **no nudge attempted**
 
+PR-MSG-4 proves the broker daemon:
+
+- Cursor resumes on restart (byte-offset persistence)
+- Deferred ticket transitions (pending → nudged, pending → deferred →
+  nudged, pending → abandoned)
+- Safe / unsafe poke decisions (mocked pane state)
+- Pidfile single-instance guard
+- Exactly-once nudge per message_sent event across crash-restart
+
 The architectural invariant is that ``send_with_attention`` wraps (not
 replaces) ``send_message``, so all durability guarantees still hold and
-no tmux coupling leaks into the bus layer.
+no tmux coupling leaks into the bus layer.  The broker reuses existing
+pane-state helpers rather than inventing new ones.
 """
 
 from __future__ import annotations
 
+import json
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bid_euchre.ops.attention import send_with_attention, should_nudge_for_message
+from bid_euchre.ops.attention import (
+    MAX_ATTEMPTS,
+    AttentionState,
+    DeferredTicket,
+    acquire_pidfile,
+    get_status,
+    load_tickets,
+    pending_tickets,
+    read_cursor,
+    read_pidfile,
+    release_pidfile,
+    run_once,
+    send_with_attention,
+    should_nudge_for_message,
+    write_cursor,
+)
 from bid_euchre.ops.message_bus import create_message, shared_bus_root
 from bid_euchre.ops.worker_pool import PoolAction
 
@@ -506,3 +535,589 @@ class TestNudgeTargetsRecipient:
         mock_nudge.assert_called_once()
         called_lane = mock_nudge.call_args.args[0]
         assert called_lane == "review"
+
+
+# ---------------------------------------------------------------------------
+# PR-MSG-4: Attention broker daemon
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Path:
+    """Isolated runtime root for broker tests."""
+    rt = tmp_path / "runtime"
+    rt.mkdir()
+    (rt / "events").mkdir()
+    return rt
+
+
+def _write_events(runtime_dir: Path, events: list[dict]) -> None:
+    """Append a list of event dicts to events.jsonl (creates file if absent)."""
+    events_file = runtime_dir / "events" / "events.jsonl"
+    with open(events_file, "a") as f:
+        for ev in events:
+            f.write(json.dumps(ev, sort_keys=True) + "\n")
+
+
+def _msg_sent_event(
+    *,
+    to_lane: str,
+    message_type: str,
+    priority: str = "high",
+    from_lane: str = "author-a",
+    message_id: str | None = None,
+) -> dict:
+    """Build a synthetic message_sent event matching the events.jsonl schema."""
+    return {
+        "timestamp": "2026-04-20T18:00:00+00:00",
+        "event_type": "message_sent",
+        "source": "ops.message_bus",
+        "lane_id": from_lane,
+        "payload": {
+            "message_id": message_id or f"mid-{to_lane}-{message_type}",
+            "message_type": message_type,
+            "priority": priority,
+            "to_lane": to_lane,
+            "task_id": None,
+            "thread_id": None,
+        },
+    }
+
+
+def _safe_pane(_lane_id: str) -> tuple[str, str]:
+    return ("safe", "idle")
+
+
+def _busy_pane(_lane_id: str) -> tuple[str, str]:
+    return ("busy", "active_work_detected")
+
+
+def _missing_pane(_lane_id: str) -> tuple[str, str]:
+    return ("missing", "pane_not_found")
+
+
+def _record_nudge_fn(recorder: list[str]):
+    """Build a nudge_fn that records each lane it was asked to nudge."""
+
+    def _fn(lane_id: str) -> PoolAction:
+        recorder.append(lane_id)
+        return PoolAction(
+            action="inbox_nudge",
+            lane_id=lane_id,
+            reason=f"fake nudge to {lane_id}",
+            executed=True,
+        )
+
+    return _fn
+
+
+class TestAttentionStateLayout:
+    """Filesystem-layout invariants for the broker state dir."""
+
+    def test_from_runtime_dir_uses_attention_broker_subdir(
+        self, runtime_dir: Path
+    ) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert state.root == runtime_dir / "attention_broker"
+        assert state.pidfile.name == "pid"
+        assert state.cursor_file.name == "cursor.json"
+        assert state.tickets_file.name == "deferred_tickets.jsonl"
+        assert state.failure_sentinel.name == "FAILED"
+        assert state.events_file == runtime_dir / "events" / "events.jsonl"
+
+    def test_ensure_dir_creates_directory(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert not state.root.exists()
+        state.ensure_dir()
+        assert state.root.is_dir()
+
+
+class TestPidfileGuard:
+    """Single-instance protection via liveness-checked pidfile."""
+
+    def test_acquire_empty_succeeds(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert acquire_pidfile(state) is True
+        assert state.pidfile.read_text().strip() == str(os.getpid())
+
+    def test_stale_pidfile_is_replaced(self, runtime_dir: Path) -> None:
+        """A pidfile pointing at a dead PID must be claimable."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        # PID 1 typically exists, but 999999 almost certainly does not.
+        dead_pid = 999_999
+        state.pidfile.write_text(f"{dead_pid}\n")
+        assert acquire_pidfile(state) is True
+        assert state.pidfile.read_text().strip() == str(os.getpid())
+
+    def test_garbage_pidfile_is_replaced(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        state.pidfile.write_text("not-a-pid\n")
+        assert acquire_pidfile(state) is True
+
+    def test_live_pidfile_blocks_acquire(self, runtime_dir: Path) -> None:
+        """A pidfile pointing at a LIVE process (other than us) refuses
+        acquisition.
+
+        We simulate by writing the current test process's PID as if another
+        daemon owned it, then calling acquire_pidfile with a monkey-patched
+        getpid() that returns a different PID.
+        """
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        # The test process itself is alive — write its pid as though it were
+        # "another daemon".
+        owner_pid = os.getpid()
+        state.pidfile.write_text(f"{owner_pid}\n")
+
+        with patch(f"{_ATTENTION}.os.getpid", return_value=owner_pid + 1):
+            assert acquire_pidfile(state) is False
+
+    def test_release_only_removes_own_pidfile(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        foreign_pid = os.getpid() + 1
+        state.pidfile.write_text(f"{foreign_pid}\n")
+        release_pidfile(state)  # we are not the owner
+        assert state.pidfile.exists()
+        assert state.pidfile.read_text().strip() == str(foreign_pid)
+
+    def test_release_removes_our_pidfile(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert acquire_pidfile(state) is True
+        release_pidfile(state)
+        assert not state.pidfile.exists()
+
+    def test_read_pidfile_reports_live_only(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        state.pidfile.write_text("999999\n")  # dead
+        assert read_pidfile(state) is None
+        state.pidfile.write_text(f"{os.getpid()}\n")
+        assert read_pidfile(state) == os.getpid()
+
+
+class TestCursorResume:
+    """events.jsonl byte-offset cursor persists across daemon restarts."""
+
+    def test_cursor_default_zero(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert read_cursor(state) == 0
+
+    def test_cursor_roundtrip(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        write_cursor(state, 1234)
+        assert read_cursor(state) == 1234
+
+    def test_malformed_cursor_file_falls_back_to_zero(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        state.cursor_file.write_text("not json")
+        assert read_cursor(state) == 0
+
+    def test_run_once_advances_cursor(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        assert read_cursor(state) == 0
+        nudged: list[str] = []
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        size = (runtime_dir / "events" / "events.jsonl").stat().st_size
+        assert read_cursor(state) == size
+        assert nudged == ["author-b"]
+
+    def test_run_once_does_not_replay_on_restart(self, runtime_dir: Path) -> None:
+        """Second run with no new events must produce no new nudges."""
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == ["author-b"]
+        # Simulate a daemon restart — the cursor persists, so the second
+        # run sees no new events.
+        nudged.clear()
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == []
+
+
+class TestSafePokeDecision:
+    """Safe / unsafe poke classifier steers the ticket transitions."""
+
+    def test_safe_pane_nudges_immediately(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == ["author-b"]
+        assert summary.nudged == 1
+        assert summary.tickets_created == 1
+        assert summary.pending_after == 0
+
+    def test_busy_pane_defers_no_nudge(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == []
+        assert summary.nudged == 0
+        assert summary.deferred == 1
+        assert summary.pending_after == 1
+
+    def test_missing_pane_abandons(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_missing_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == []
+        assert summary.abandoned == 1
+        assert summary.pending_after == 0
+
+    def test_self_loop_is_filtered(self, runtime_dir: Path) -> None:
+        """An event where sender == recipient creates no ticket."""
+        ev = _msg_sent_event(
+            to_lane="author-a",
+            message_type="blocker",
+            from_lane="author-a",
+        )
+        _write_events(runtime_dir, [ev])
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert summary.tickets_created == 0
+        assert nudged == []
+
+    def test_non_nudge_type_creates_no_ticket(self, runtime_dir: Path) -> None:
+        """progress / ack / completion never create broker tickets."""
+        events = [
+            _msg_sent_event(to_lane="author-b", message_type=t)
+            for t in ("progress", "ack", "completion", "assignment")
+        ]
+        _write_events(runtime_dir, events)
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert summary.new_events_seen == len(events)
+        assert summary.tickets_created == 0
+        assert nudged == []
+
+
+class TestDeferredTicketTransitions:
+    """Exercises the pending → deferred → nudged / abandoned transitions."""
+
+    def test_busy_then_safe_nudges_exactly_once(self, runtime_dir: Path) -> None:
+        """Cycle 1 defers (busy), cycle 2 (after retry window) nudges."""
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="escalation")],
+        )
+        nudged: list[str] = []
+
+        # Cycle 1: busy → defer
+        t0 = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        summary1 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+            now=t0,
+        )
+        assert summary1.deferred == 1
+        assert summary1.pending_after == 1
+        assert nudged == []
+
+        # Cycle 2: safe → nudge, at a time well past the first retry window
+        t1 = t0 + timedelta(seconds=60)
+        summary2 = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+            now=t1,
+        )
+        assert summary2.nudged == 1
+        assert summary2.pending_after == 0
+        assert nudged == ["author-b"]
+
+    def test_retry_before_window_is_a_no_op(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        t0 = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+            now=t0,
+        )
+        # 1 second later — still well within the 10s first-retry window.
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+            now=t0 + timedelta(seconds=1),
+        )
+        # The pane is now "safe" BUT we haven't reached next_retry_at yet,
+        # so nothing should fire.
+        assert summary.nudged == 0
+        assert summary.deferred == 0
+        assert nudged == []
+
+    def test_exhausted_retries_abandon(self, runtime_dir: Path) -> None:
+        """After MAX_ATTEMPTS on a persistently busy pane, ticket is abandoned."""
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+
+        for i in range(MAX_ATTEMPTS):
+            run_once(
+                runtime_dir=runtime_dir,
+                pane_state_fn=_busy_pane,
+                nudge_fn=_record_nudge_fn(nudged),
+                now=now + timedelta(seconds=1000 * i),
+            )
+
+        assert nudged == []
+        tickets = list(
+            load_tickets(AttentionState.from_runtime_dir(runtime_dir)).values()
+        )
+        assert len(tickets) == 1
+        assert tickets[0].status == "abandoned"
+        assert tickets[0].attempts == MAX_ATTEMPTS
+
+    def test_ticket_dedup_on_duplicate_message_id(self, runtime_dir: Path) -> None:
+        """Same message_id emitted twice creates only one ticket."""
+        ev = _msg_sent_event(
+            to_lane="author-b",
+            message_type="blocker",
+            message_id="stable-id",
+        )
+        _write_events(runtime_dir, [ev, ev])
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert summary.tickets_created == 1
+        assert nudged == ["author-b"]
+
+    def test_pending_tickets_helper(self, runtime_dir: Path) -> None:
+        """After one busy cycle, pending_tickets reports the unresolved one."""
+        _write_events(
+            runtime_dir,
+            [
+                _msg_sent_event(
+                    to_lane="author-b",
+                    message_type="blocker",
+                    message_id="a",
+                ),
+                _msg_sent_event(
+                    to_lane="author-c",
+                    message_type="escalation",
+                    message_id="b",
+                ),
+            ],
+        )
+        nudged: list[str] = []
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        pending = pending_tickets(state)
+        pending_lanes = {t.to_lane for t in pending}
+        assert pending_lanes == {"author-b", "author-c"}
+        assert all(t.status == "pending" for t in pending)
+
+
+class TestTicketPersistence:
+    """Ticket state survives crash-restart via append-only jsonl."""
+
+    def test_jsonl_records_each_transition(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        t0 = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn([]),
+            now=t0,
+        )
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn([]),
+            now=t0 + timedelta(seconds=60),
+        )
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        lines = [
+            line for line in state.tickets_file.read_text().splitlines() if line.strip()
+        ]
+        # Three lines: initial (pending), defer, nudge.
+        assert len(lines) == 3
+        statuses = [json.loads(line)["status"] for line in lines]
+        assert statuses == ["pending", "pending", "nudged"]
+
+    def test_load_tickets_uses_last_entry_per_id(self, runtime_dir: Path) -> None:
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        # Simulate two transitions by hand.
+        base = {
+            "ticket_id": "tkt-1",
+            "message_id": "mid-1",
+            "to_lane": "author-b",
+            "message_type": "blocker",
+            "priority": "high",
+            "created_at": "2026-04-20T18:00:00+00:00",
+            "next_retry_at": "2026-04-20T18:00:00+00:00",
+            "last_reason": "new_ticket",
+        }
+        with open(state.tickets_file, "w") as f:
+            f.write(json.dumps({**base, "status": "pending", "attempts": 0}) + "\n")
+            f.write(json.dumps({**base, "status": "nudged", "attempts": 1}) + "\n")
+        tickets = load_tickets(state)
+        assert set(tickets.keys()) == {"tkt-1"}
+        assert tickets["tkt-1"].status == "nudged"
+        assert tickets["tkt-1"].attempts == 1
+
+
+class TestStatusSurface:
+    """get_status() produces a readable operator snapshot."""
+
+    def test_status_reports_no_broker_on_fresh_tree(self, runtime_dir: Path) -> None:
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.alive is False
+        assert status.pid is None
+        assert status.pending_count == 0
+        assert status.nudged_count == 0
+        assert status.abandoned_count == 0
+
+    def test_status_reports_pending_after_busy_cycle(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_busy_pane,
+            nudge_fn=_record_nudge_fn([]),
+        )
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.pending_count == 1
+        assert status.nudged_count == 0
+
+    def test_status_reports_nudged_after_safe_cycle(self, runtime_dir: Path) -> None:
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="escalation")],
+        )
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn([]),
+        )
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.pending_count == 0
+        assert status.nudged_count == 1
+
+    def test_status_last_cycle_round_trips(self, runtime_dir: Path) -> None:
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn([]),
+        )
+        status = get_status(runtime_dir=runtime_dir)
+        assert status.last_cycle is not None
+        assert "timestamp" in status.last_cycle
+        assert status.last_cycle["nudged"] == 0
+
+
+class TestCursorTruncation:
+    """Safety net when events.jsonl is rotated / truncated."""
+
+    def test_cursor_resets_when_file_shrinks(self, runtime_dir: Path) -> None:
+        """If events.jsonl is truncated below the cursor, we restart from 0."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        events_file = runtime_dir / "events" / "events.jsonl"
+        events_file.write_text("x" * 10_000)
+        write_cursor(state, 9_000)
+        # Truncate.
+        events_file.write_text("")
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        nudged: list[str] = []
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+        )
+        assert nudged == ["author-b"]
+
+
+class TestDeferredTicketSerialization:
+    """Direct round-trip tests for DeferredTicket.to_json / from_json."""
+
+    def test_round_trip(self) -> None:
+        ticket = DeferredTicket(
+            ticket_id="tkt-abc",
+            message_id="mid-1",
+            to_lane="author-b",
+            message_type="blocker",
+            priority="urgent",
+            created_at="2026-04-20T18:00:00+00:00",
+            next_retry_at="2026-04-20T18:00:10+00:00",
+            attempts=1,
+            last_reason="deferred:active_work_detected",
+            status="pending",
+        )
+        roundtripped = DeferredTicket.from_json(ticket.to_json())
+        assert roundtripped == ticket


### PR DESCRIPTION
## Summary

PR-MSG-4 — the larger optional follow-on in the messaging revamp chain
after PR-MSG-1 (#2670), PR-MSG-2 (#2671), and PR-MSG-3 (#2669).

Adds a background **attention broker daemon** that watches
``.claude/runtime/events/events.jsonl`` for ``message_sent`` events and
nudges the recipient lane only when the pane looks safe to poke.  Where
PR-MSG-2's immediate-send policy fires-and-forgets a nudge at call
time, this daemon is the safety net for the case where the recipient
is actively working (spinner, validation process, approval prompt) and
a blind ``tmux send-keys`` would collide with that work.

## Plan

[PR-MSG-4 design](plans/sessions/2026-04-20_messaging-revamp-execution-plan.md) — messaging revamp execution plan § PR-MSG-4.

### Architecture
- ``message_bus`` stays durable-only.  No tmux coupling added to
  ``send_message`` — the bus boundary invariant is preserved.
- Broker lives in ``src/bid_euchre/ops/attention.py``, alongside the
  PR-MSG-2 delivery-policy helpers.  ``attention → monitor/worker_pool``
  imports match the existing layering (no new cycles).
- State rooted at ``.claude/runtime/attention_broker/``:
  - ``pid`` — pidfile with liveness check (one daemon per repo).
  - ``cursor.json`` — byte-offset tail position into events.jsonl.
  - ``deferred_tickets.jsonl`` — append-only ticket transitions.
    Last entry per ``ticket_id`` wins on replay.
  - ``last_cycle.json`` — per-cycle summary for ``attention status``.
  - ``FAILED`` — optional failure sentinel, surfaced by
    ``post-tool-daemon-notify.sh``.

### Exactly-once semantics
The cycle ordering makes crash-restart safe:

1. Load current ticket state from the durable log.
2. Tail new events from the persisted cursor.
3. Append initial ``pending`` tickets for each nudge-worthy event.
4. Advance the cursor **after** tickets are persisted.
5. Evaluate every pending ticket.

On crash-restart, events before the cursor are never re-read, and
tickets survive via JSONL replay.  Dedup on ``message_id`` protects
against cursor-advance races.

### Retry budget
Busy panes defer on a bounded schedule: 10s → 30s → 90s → abandon
(``MAX_ATTEMPTS = 4``).  A persistently-busy lane cannot pin a ticket
forever.

### CLI
```
ops.py attention once                      # one cycle (ingest + evaluate)
ops.py attention run --interval 3          # long-running daemon
ops.py attention status                    # operator snapshot
ops.py --json attention status             # JSON format
```

### Autostart
- ``.claude/hooks/attention-broker-autostart.sh`` — SessionStart hook.
  Pidfile-guarded pre-check + daemon-level ``acquire_pidfile`` handle
  the session-start race.  Opt-out via ``attention_broker/disabled``
  sentinel.  Uses ``trap 'exit 0' ERR`` so a hook failure never
  zero-tokens a session.
- ``.claude/settings.json`` — registers the new SessionStart hook.
- ``.claude/hooks/post-tool-daemon-notify.sh`` — surfaces the
  ``attention_broker/FAILED`` sentinel in the same way as the CI
  poller and review-loop daemons.

## Worktree proof
```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git worktree list | head -1
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
```

## Repro / Validation

```bash
# Unit + integration tests (80 passed locally)
uv run python -m pytest tests/unit/test_ops_attention.py \
  tests/integration/test_attention_broker.py

# Smoke CLI against an isolated runtime dir
mkdir -p /tmp/attn-smoke/.claude/runtime/events
touch /tmp/attn-smoke/.claude/runtime/events/events.jsonl
cd /tmp/attn-smoke && uv run python scripts/internal/ops.py attention once
uv run python scripts/internal/ops.py attention status
uv run python scripts/internal/ops.py --json attention status

# Tier 2 full validation
make check-gated   # ✓ All checks passed
```

## Tests

- ``tests/unit/test_ops_attention.py`` — adds 9 new test classes covering:
  - ``AttentionState`` filesystem layout
  - Pidfile guard (empty, stale, garbage, live, release, roundtrip)
  - Cursor resume (default, roundtrip, malformed file, advance,
    no-replay on restart)
  - Safe/busy/missing pane decisions, self-loop filter,
    non-nudge-type skip
  - Deferred ticket transitions (busy→safe nudge-once, retry-before-
    window no-op, exhausted-retries abandon, dedup on duplicate
    message_id, ``pending_tickets`` helper)
  - Ticket persistence (JSONL records each transition, load replay
    uses last entry per id)
  - Status surface (no-broker, pending, nudged, last-cycle round-trip)
  - Cursor truncation reset, ticket serialization round-trip
- ``tests/integration/test_attention_broker.py`` — end-to-end scenarios
  driving real ``send_message`` → real ``events.jsonl`` → ``run_once`` →
  durable ticket log:
  - **Busy→idle nudge-exactly-once** (headline invariant)
  - Crash-restart preserves state without double-nudging
  - Persistently-busy lane abandons after ``MAX_ATTEMPTS``
  - Progress messages create no ticket (non-nudge-worthy)
  - Self-addressed blocker is filtered (bus audit echo guard)
  - Two blockers → two tickets → two distinct nudges
  - Pidfile lifecycle visible to ``get_status`` (live vs. stale PID)
  - ``send_message`` sanity-check emits the expected event line

## Scope
Files declared in the task packet, all touched:
- ``src/bid_euchre/ops/attention.py`` (+931)
- ``scripts/internal/ops.py`` (+118)
- ``tests/unit/test_ops_attention.py`` (+631)
- ``tests/integration/test_attention_broker.py`` (new, +503)
- ``.claude/hooks/attention-broker-autostart.sh`` (new, +78)
- ``.claude/hooks/post-tool-daemon-notify.sh`` (+11)
- ``.claude/settings.json`` (+9)

## Test plan
- [x] Tier 1 unit + integration tests pass (80/80)
- [x] Smoke CLI in an isolated runtime dir (``once`` + ``status``)
- [x] Tier 2 ``make check-gated`` passes
- [x] Autostart hook exits 0 on pre-existing broker / no-uv / healthy
      launch paths
- [ ] Operator proving: observe at least one ``blocker`` nudge cycle
      from a real lane interaction before promoting out of
      best-effort-mode

## Task packet
``741591219142`` (PR-MSG-4 attention broker daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)