### PR TITLE
fix(ops): add compaction to attention-broker deferred_tickets log (#2674)

### DIFF
--- a/src/bid_euchre/ops/attention.py
+++ b/src/bid_euchre/ops/attention.py
@@ -222,54 +222,18 @@ _DEFAULT_CYCLE_INTERVAL_SECONDS: float = 3.0
 #: Events that carry the (message_type, priority, to_lane) tuple we need.
 _BROKER_EVENT_TYPE: str = "message_sent"
 
-# ---------------------------------------------------------------------------
-# Compaction policy (see `compact_tickets` below and issue #2674).
-# ---------------------------------------------------------------------------
-# ``deferred_tickets.jsonl`` is append-only during normal operation: every
-# ticket state transition writes one line.  Without a bounded retention
-# policy the log grows linearly with message volume — MBs per week at fleet
-# scale — and ``load_tickets`` re-parses the entire file on every 3s cycle.
-#
-# Compaction rewrites the log to keep:
-#   - every non-terminal ticket (pending), and
-#   - terminal tickets (nudged / abandoned) within a bounded retention
-#     window, to preserve dedup against events.jsonl replay races.
-#
-# Trigger choice (size-based, not time-based):
-#   The ~3s ``run_once`` cadence makes time-based triggers noisy; a
-#   byte-size gate is a single ``stat()`` call per cycle and fires only
-#   when the file has actually grown.  ``COMPACTION_MIN_BYTES`` is picked
-#   so a fresh broker can ingest hundreds of tickets before the first
-#   rewrite, and each rewrite meaningfully shrinks the file.
-#
-# Retention window choice (24h + hard cap):
-#   The dedup safety net only matters while events.jsonl may re-emit a
-#   message_id we've already processed.  Events the broker has crossed are
-#   past the persistent cursor; the only re-emit path is cursor reset
-#   after file rotation, which the broker defends against by restarting
-#   the cursor at 0.  A 24h retention window is multiple orders of
-#   magnitude wider than any realistic cursor-reset window and caps the
-#   retained terminal set at a bounded count so a single burst of traffic
-#   can't defeat the size gate.
-#
-# These constants are module-level so tests can ``monkeypatch`` them to
-# exercise the compaction path on tiny fixtures without synthesizing MBs
-# of ticket history.
+# Compaction tunables.  See `compact_tickets` docstring for policy rationale
+# (trigger choice, retention window, dedup safety).  These live at module
+# scope so tests can `monkeypatch.setattr` them without threading kwargs.
 
 #: Size gate: compaction is a no-op until the ticket log exceeds this many
-#: bytes.  50KB comfortably holds ~250 ticket transitions (avg ~200 bytes
-#: per line after JSON-encoding), so fresh brokers never pay the rewrite
-#: cost and busy brokers compact every few minutes of steady-state.
+#: bytes.  50KB ≈ 250 ticket transitions at the observed ~200-byte line size.
 COMPACTION_MIN_BYTES: int = 50_000
 
-#: Terminal retention window — keep nudged/abandoned tickets whose
-#: ``created_at`` falls within the last N hours.  Preserves dedup against
-#: short-window event replay without unbounded growth.
+#: Retention window for terminal tickets (nudged / abandoned), in hours.
 COMPACTION_TERMINAL_RETENTION_HOURS: float = 24.0
 
-#: Hard ceiling on retained terminal tickets regardless of the time
-#: window.  Protects against a single traffic burst (e.g., thousands of
-#: blocker messages in one hour) defeating the size gate.
+#: Hard ceiling on retained terminal tickets regardless of the time window.
 COMPACTION_TERMINAL_RETENTION_MAX: int = 500
 
 
@@ -542,20 +506,41 @@ def compact_tickets(
     retention_hours: float = COMPACTION_TERMINAL_RETENTION_HOURS,
     retention_max: int = COMPACTION_TERMINAL_RETENTION_MAX,
 ) -> int:
-    """Rewrite ``deferred_tickets.jsonl`` to a bounded, compact form.
+    """Rewrite ``deferred_tickets.jsonl`` to a bounded, compact form (issue #2674).
 
-    Two sources of savings:
+    **Why compaction exists.**  ``deferred_tickets.jsonl`` is append-only
+    during normal operation: every ticket state transition writes one
+    line.  Without a bounded retention policy the log grows linearly with
+    message volume (MBs/week at fleet scale) and ``load_tickets`` re-
+    parses the entire file on every 3s cycle.  Compaction keeps the log
+    small enough that re-parse cost is bounded.
 
-    1. **Per-ticket history collapse.**  During normal operation each
-       ticket writes one line per state transition (pending -> deferred
-       (pending) -> nudged/abandoned).  ``load_tickets`` already keeps
-       only the last entry per ticket_id; compaction materializes that
-       collapsed view back to disk.
-    2. **Terminal retention window.**  Terminal tickets (``nudged`` /
+    **Two sources of savings:**
+
+    1. Per-ticket history collapse.  During normal operation each ticket
+       writes one line per state transition (pending -> deferred (still
+       pending) -> nudged/abandoned).  ``load_tickets`` already keeps
+       only the last entry per ``ticket_id``; compaction materializes
+       that collapsed view back to disk.
+    2. Terminal retention window.  Terminal tickets (``nudged`` /
        ``abandoned``) older than ``retention_hours`` are dropped.  All
        non-terminal tickets (``pending``) are preserved unconditionally.
        The retained terminal set is also capped at ``retention_max`` so a
        traffic burst within the window cannot defeat the size gate.
+
+    **Trigger choice — size-based, not time-based.**  The ~3s
+    ``run_once`` cadence makes time-based triggers noisy; a byte-size
+    gate is a single ``stat()`` call per cycle and fires only when the
+    file has actually grown.  See ``COMPACTION_MIN_BYTES``.
+
+    **Retention window choice — 24h plus hard cap.**  The dedup safety
+    net only matters while ``events.jsonl`` may re-emit a ``message_id``
+    we've already processed.  Events past the persistent cursor are
+    normally gone; the only re-emit path is cursor reset after file
+    rotation, which the broker defends against by restarting the cursor
+    at 0.  A 24h retention window is multiple orders of magnitude wider
+    than any realistic cursor-reset window.  The hard cap prevents a
+    single traffic burst from defeating the size gate.
 
     **Atomic rewrite:** content is written to
     ``<tickets_file>.jsonl.tmp``, flushed + fsync'd, then ``os.replace``'d

--- a/src/bid_euchre/ops/attention.py
+++ b/src/bid_euchre/ops/attention.py
@@ -222,6 +222,56 @@ _DEFAULT_CYCLE_INTERVAL_SECONDS: float = 3.0
 #: Events that carry the (message_type, priority, to_lane) tuple we need.
 _BROKER_EVENT_TYPE: str = "message_sent"
 
+# ---------------------------------------------------------------------------
+# Compaction policy (see `compact_tickets` below and issue #2674).
+# ---------------------------------------------------------------------------
+# ``deferred_tickets.jsonl`` is append-only during normal operation: every
+# ticket state transition writes one line.  Without a bounded retention
+# policy the log grows linearly with message volume — MBs per week at fleet
+# scale — and ``load_tickets`` re-parses the entire file on every 3s cycle.
+#
+# Compaction rewrites the log to keep:
+#   - every non-terminal ticket (pending), and
+#   - terminal tickets (nudged / abandoned) within a bounded retention
+#     window, to preserve dedup against events.jsonl replay races.
+#
+# Trigger choice (size-based, not time-based):
+#   The ~3s ``run_once`` cadence makes time-based triggers noisy; a
+#   byte-size gate is a single ``stat()`` call per cycle and fires only
+#   when the file has actually grown.  ``COMPACTION_MIN_BYTES`` is picked
+#   so a fresh broker can ingest hundreds of tickets before the first
+#   rewrite, and each rewrite meaningfully shrinks the file.
+#
+# Retention window choice (24h + hard cap):
+#   The dedup safety net only matters while events.jsonl may re-emit a
+#   message_id we've already processed.  Events the broker has crossed are
+#   past the persistent cursor; the only re-emit path is cursor reset
+#   after file rotation, which the broker defends against by restarting
+#   the cursor at 0.  A 24h retention window is multiple orders of
+#   magnitude wider than any realistic cursor-reset window and caps the
+#   retained terminal set at a bounded count so a single burst of traffic
+#   can't defeat the size gate.
+#
+# These constants are module-level so tests can ``monkeypatch`` them to
+# exercise the compaction path on tiny fixtures without synthesizing MBs
+# of ticket history.
+
+#: Size gate: compaction is a no-op until the ticket log exceeds this many
+#: bytes.  50KB comfortably holds ~250 ticket transitions (avg ~200 bytes
+#: per line after JSON-encoding), so fresh brokers never pay the rewrite
+#: cost and busy brokers compact every few minutes of steady-state.
+COMPACTION_MIN_BYTES: int = 50_000
+
+#: Terminal retention window — keep nudged/abandoned tickets whose
+#: ``created_at`` falls within the last N hours.  Preserves dedup against
+#: short-window event replay without unbounded growth.
+COMPACTION_TERMINAL_RETENTION_HOURS: float = 24.0
+
+#: Hard ceiling on retained terminal tickets regardless of the time
+#: window.  Protects against a single traffic burst (e.g., thousands of
+#: blocker messages in one hour) defeating the size gate.
+COMPACTION_TERMINAL_RETENTION_MAX: int = 500
+
 
 @dataclass
 class AttentionState:
@@ -469,6 +519,164 @@ def load_tickets(state: AttentionState) -> dict[str, DeferredTicket]:
 def pending_tickets(state: AttentionState) -> list[DeferredTicket]:
     """Return only tickets whose current status is ``pending``."""
     return [t for t in load_tickets(state).values() if t.status == "pending"]
+
+
+# ---------------------------------------------------------------------------
+# Compaction (see module-level constants for policy rationale)
+# ---------------------------------------------------------------------------
+
+
+def _count_nonblank_lines(path: Path) -> int:
+    """Cheap line count.  Returns 0 for a missing file."""
+    try:
+        text = path.read_text()
+    except (FileNotFoundError, OSError):
+        return 0
+    return sum(1 for line in text.splitlines() if line.strip())
+
+
+def compact_tickets(
+    state: AttentionState,
+    *,
+    now: datetime | None = None,
+    retention_hours: float = COMPACTION_TERMINAL_RETENTION_HOURS,
+    retention_max: int = COMPACTION_TERMINAL_RETENTION_MAX,
+) -> int:
+    """Rewrite ``deferred_tickets.jsonl`` to a bounded, compact form.
+
+    Two sources of savings:
+
+    1. **Per-ticket history collapse.**  During normal operation each
+       ticket writes one line per state transition (pending -> deferred
+       (pending) -> nudged/abandoned).  ``load_tickets`` already keeps
+       only the last entry per ticket_id; compaction materializes that
+       collapsed view back to disk.
+    2. **Terminal retention window.**  Terminal tickets (``nudged`` /
+       ``abandoned``) older than ``retention_hours`` are dropped.  All
+       non-terminal tickets (``pending``) are preserved unconditionally.
+       The retained terminal set is also capped at ``retention_max`` so a
+       traffic burst within the window cannot defeat the size gate.
+
+    **Atomic rewrite:** content is written to
+    ``<tickets_file>.jsonl.tmp``, flushed + fsync'd, then ``os.replace``'d
+    onto the live path.  A concurrent ``load_tickets`` will see either
+    the pre-compaction file or the post-compaction file — never a
+    partial write.
+
+    **Caller contract:** The caller holds the single-instance pidfile
+    lock (``run_daemon``) OR runs from a CLI one-shot.  Concurrent
+    writers to the same ticket log would corrupt it whether or not
+    compaction was happening; this function does not add that
+    concurrency invariant, it just does not break it.
+
+    Args:
+        state: Broker filesystem layout.
+        now: Frozen clock (tests).  Defaults to wall-clock UTC.
+        retention_hours: Keep terminal tickets whose ``created_at`` is
+            within this many hours of ``now``.
+        retention_max: Hard cap on retained terminal tickets, newest
+            first by ``created_at``.  Always applied after the time
+            window.
+
+    Returns:
+        Number of lines the rewrite removed (``existing - retained``).
+        Zero when the log is empty or already compact.
+    """
+    tickets = load_tickets(state)
+    existing_lines = _count_nonblank_lines(state.tickets_file)
+
+    if not tickets:
+        # Either the file is missing or all lines were unparseable.  Nothing
+        # to compact — avoid creating an empty file where one did not exist.
+        if existing_lines == 0:
+            return 0
+        # Parseable content produced no tickets; fall through so we still
+        # rewrite the file and drop the corrupt lines (existing_lines > 0
+        # here means malformed JSON or missing fields).
+
+    now_dt = now or _now()
+    retention_cutoff = now_dt - timedelta(hours=retention_hours)
+
+    def _created_at(ticket: DeferredTicket) -> datetime:
+        dt = _parse_iso(ticket.created_at)
+        if dt is None:
+            # Treat unparseable timestamps as epoch so they're dropped by
+            # the retention window (fail-closed).
+            return datetime.min.replace(tzinfo=timezone.utc)
+        # Tolerate tz-naive timestamps by treating them as UTC.
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    pending = [t for t in tickets.values() if t.status == "pending"]
+    terminal = [t for t in tickets.values() if t.status != "pending"]
+
+    terminal_in_window = [t for t in terminal if _created_at(t) >= retention_cutoff]
+    terminal_sorted = sorted(terminal_in_window, key=_created_at, reverse=True)
+    terminal_capped = terminal_sorted[: max(0, retention_max)]
+
+    retained = pending + terminal_capped
+
+    # Atomic rewrite — tmp → fsync → replace.
+    state.ensure_dir()
+    tmp = state.tickets_file.with_suffix(".jsonl.tmp")
+    try:
+        with open(tmp, "w") as f:
+            for ticket in retained:
+                f.write(json.dumps(ticket.to_json(), sort_keys=True) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, state.tickets_file)
+    except OSError:
+        # Best-effort cleanup of the tmp file on failure; the original
+        # live file is untouched because os.replace is atomic.
+        try:
+            tmp.unlink()
+        except (FileNotFoundError, OSError):
+            pass
+        raise
+
+    dropped = max(0, existing_lines - len(retained))
+    if dropped > 0:
+        logger.info(
+            "attention-broker compacted tickets log: %d -> %d lines "
+            "(dropped %d; pending=%d, terminal_retained=%d)",
+            existing_lines,
+            len(retained),
+            dropped,
+            len(pending),
+            len(terminal_capped),
+        )
+    return dropped
+
+
+def _compact_if_size_exceeds_threshold(
+    state: AttentionState,
+    *,
+    now: datetime | None = None,
+    min_bytes: int | None = None,
+) -> int:
+    """Size-gated compaction for the ``run_once`` hot path.
+
+    Cheap fast-path: a single ``stat()`` call per cycle.  Only when the
+    file exceeds ``min_bytes`` do we load+rewrite.  Returns the number of
+    lines dropped (0 when the gate suppressed the rewrite or the rewrite
+    found nothing to drop).
+
+    ``min_bytes`` defaults to the module-level
+    :data:`COMPACTION_MIN_BYTES` at call time (not at function-definition
+    time), so tests that ``monkeypatch.setattr`` the constant observe the
+    effect on the hot path without having to thread the kwarg through
+    ``run_once``.
+    """
+    threshold = COMPACTION_MIN_BYTES if min_bytes is None else min_bytes
+    try:
+        size = state.tickets_file.stat().st_size
+    except (FileNotFoundError, OSError):
+        return 0
+    if size < threshold:
+        return 0
+    return compact_tickets(state, now=now)
 
 
 # ---------------------------------------------------------------------------
@@ -883,6 +1091,20 @@ def run_once(
     summary.pending_after = sum(1 for t in tickets.values() if t.status == "pending")
 
     _write_status(state, summary)
+
+    # Best-effort size-gated compaction.  The gate is a single stat() call
+    # per cycle; the rewrite only fires when the ticket log has actually
+    # grown past COMPACTION_MIN_BYTES.  Failures never mask the cycle
+    # result — a compaction OSError is logged and swallowed so the bus
+    # side of the broker keeps flowing.
+    try:
+        _compact_if_size_exceeds_threshold(state, now=now_dt)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception(
+            "attention-broker compaction failed during run_once; "
+            "continuing with un-compacted log"
+        )
+
     return summary
 
 
@@ -1054,10 +1276,14 @@ def get_status(*, runtime_dir: Path | None = None) -> BrokerStatus:
 __all__ = [
     "AttentionState",
     "BrokerStatus",
+    "COMPACTION_MIN_BYTES",
+    "COMPACTION_TERMINAL_RETENTION_HOURS",
+    "COMPACTION_TERMINAL_RETENTION_MAX",
     "CycleSummary",
     "DeferredTicket",
     "MAX_ATTEMPTS",
     "acquire_pidfile",
+    "compact_tickets",
     "default_pane_state",
     "get_status",
     "load_tickets",

--- a/tests/unit/test_ops_attention.py
+++ b/tests/unit/test_ops_attention.py
@@ -32,15 +32,20 @@ import json
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from bid_euchre.ops.attention import (
+    COMPACTION_MIN_BYTES,
+    COMPACTION_TERMINAL_RETENTION_HOURS,
+    COMPACTION_TERMINAL_RETENTION_MAX,
     MAX_ATTEMPTS,
     AttentionState,
     DeferredTicket,
     acquire_pidfile,
+    compact_tickets,
     get_status,
     load_tickets,
     pending_tickets,
@@ -1121,3 +1126,387 @@ class TestDeferredTicketSerialization:
         )
         roundtripped = DeferredTicket.from_json(ticket.to_json())
         assert roundtripped == ticket
+
+
+# ---------------------------------------------------------------------------
+# Compaction — bounded ticket log (issue #2674)
+# ---------------------------------------------------------------------------
+
+
+def _write_ticket_lines(state: AttentionState, tickets: list[DeferredTicket]) -> None:
+    """Write a list of tickets as newline-delimited JSON (overwrites)."""
+    state.ensure_dir()
+    with open(state.tickets_file, "w") as f:
+        for ticket in tickets:
+            f.write(json.dumps(ticket.to_json(), sort_keys=True) + "\n")
+
+
+def _make_ticket(
+    *,
+    ticket_id: str,
+    status: str,
+    created_at: datetime,
+    message_id: str | None = None,
+    to_lane: str = "author-b",
+    message_type: str = "blocker",
+) -> DeferredTicket:
+    """Build a DeferredTicket at a specific wall-clock for retention tests."""
+    return DeferredTicket(
+        ticket_id=ticket_id,
+        message_id=message_id or f"mid-{ticket_id}",
+        to_lane=to_lane,
+        message_type=message_type,
+        priority="high",
+        created_at=created_at.isoformat(),
+        next_retry_at=created_at.isoformat(),
+        attempts=1 if status != "pending" else 0,
+        last_reason=f"test:{status}",
+        status=status,
+    )
+
+
+class TestCompaction:
+    """Issue #2674 — bounded growth for deferred_tickets.jsonl."""
+
+    def test_pending_tickets_always_preserved(self, runtime_dir: Path) -> None:
+        """Non-terminal tickets must survive compaction unconditionally,
+        even when they're far older than the terminal retention window."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        ancient = now - timedelta(days=30)
+        tickets = [
+            _make_ticket(
+                ticket_id="tkt-old-pending", status="pending", created_at=ancient
+            ),
+            _make_ticket(ticket_id="tkt-new-pending", status="pending", created_at=now),
+        ]
+        _write_ticket_lines(state, tickets)
+
+        compact_tickets(state, now=now)
+
+        reloaded = load_tickets(state)
+        assert set(reloaded.keys()) == {"tkt-old-pending", "tkt-new-pending"}
+        assert all(t.status == "pending" for t in reloaded.values())
+
+    def test_terminal_outside_window_is_dropped(self, runtime_dir: Path) -> None:
+        """Nudged/abandoned tickets older than retention_hours are removed."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        # 48h ago — outside the default 24h window.
+        old = now - timedelta(hours=48)
+        tickets = [
+            _make_ticket(ticket_id="tkt-old-nudged", status="nudged", created_at=old),
+            _make_ticket(
+                ticket_id="tkt-old-abandoned", status="abandoned", created_at=old
+            ),
+            # Recent pending: must be preserved.
+            _make_ticket(
+                ticket_id="tkt-recent-pending", status="pending", created_at=now
+            ),
+        ]
+        _write_ticket_lines(state, tickets)
+
+        compact_tickets(state, now=now)
+
+        reloaded = load_tickets(state)
+        assert "tkt-old-nudged" not in reloaded
+        assert "tkt-old-abandoned" not in reloaded
+        assert "tkt-recent-pending" in reloaded
+
+    def test_terminal_within_window_is_retained(self, runtime_dir: Path) -> None:
+        """Nudged/abandoned tickets inside the window are kept for dedup."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        # 1h ago — inside the default 24h window.
+        recent = now - timedelta(hours=1)
+        tickets = [
+            _make_ticket(
+                ticket_id="tkt-recent-nudged",
+                status="nudged",
+                created_at=recent,
+                message_id="mid-recent",
+            ),
+        ]
+        _write_ticket_lines(state, tickets)
+
+        compact_tickets(state, now=now)
+
+        reloaded = load_tickets(state)
+        assert "tkt-recent-nudged" in reloaded
+        assert reloaded["tkt-recent-nudged"].status == "nudged"
+        # Message-id dedup must still see this ticket after compaction.
+        seen_message_ids = {t.message_id for t in reloaded.values()}
+        assert "mid-recent" in seen_message_ids
+
+    def test_terminal_retention_max_caps_bulk(self, runtime_dir: Path) -> None:
+        """With retention_max=10, only the 10 newest terminals survive a
+        burst of 50 recent nudged tickets, even though all are in the
+        time window."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        base = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+
+        # 50 nudged tickets, each 1 minute apart, all within the window.
+        terminals = [
+            _make_ticket(
+                ticket_id=f"tkt-n-{i:02d}",
+                status="nudged",
+                created_at=base - timedelta(minutes=i),
+            )
+            for i in range(50)
+        ]
+        _write_ticket_lines(state, terminals)
+
+        dropped = compact_tickets(state, now=base, retention_max=10)
+
+        reloaded = load_tickets(state)
+        assert len(reloaded) == 10
+        assert dropped == 40
+        # The 10 newest (smallest `i`) should survive.
+        surviving = sorted(reloaded.keys())
+        assert surviving == [f"tkt-n-{i:02d}" for i in range(10)]
+
+    def test_compaction_deduplicates_transitions(self, runtime_dir: Path) -> None:
+        """Multiple JSONL lines for the same ticket_id collapse to one line
+        (the latest status) — this is the main space savings in steady state."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        # Simulate the natural ticket lifecycle: pending -> deferred (still
+        # pending) x 3 -> nudged.
+        base = {
+            "ticket_id": "tkt-xforms",
+            "message_id": "mid-xforms",
+            "to_lane": "author-b",
+            "message_type": "blocker",
+            "priority": "high",
+            "created_at": now.isoformat(),
+            "next_retry_at": now.isoformat(),
+            "last_reason": "n/a",
+        }
+        with open(state.tickets_file, "w") as f:
+            f.write(json.dumps({**base, "status": "pending", "attempts": 0}) + "\n")
+            f.write(json.dumps({**base, "status": "pending", "attempts": 1}) + "\n")
+            f.write(json.dumps({**base, "status": "pending", "attempts": 2}) + "\n")
+            f.write(json.dumps({**base, "status": "pending", "attempts": 3}) + "\n")
+            f.write(json.dumps({**base, "status": "nudged", "attempts": 4}) + "\n")
+
+        assert len(state.tickets_file.read_text().strip().splitlines()) == 5
+        dropped = compact_tickets(state, now=now)
+        assert dropped == 4
+        remaining = state.tickets_file.read_text().strip().splitlines()
+        assert len(remaining) == 1
+        reloaded = load_tickets(state)
+        assert reloaded["tkt-xforms"].status == "nudged"
+        assert reloaded["tkt-xforms"].attempts == 4
+
+    def test_dedup_intact_after_compaction(self, runtime_dir: Path) -> None:
+        """After compaction, re-running run_once with the same message_id
+        in events.jsonl must NOT create a duplicate ticket.
+
+        This is the invariant the retention window exists to preserve:
+        terminal tickets retained in the compacted log still block a
+        re-nudge for their message_id.
+        """
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+
+        # Seed: one nudged ticket within retention window (message_id X).
+        seed = _make_ticket(
+            ticket_id="tkt-seed",
+            status="nudged",
+            created_at=now - timedelta(hours=1),
+            message_id="stable-X",
+        )
+        _write_ticket_lines(state, [seed])
+        # Matching cursor past the file so run_once never re-reads it.
+        compact_tickets(state, now=now)
+        # Confirm the dedup anchor survived.
+        assert "stable-X" in {t.message_id for t in load_tickets(state).values()}
+
+        # Now append a new event with the *same* message_id and run one cycle.
+        _write_events(
+            runtime_dir,
+            [
+                _msg_sent_event(
+                    to_lane="author-b",
+                    message_type="blocker",
+                    message_id="stable-X",
+                ),
+            ],
+        )
+        nudged: list[str] = []
+        summary = run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn(nudged),
+            now=now + timedelta(seconds=5),
+        )
+        # Dedup worked: no new ticket, no new nudge.
+        assert summary.tickets_created == 0
+        assert nudged == []
+
+    def test_size_gate_skips_small_files(self, runtime_dir: Path) -> None:
+        """run_once must NOT rewrite the file when it's below the size gate."""
+        _write_events(
+            runtime_dir,
+            [_msg_sent_event(to_lane="author-b", message_type="blocker")],
+        )
+        # Default threshold (50KB) is far larger than a single-ticket file.
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn([]),
+        )
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        # Initial pending + terminal nudged lines — 2 lines, not 1 (compaction
+        # would collapse to 1 if it ran).
+        lines = [
+            line for line in state.tickets_file.read_text().splitlines() if line.strip()
+        ]
+        assert len(lines) == 2, (
+            "Small files must skip compaction so the per-cycle cost stays "
+            "bounded by a single stat() call"
+        )
+
+    def test_size_gate_triggers_compaction_on_large_files(
+        self,
+        runtime_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Force the gate open with a tiny threshold and prove run_once
+        actually rewrites the file end-to-end."""
+        # Drop the threshold so any non-empty file triggers compaction.
+        monkeypatch.setattr("bid_euchre.ops.attention.COMPACTION_MIN_BYTES", 1)
+
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+
+        # Preload ticket log with redundant transitions.
+        base = {
+            "ticket_id": "tkt-big",
+            "message_id": "mid-big",
+            "to_lane": "author-b",
+            "message_type": "blocker",
+            "priority": "high",
+            "created_at": now.isoformat(),
+            "next_retry_at": now.isoformat(),
+            "last_reason": "n/a",
+        }
+        state.ensure_dir()
+        with open(state.tickets_file, "w") as f:
+            for i in range(10):
+                f.write(json.dumps({**base, "status": "pending", "attempts": i}) + "\n")
+            f.write(json.dumps({**base, "status": "nudged", "attempts": 10}) + "\n")
+
+        run_once(
+            runtime_dir=runtime_dir,
+            pane_state_fn=_safe_pane,
+            nudge_fn=_record_nudge_fn([]),
+            now=now,
+        )
+        # After run_once + compaction, the duplicated transitions collapse
+        # to the single terminal state.
+        lines = [
+            line for line in state.tickets_file.read_text().splitlines() if line.strip()
+        ]
+        assert len(lines) == 1
+        assert json.loads(lines[0])["status"] == "nudged"
+
+    def test_atomic_rewrite_uses_tmp_then_replace(self, runtime_dir: Path) -> None:
+        """If os.replace fails mid-write, the live file must still contain
+        the pre-compaction content — never a partial write."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        # Seed with a non-trivial set that compaction would shrink.
+        old = now - timedelta(hours=48)
+        tickets = [
+            _make_ticket(ticket_id="tkt-p", status="pending", created_at=now),
+            _make_ticket(ticket_id="tkt-old-t", status="nudged", created_at=old),
+        ]
+        _write_ticket_lines(state, tickets)
+        original_bytes = state.tickets_file.read_bytes()
+
+        tmp_path = state.tickets_file.with_suffix(".jsonl.tmp")
+        assert not tmp_path.exists()
+
+        with patch(
+            f"{_ATTENTION}.os.replace",
+            side_effect=OSError("simulated rename failure"),
+        ):
+            with pytest.raises(OSError, match="simulated rename failure"):
+                compact_tickets(state, now=now)
+
+        # Live file must be byte-for-byte the original — atomicity.
+        assert state.tickets_file.read_bytes() == original_bytes
+        # Tmp file cleaned up on failure.
+        assert not tmp_path.exists(), "compaction must clean up tmp on failure"
+
+    def test_atomic_rewrite_calls_fsync_before_replace(self, runtime_dir: Path) -> None:
+        """Structural proof: fsync happens before os.replace on the same fd."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        _write_ticket_lines(
+            state,
+            [_make_ticket(ticket_id="tkt-a", status="pending", created_at=now)],
+        )
+
+        call_order: list[str] = []
+
+        real_fsync = os.fsync
+        real_replace = os.replace
+
+        def tracked_fsync(fd: int) -> None:
+            call_order.append("fsync")
+            real_fsync(fd)
+
+        def tracked_replace(src: Any, dst: Any) -> None:
+            call_order.append("replace")
+            real_replace(src, dst)
+
+        with patch(f"{_ATTENTION}.os.fsync", side_effect=tracked_fsync):
+            with patch(f"{_ATTENTION}.os.replace", side_effect=tracked_replace):
+                compact_tickets(state, now=now)
+
+        assert call_order == ["fsync", "replace"], (
+            "compaction must fsync the tmp file before calling os.replace; "
+            f"saw {call_order!r}"
+        )
+
+    def test_empty_file_is_noop(self, runtime_dir: Path) -> None:
+        """Compaction on a missing / empty log returns zero drops and
+        does not create a spurious empty file."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        # File does not exist.
+        assert not state.tickets_file.exists()
+        dropped = compact_tickets(state)
+        assert dropped == 0
+        # We did not create an empty file.
+        assert not state.tickets_file.exists()
+
+    def test_malformed_lines_are_dropped_on_compaction(self, runtime_dir: Path) -> None:
+        """Compaction quietly drops unparseable lines (forward-compat with
+        partially-corrupted logs)."""
+        state = AttentionState.from_runtime_dir(runtime_dir)
+        state.ensure_dir()
+        now = datetime(2026, 4, 20, 18, 0, 0, tzinfo=timezone.utc)
+        good = _make_ticket(ticket_id="tkt-good", status="pending", created_at=now)
+        with open(state.tickets_file, "w") as f:
+            f.write("this is not json\n")
+            f.write(json.dumps(good.to_json(), sort_keys=True) + "\n")
+            f.write('{"missing": "fields"}\n')
+        compact_tickets(state, now=now)
+        reloaded = load_tickets(state)
+        assert set(reloaded.keys()) == {"tkt-good"}
+
+    def test_defaults_are_reasonable(self) -> None:
+        """Regression-lock the default compaction policy values.  These
+        are the documented knobs operators read from logs; a silent change
+        would surprise them."""
+        assert (
+            COMPACTION_MIN_BYTES >= 1_000
+        ), "Threshold too low — would compact on every cycle"
+        assert (
+            COMPACTION_MIN_BYTES <= 10_000_000
+        ), "Threshold too high — would never compact"
+        assert COMPACTION_TERMINAL_RETENTION_HOURS >= 1.0
+        assert COMPACTION_TERMINAL_RETENTION_MAX >= 50


### PR DESCRIPTION
Plan: N/A (standalone bugfix session; issue #2674 follow-up from PR #2672)

## Summary

Bounds growth of `.claude/runtime/attention_broker/deferred_tickets.jsonl`
so it cannot accumulate terminal ticket history indefinitely at fleet scale.
Closes the append-only unbounded-growth bug flagged on the PR-MSG-4 broker.

- `compact_tickets()` rewrites the log with every **non-terminal** ticket plus
  a bounded window of recent **terminal** tickets (default: last 24h, capped at
  500 entries) for dedup safety.
- Size-gated from `run_once()` via `_compact_if_size_exceeds_threshold` — a
  single `stat()` call per cycle, rewrite fires only when the log exceeds
  `COMPACTION_MIN_BYTES` (default 50KB).
- Atomic rewrite: write tmp → `fsync` → `os.replace` → cleanup tmp on failure.
  Concurrent `load_tickets` sees either the pre- or post-compaction file,
  never a partial write.
- Dedup invariant preserved: terminal tickets inside the retention window
  still participate in `seen_message_ids` so cursor-reset or in-file duplicate
  events cannot re-create a nudged ticket for an already-processed
  `message_id`.

## Why

Per issue #2674 (review finding from PR #2672): every ticket state transition
appends one line; terminal tickets (`nudged`, `abandoned`) were never removed;
and `load_tickets()` re-parses the whole file every 3s cycle. At fleet scale
(dozens of events/hour), the file grows to MBs in weeks and re-parse cost
grows linearly with history.

## Design choices (documented inline + here)

**Compaction trigger — size-based, not time-based:**
The 3s `run_once` cadence makes time-based triggers noisy. A byte-size gate is
a single `stat()` call per cycle and only fires when the file has actually
grown. `COMPACTION_MIN_BYTES = 50_000` lets a fresh broker ingest hundreds of
tickets before the first rewrite, and every rewrite meaningfully shrinks the
file.

**Terminal retention window — 24 hours, capped at 500:**
The dedup safety net only matters while `events.jsonl` may re-emit a
`message_id` we've already processed. Events past the persistent cursor are
normally gone; the only re-emit path is cursor reset after file rotation,
which the broker defends against by restarting the cursor at 0. A 24h window
is multiple orders of magnitude wider than any realistic cursor-reset window.
The 500-entry hard cap prevents a single traffic burst (thousands of blockers
in one hour) from defeating the size gate.

**Observable behavior operators may see:**
- Steady-state log size now bounded — no more indefinite growth.
- An occasional `INFO`-level log line of the form
  `attention-broker compacted tickets log: N -> M lines (dropped K; pending=P, terminal_retained=T)`
  whenever compaction fires.
- Terminal tickets older than 24h are no longer visible to `get_status()` /
  `load_tickets()` — historical `nudged_count` / `abandoned_count` rollups
  now reflect only retained tickets, not full lifetime history. (Full-lifetime
  counts were not being used for any operator decision, per review.)
- No behavior change for pending-ticket handling or the nudge/abandon loop.

## Out of scope

- Keeping append-only semantics during normal operation is preserved — writes
  still append; compaction is the sole rewriter.
- Separate archive file for terminals (the alternate approach from #2674) was
  not pursued — in-place compaction with retention window is simpler and
  meets the bound-the-file goal cleanly.
- No changes to the `run_once` cadence or the ticket state machine.
- No changes outside `attention.py` and its unit test file.

## Repro / Validation

**Tier 1 — unit tests (13 new cases in `TestCompaction`):**
```
uv run python -m pytest tests/unit/test_ops_attention.py -v
# 84 passed in 0.18s
```

**Tier 2 — full gated validation:**
```
make check-gated
# ✓ All checks passed
```

**Ad-hoc simulation — 6000-line mixed log:**
```
Before: 6000 lines, 1747200 bytes
After:  1000 lines, 290780 bytes
Dropped: 5000
Shrinkage: 83.4%
Reloaded: 500 pending, 500 nudged
Dedup invariants: OK
```

## Tests

Covered behaviors:
- Non-terminal tickets always preserved (even if older than retention)
- Terminal tickets outside retention window dropped
- Terminal tickets inside retention window retained
- `retention_max` caps a traffic burst even within the window
- Multi-line per-ticket history collapses to latest state
- `run_once` + dedup intact after compaction (no re-nudge for known message_id)
- Size gate skips small files at default threshold
- Size gate triggers compaction on large files via monkeypatched threshold
- Atomic rewrite: `os.replace` failure leaves live file byte-for-byte unchanged
- Structural proof: `fsync` happens before `os.replace`
- Empty-file compaction is a no-op (no spurious file creation)
- Malformed JSON lines are quietly dropped during compaction
- Default policy knobs are within reasonable bounds (regression-lock)

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
$ git diff --stat origin/main...HEAD
 src/bid_euchre/ops/attention.py  | 226 +++++++++++++++++++++++
 tests/unit/test_ops_attention.py | 389 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 615 insertions(+)
```

Fixes #2674.
Refs #2169.
