### PR TITLE
feat(ops): PermissionDenied alert hook for classifier denial visibility

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -122,6 +122,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$CLAUDE_PROJECT_DIR\"/scripts/internal/hooks/permission_denied_alert.sh'",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -165,6 +175,8 @@
       "Write(.claude/settings.json)",
       "Edit(.claude/hooks/**)",
       "Write(.claude/hooks/**)",
+      "Edit(.claude/runtime/classifier_denials/**)",
+      "Write(.claude/runtime/classifier_denials/**)",
       "Edit(MEMORY.md)",
       "Write(MEMORY.md)",
       "Edit(plans/**)",

--- a/scripts/internal/hooks/permission_denied_alert.sh
+++ b/scripts/internal/hooks/permission_denied_alert.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# permission_denied_alert.sh — escalate auto-mode classifier denials to ops.
+#
+# Companion to .claude/hooks/permission-denied-log.sh. The log hook provides
+# historical JSONL for observation; this hook converts a live denial into an
+# operator-visible escalation so unattended fleet lanes do not silently stall
+# on Sonnet 4.6 classifier blocks.
+#
+# Context: PR #2675 switched fleet defaultMode from bypassPermissions to
+# "auto" (classifier-gated). When the classifier blocks a tool call it emits
+# a PermissionDenied event. The Claude Code UI shows a "Recently denied" tab
+# with a manual retry key, but that UX assumes an operator is watching —
+# useless for the autonomous fleet overnight.
+#
+# Behavior:
+#   1. Reads JSON denial payload from stdin (best-effort parse).
+#   2. Derives lane id from $CLAUDE_AGENT_NAME or $CLAUDE_PROJECT_DIR
+#      (falls back to hostname — never crashes).
+#   3. Sends an escalation message to the ops lane via ops.py message send
+#      (best-effort; swallowed if ops.py is unavailable).
+#   4. Appends a JSONL record to
+#      .claude/runtime/classifier_denials/YYYY-MM-DD.jsonl with fields:
+#      {ts, lane, tool, rule, message}. This schema is a contract with
+#      future observation tooling — treat changes as breaking.
+#
+# Safety:
+#   - Always exits 0. Hook must never block the lane.
+#   - All subshells and writes are wrapped in `|| true`.
+#   - Message body is truncated to 200 chars to avoid oversized messages.
+#
+# Refs: #2249 (self-modification gating), #2238 (review-lane permission stalls)
+set -u  # -e deliberately omitted so partial failures never block the lane
+
+MAX_MESSAGE_LEN=200
+
+# ---------------------------------------------------------------------------
+# Step 1 — parse stdin defensively
+# ---------------------------------------------------------------------------
+INPUT=$(cat 2>/dev/null || echo "")
+
+# Extract fields, tolerating missing keys, malformed JSON, and empty input.
+# Accept multiple schema variants:
+#   - task packet spec: {tool_name, rule_matched, message}
+#   - observed Claude Code payload: {tool_name, reason, tool_input, session_id}
+TOOL_NAME="unknown"
+RULE="unknown"
+MESSAGE=""
+if [ -n "$INPUT" ]; then
+  TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  RULE=$(printf '%s' "$INPUT" | jq -r '.rule_matched // .reason // "unknown"' 2>/dev/null || echo "unknown")
+  MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // .reason // ""' 2>/dev/null || echo "")
+fi
+
+# Normalize "null" → "unknown"/"" and guard against jq printing literal null
+[ "$TOOL_NAME" = "null" ] && TOOL_NAME="unknown"
+[ "$RULE" = "null" ] && RULE="unknown"
+[ "$MESSAGE" = "null" ] && MESSAGE=""
+
+# Truncate message body to MAX_MESSAGE_LEN chars
+if [ ${#MESSAGE} -gt $MAX_MESSAGE_LEN ]; then
+  MESSAGE="${MESSAGE:0:$MAX_MESSAGE_LEN}..."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — derive lane id
+# ---------------------------------------------------------------------------
+LANE=""
+if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
+  LANE=$(printf '%s' "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+  DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR" 2>/dev/null || echo "")
+  case "$DIR_NAME" in
+    *steward-author-scratch) LANE="author-scratch" ;;
+    *steward-author-b)       LANE="author-b" ;;
+    *steward-author-c)       LANE="author-c" ;;
+    *steward-author-d)       LANE="author-d" ;;
+    *steward-author)         LANE="author-a" ;;
+    *steward-brws-author-a)  LANE="brws-author-a" ;;
+    *steward-brws-author-b)  LANE="brws-author-b" ;;
+    *steward-brws-author-c)  LANE="brws-author-c" ;;
+    *steward-brws-author-d)  LANE="brws-author-d" ;;
+    *steward-analyst-b)      LANE="analyst-b" ;;
+    *steward-analyst-c)      LANE="analyst-c" ;;
+    *steward-analyst-d)      LANE="analyst-d" ;;
+    *steward-analyst)        LANE="analyst-a" ;;
+    *steward-flex-a)         LANE="flex-a" ;;
+    *steward-flex-b)         LANE="flex-b" ;;
+    *steward-flex-c)         LANE="flex-c" ;;
+    *steward-flex-d)         LANE="flex-d" ;;
+    *steward-review)         LANE="review" ;;
+    *steward-ops)            LANE="ops" ;;
+    Bid-Euchre)              LANE="main" ;;
+    *)                       LANE=$(printf '%s' "$DIR_NAME" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/') ;;
+  esac
+fi
+# Final fallback: hostname. Never let LANE be empty.
+if [ -z "$LANE" ]; then
+  LANE=$(hostname 2>/dev/null || echo "unknown")
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — append JSONL record to dated denials log
+# ---------------------------------------------------------------------------
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+DATE_STAMP=$(date -u +"%Y-%m-%d" 2>/dev/null || echo "unknown-date")
+
+LOG_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/runtime/classifier_denials"
+LOG_FILE="$LOG_DIR/${DATE_STAMP}.jsonl"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+# Build record with jq for proper JSON encoding; fall back to hand-rolled JSON
+# if jq is missing or fails.
+RECORD=$(jq -nc \
+  --arg ts "$TIMESTAMP" \
+  --arg lane "$LANE" \
+  --arg tool "$TOOL_NAME" \
+  --arg rule "$RULE" \
+  --arg message "$MESSAGE" \
+  '{ts: $ts, lane: $lane, tool: $tool, rule: $rule, message: $message}' \
+  2>/dev/null) || RECORD=""
+
+if [ -z "$RECORD" ]; then
+  # Hand-rolled fallback (escape backslashes + double quotes only)
+  _esc() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+  }
+  RECORD=$(printf '{"ts":"%s","lane":"%s","tool":"%s","rule":"%s","message":"%s"}' \
+    "$(_esc "$TIMESTAMP")" \
+    "$(_esc "$LANE")" \
+    "$(_esc "$TOOL_NAME")" \
+    "$(_esc "$RULE")" \
+    "$(_esc "$MESSAGE")")
+fi
+
+printf '%s\n' "$RECORD" >> "$LOG_FILE" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Step 4 — send ops escalation (best-effort)
+# ---------------------------------------------------------------------------
+# Use --no-nudge by default to avoid racing with the lane that just emitted
+# the denial; ops receives via inbox poll within its normal monitoring cycle.
+SUMMARY="Classifier denial: ${TOOL_NAME} blocked by ${RULE}"
+if [ ${#SUMMARY} -gt 250 ]; then
+  SUMMARY="${SUMMARY:0:250}..."
+fi
+
+if command -v uv >/dev/null 2>&1; then
+  (
+    cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+    uv run python scripts/internal/ops.py message send \
+      --from "$LANE" \
+      --to ops \
+      --type escalation \
+      --summary "$SUMMARY" \
+      --priority high \
+      --no-nudge \
+      >/dev/null 2>&1
+  ) || true
+fi
+
+# Return hook response and always exit 0.
+printf '%s\n' '{"hookSpecificOutput": {"hookEventName": "PermissionDenied", "retry": false}}'
+exit 0

--- a/tests/fixtures/classifier_denial_sample.json
+++ b/tests/fixtures/classifier_denial_sample.json
@@ -1,0 +1,9 @@
+{
+  "tool_name": "Bash",
+  "rule_matched": "Self-Modification",
+  "message": "Attempted to edit ~/.claude/settings.json without explicit User Intent override",
+  "session_id": "test-session-abc123",
+  "tool_input": {
+    "command": "echo 'x' >> ~/.claude/settings.json"
+  }
+}

--- a/tests/unit/hooks/__init__.py
+++ b/tests/unit/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Hook script unit tests."""

--- a/tests/unit/hooks/test_permission_denied_alert.py
+++ b/tests/unit/hooks/test_permission_denied_alert.py
@@ -1,0 +1,270 @@
+"""Unit tests for scripts/internal/hooks/permission_denied_alert.sh.
+
+The hook fires on PermissionDenied events emitted by the Sonnet 4.6 auto-mode
+classifier (Claude Code v2.1.89+). It converts a classifier denial into:
+  - an ops-lane escalation message (via ops.py message send)
+  - a JSONL audit record under .claude/runtime/classifier_denials/YYYY-MM-DD.jsonl
+
+Tests cover:
+  - Happy path (fixture → escalation invoked, JSONL record with expected schema).
+  - Empty stdin (exit 0, no crash).
+  - Malformed JSON stdin (exit 0, no crash).
+  - Message truncation for oversized payloads.
+  - Lane fallback when env vars are unset.
+
+The ops.py invocation is mocked by prepending a directory with a stub `uv`
+shim to PATH. The stub records the argv it received so we can assert the
+expected flags (--from, --to ops, --type escalation, --summary).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HOOK_SH = REPO_ROOT / "scripts" / "internal" / "hooks" / "permission_denied_alert.sh"
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "classifier_denial_sample.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_mock_uv(bin_dir: Path, capture_file: Path) -> Path:
+    """Write a mock `uv` executable to bin_dir that records argv to capture_file.
+
+    The hook invokes: `uv run python scripts/internal/ops.py message send ...`.
+    The mock records the full argv then exits 0, which simulates a successful
+    ops.py call without actually sending a message.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "uv"
+    shim.write_text(
+        "#!/usr/bin/env bash\n" f'printf "%s\\n" "$@" >> "{capture_file}"\n' "exit 0\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return shim
+
+
+def _run_hook(
+    tmp_path: Path,
+    *,
+    stdin_payload: str,
+    lane_env: str | None = "author-b",
+    project_dir: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    """Run the hook with a controlled PATH, env, and CLAUDE_PROJECT_DIR.
+
+    Returns (completed_process, uv_capture_path, project_dir) so callers can
+    assert on the JSONL log contents and the ops.py argv.
+    """
+    project_dir = project_dir or tmp_path / "project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir = tmp_path / "bin"
+    uv_capture = tmp_path / "uv_argv.log"
+    _write_mock_uv(bin_dir, uv_capture)
+
+    # Keep the minimal PATH the hook needs (jq, sed, date, bash builtins, the
+    # mock uv). Use /usr/bin + /bin for coreutils and prepend bin_dir so the
+    # stub is picked up instead of any real uv on the system.
+    env: dict[str, str] = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+    }
+    if lane_env is not None:
+        env["CLAUDE_AGENT_NAME"] = f"steward-{lane_env}"
+
+    result = subprocess.run(
+        ["bash", str(HOOK_SH)],
+        input=stdin_payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result, uv_capture, project_dir
+
+
+def _read_denial_record(project_dir: Path) -> dict:
+    """Find today's JSONL file and return the first record as a dict."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    log = project_dir / ".claude" / "runtime" / "classifier_denials" / f"{today}.jsonl"
+    assert log.exists(), f"expected JSONL log at {log}"
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert lines, f"JSONL log at {log} was empty"
+    return json.loads(lines[-1])
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    """Fixture input produces escalation + JSONL record."""
+
+    def test_hook_exits_zero_with_fixture(self, tmp_path: Path) -> None:
+        payload = FIXTURE.read_text(encoding="utf-8")
+        result, _, _ = _run_hook(tmp_path, stdin_payload=payload)
+        assert result.returncode == 0, result.stderr
+
+    def test_jsonl_record_has_expected_fields(self, tmp_path: Path) -> None:
+        payload = FIXTURE.read_text(encoding="utf-8")
+        _, _, project_dir = _run_hook(tmp_path, stdin_payload=payload)
+        record = _read_denial_record(project_dir)
+        # Schema contract — treat changes as breaking (see hook docstring).
+        assert set(record.keys()) == {"ts", "lane", "tool", "rule", "message"}
+        assert record["tool"] == "Bash"
+        assert record["rule"] == "Self-Modification"
+        assert "settings.json" in record["message"]
+        assert record["lane"] == "author-b"
+        # ts should be ISO-8601 UTC
+        assert record["ts"].endswith("Z")
+
+    def test_ops_message_send_invoked(self, tmp_path: Path) -> None:
+        payload = FIXTURE.read_text(encoding="utf-8")
+        _, uv_capture, _ = _run_hook(tmp_path, stdin_payload=payload)
+        assert uv_capture.exists(), "mock uv was not invoked"
+        argv = uv_capture.read_text(encoding="utf-8").splitlines()
+        # Expect: run python scripts/internal/ops.py message send --from <lane>
+        #         --to ops --type escalation --summary ... --priority high --no-nudge
+        assert argv[:2] == ["run", "python"], argv
+        assert "scripts/internal/ops.py" in argv[2]
+        assert "message" in argv
+        assert "send" in argv
+        assert "--from" in argv
+        assert argv[argv.index("--from") + 1] == "author-b"
+        assert "--to" in argv
+        assert argv[argv.index("--to") + 1] == "ops"
+        assert "--type" in argv
+        assert argv[argv.index("--type") + 1] == "escalation"
+        # Summary must name the tool and the rule
+        summary = argv[argv.index("--summary") + 1]
+        assert "Bash" in summary
+        assert "Self-Modification" in summary
+
+
+# ---------------------------------------------------------------------------
+# Defensive input handling
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveStdin:
+    """Hook must exit 0 regardless of stdin shape — never block the lane."""
+
+    def test_empty_stdin_exits_zero(self, tmp_path: Path) -> None:
+        result, _, project_dir = _run_hook(tmp_path, stdin_payload="")
+        assert result.returncode == 0, result.stderr
+        # A record is still written with tool="unknown" / rule="unknown"
+        record = _read_denial_record(project_dir)
+        assert record["tool"] == "unknown"
+        assert record["rule"] == "unknown"
+
+    def test_malformed_json_exits_zero(self, tmp_path: Path) -> None:
+        result, _, project_dir = _run_hook(tmp_path, stdin_payload="not json")
+        assert result.returncode == 0, result.stderr
+        record = _read_denial_record(project_dir)
+        assert record["tool"] == "unknown"
+        assert record["rule"] == "unknown"
+
+    def test_partial_json_missing_keys_exits_zero(self, tmp_path: Path) -> None:
+        result, _, project_dir = _run_hook(
+            tmp_path, stdin_payload=json.dumps({"tool_name": "Edit"})
+        )
+        assert result.returncode == 0, result.stderr
+        record = _read_denial_record(project_dir)
+        assert record["tool"] == "Edit"
+        assert record["rule"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Message truncation
+# ---------------------------------------------------------------------------
+
+
+class TestMessageTruncation:
+    """Oversized message fields are truncated to keep JSONL + ops args small."""
+
+    def test_long_message_is_truncated(self, tmp_path: Path) -> None:
+        long_msg = "A" * 500
+        payload = json.dumps(
+            {
+                "tool_name": "Bash",
+                "rule_matched": "TestRule",
+                "message": long_msg,
+            }
+        )
+        _, _, project_dir = _run_hook(tmp_path, stdin_payload=payload)
+        record = _read_denial_record(project_dir)
+        assert len(record["message"]) < len(long_msg), record["message"]
+        assert record["message"].endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# Lane derivation
+# ---------------------------------------------------------------------------
+
+
+class TestLaneDerivation:
+    """Lane id falls back gracefully when env vars are missing."""
+
+    def test_lane_from_project_dir_when_agent_name_unset(self, tmp_path: Path) -> None:
+        # Simulate the author-b worktree layout
+        project_dir = tmp_path / "Bid-Euchre-steward-author-b"
+        project_dir.mkdir()
+        result, _, _ = _run_hook(
+            tmp_path,
+            stdin_payload=FIXTURE.read_text(encoding="utf-8"),
+            lane_env=None,
+            project_dir=project_dir,
+        )
+        assert result.returncode == 0
+        record = _read_denial_record(project_dir)
+        assert record["lane"] == "author-b"
+
+    def test_lane_falls_back_to_nonempty_string(self, tmp_path: Path) -> None:
+        # Unknown project dir shape + no CLAUDE_AGENT_NAME → hostname fallback
+        project_dir = tmp_path / "unrecognized-layout"
+        project_dir.mkdir()
+        result, _, _ = _run_hook(
+            tmp_path,
+            stdin_payload=FIXTURE.read_text(encoding="utf-8"),
+            lane_env=None,
+            project_dir=project_dir,
+        )
+        assert result.returncode == 0
+        record = _read_denial_record(project_dir)
+        # Must never be empty (would break ops.py --from validation)
+        assert record["lane"], record
+
+
+# ---------------------------------------------------------------------------
+# Executable bit (smoke)
+# ---------------------------------------------------------------------------
+
+
+def test_hook_script_is_executable() -> None:
+    assert HOOK_SH.exists(), HOOK_SH
+    mode = HOOK_SH.stat().st_mode
+    assert mode & stat.S_IXUSR, f"hook script not executable: {oct(mode)}"
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="Fixture shape sanity — skipped in CI to avoid duplicate coverage",
+)
+def test_fixture_is_valid_json() -> None:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    # Required fields per the packet's declared schema
+    assert "tool_name" in data
+    assert "rule_matched" in data
+    assert "message" in data


### PR DESCRIPTION
## Summary

- New `scripts/internal/hooks/permission_denied_alert.sh` converts Sonnet 4.6
  auto-mode classifier denials into operator-visible ops escalations and a
  dated JSONL audit log, so unattended fleet lanes no longer silently stall
  overnight.
- Wires the hook into `.claude/settings.json` as a second `PermissionDenied`
  entry (coexists with the existing observability logger
  `.claude/hooks/permission-denied-log.sh`); adds two
  `permissions.allow` entries for the new runtime subdirectory.
- Tests in `tests/unit/hooks/` cover the happy path, empty stdin, malformed
  JSON, oversized message truncation, and the lane-id fallback chain. The
  `uv`/`ops.py` invocation is mocked via a PATH shim that records argv.

## Why

PR #2675 (merged 2026-04-20) switched `permissions.defaultMode` from
`bypassPermissions` to `"auto"`. When the classifier blocks a tool call it
emits a `PermissionDenied` event. The Claude Code UI shows a "Recently
denied" tab with a manual retry key, but that UX assumes an operator is
watching — useless for the autonomous fleet overnight. Without this hook,
unattended lanes silently stall on classifier blocks with no operator
visibility.

Refs #2249 (self-modification gating story), Refs #2238 (review-lane
permission stalls, which this also helps surface).

## Repro / Validation Performed

```bash
# Hook smoke tests (from repo root)
bash scripts/internal/hooks/permission_denied_alert.sh < tests/fixtures/classifier_denial_sample.json  # exit 0
bash scripts/internal/hooks/permission_denied_alert.sh < /dev/null                                    # exit 0 (empty stdin)
echo 'not json' | bash scripts/internal/hooks/permission_denied_alert.sh                              # exit 0 (malformed)

# JSON syntax check
jq . .claude/settings.json > /dev/null

# Hook-specific unit tests — 11 passed in 2.45s
uv run python -m pytest tests/unit/hooks/ -v

# Lint
make lint                                                                                              # passes

# Tier 2
make check-gated                                                                                       # ✓ All checks passed
```

During the shell smoke tests above, the live hook appended three JSONL
records under `.claude/runtime/classifier_denials/2026-04-20.jsonl` and
posted three escalations into the ops lane inbox (which I then acked to
avoid distracting the orchestrator). This is concrete evidence of the
round-trip working end-to-end — hook output → JSONL audit → ops-lane
escalation — before any real classifier denial has fired in the fleet.

## Manual Verification Instructions (Operator)

To simulate a denial manually, open an author-scratch session and attempt
a command that soft-denies under default classifier rules (e.g.
`git push --force` without User Intent override). Observe the resulting
escalation message in the ops inbox within ~2 seconds:

```bash
uv run python scripts/internal/ops.py inbox --lane ops --type escalation
```

Expected: a `high` priority escalation with summary
`"Classifier denial: <tool> blocked by <rule>"` sourced from the lane that
hit the denial. A matching JSONL record should appear under
`.claude/runtime/classifier_denials/<today>.jsonl`.

## Log Schema — Contract with Future Observation Tooling

The hook writes JSONL records with exactly these fields:
`{ts, lane, tool, rule, message}`. This schema is the contract future
observation tooling (e.g. the denial dashboard, held back until real data
exists) will consume. **Treat any changes to field names or types as
breaking** and coordinate with the observation tool roadmap before
modifying.

## Out of Scope (per task packet)

- Denial observation dashboard — held until real data accumulates.
- Custom `autoMode.allow` rules — also held pending observation data.
- `MEMORY.md` update for PR #2675 — separate trivial task.
- No changes to `defaultMode`, `autoMode.environment`, or user-scope
  `~/.claude/settings.json`.

## Tests

Tier 1: `uv run python -m pytest tests/unit/hooks/ -v` — 11 passed.
Tier 2: `make check-gated` — ✓ All checks passed.

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
branch: ops/permission-denied-alert-hook (tracked origin/main)
```

Authored by the **author-b** lane under auto-mode classifier gating. The
classifier permitted the required edits to `.claude/settings.json` once
this packet's description named the exact change — no
`--dangerously-skip-permissions` or `bypassPermissions` override used.

Refs #2249, Refs #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)