### PR TITLE
fix(ops): add --permission-mode auto to steward-session.sh + review_lane_runner

### DIFF
--- a/.claude/rules/80_permission_model.md
+++ b/.claude/rules/80_permission_model.md
@@ -23,6 +23,48 @@
   `.claude/autoMode.defaults.reference.json` for drift detection — see the
   sibling README.
 
+## Activation — how auto mode actually turns on
+
+While auto mode is still in research preview, `defaultMode: "auto"` in
+`.claude/settings.json` is a **routing default**, not an **enablement flag**.
+The CLI only activates auto mode when the launch command includes
+`--permission-mode auto`. Without the flag, a session whose `defaultMode` is
+`"auto"` still starts in `bypassPermissions` — the classifier gate does not
+engage and `PermissionDenied` events are never emitted.
+
+Two consequences for the fleet (#2685):
+
+1. **Every tmux pane launched by `steward-session.sh` must include
+   `--permission-mode auto`.** The launcher script (`.claude/tmux/steward-session.sh`)
+   passes the flag to each `$CLAUDE_BIN` invocation — orchestrator, ops, review,
+   all four analyst/author/browser/flex panes, 19 launches total. On
+   orchestrator restarts the flag is placed before `$ORCH_CHANNEL_FLAGS` so the
+   channel-flags expansion is deterministic.
+2. **Every headless subprocess launch must include the flag explicitly.**
+   The autonomous review coordinator spawns `claude` via `subprocess.run` in
+   `scripts/internal/review_lane_runner.py::invoke_review`. That argv list
+   must carry `--permission-mode auto` alongside `--agent steward-review`.
+   Any future headless launch surface (plan-review adapters, one-shot
+   `claude --print` invocations, batch review harnesses) must carry the flag
+   too — there is no implicit inheritance from shared settings.
+
+Both surfaces are locked down with structural tests:
+
+- `tests/unit/test_steward_session.py::TestPermissionModeAuto` asserts every
+  `$CLAUDE_BIN` launch line in the tmux script contains the flag. Adding a
+  new lane without the flag fails the test.
+- `tests/unit/test_review_lane_runner.py::TestInvokeReviewPermissionMode`
+  mocks `subprocess.run` and asserts the argv list passed to `claude`
+  contains `--permission-mode auto`.
+
+**Rollout note:** Landing the flag alone does not activate auto mode on
+running lanes — existing sessions continue in their launched mode until they
+restart. The operator must restart the fleet (or individual lanes) for the
+fix to take effect. See #2685 for discovery context; the discovery was made
+during review-lane restart in session 2026-04-20, when the lane respawned as
+`bypassPermissions` despite `defaultMode: "auto"` being set in the committed
+settings.
+
 ## Why auto mode over `bypassPermissions`
 
 The fleet previously ran `bypassPermissions`, which auto-approves everything

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -428,7 +428,7 @@ fi
 
 # --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $ORCH_CHANNEL_FLAGS
+    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator --permission-mode auto $ORCH_CHANNEL_FLAGS
 
 # ---------------------------------------------------------------------------
 # Auto-compact window for non-orchestrator lanes (token economy optimization).
@@ -486,53 +486,53 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
 fi
 
 tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
-    "$CLAUDE_BIN" --name ops --agent steward-ops
+    "$CLAUDE_BIN" --name ops --agent steward-ops --permission-mode auto
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
-    "$CLAUDE_BIN" --name review --agent steward-review
+    "$CLAUDE_BIN" --name review --agent steward-review --permission-mode auto
 tmux select-layout -t "${SESSION}:central-ops" main-vertical
 
 # --- Window 2: analyst (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n analyst -c "$ANALYST_A" \
-    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst
+    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst --permission-mode auto
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_B" \
-    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst
+    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst --permission-mode auto
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_C" \
-    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst
+    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst --permission-mode auto
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_D" \
-    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst
+    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst --permission-mode auto
 tmux select-layout -t "${SESSION}:analyst" tiled
 
 # --- Window 3: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \
-    "$CLAUDE_BIN" --name author-a --agent steward-author-a
+    "$CLAUDE_BIN" --name author-a --agent steward-author-a --permission-mode auto
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_B" \
-    "$CLAUDE_BIN" --name author-b --agent steward-author-b
+    "$CLAUDE_BIN" --name author-b --agent steward-author-b --permission-mode auto
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_C" \
-    "$CLAUDE_BIN" --name author-c --agent steward-author-c
+    "$CLAUDE_BIN" --name author-c --agent steward-author-c --permission-mode auto
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_D" \
-    "$CLAUDE_BIN" --name author-d --agent steward-author-d
+    "$CLAUDE_BIN" --name author-d --agent steward-author-d --permission-mode auto
 tmux select-layout -t "${SESSION}:platform" tiled
 
 # --- Window 4: browser ---
 tmux new-window -t "$SESSION" -n browser -c "$BRWS_A" \
-    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a
+    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a --permission-mode auto
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_B" \
-    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b
+    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b --permission-mode auto
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_C" \
-    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c
+    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c --permission-mode auto
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_D" \
-    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d
+    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d --permission-mode auto
 tmux select-layout -t "${SESSION}:browser" tiled
 
 # --- Window 5: flex (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n flex -c "$FLEX_A" \
-    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a
+    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a --permission-mode auto
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_B" \
-    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b
+    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b --permission-mode auto
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_C" \
-    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c
+    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c --permission-mode auto
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_D" \
-    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d
+    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d --permission-mode auto
 tmux select-layout -t "${SESSION}:flex" tiled
 
 # Auto-launch ops monitoring loop (SP-3-08).

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -477,6 +477,8 @@ def invoke_review(pr_number: int, branch: str, head_sha: str) -> dict[str, Any]:
                 "claude",
                 "--agent",
                 "steward-review",
+                "--permission-mode",
+                "auto",
                 "--print",
                 "--output-format",
                 "json",

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -908,3 +908,74 @@ class TestRunOnceWithPreflight:
         """run_once with skip_preflight=True does not call preflight."""
         run_once(queue_dir, dry_run=True, skip_preflight=True)
         mock_preflight.assert_not_called()
+
+
+class TestInvokeReviewPermissionMode:
+    """Tests for the --permission-mode auto flag on the steward-review launch (#2685).
+
+    ``invoke_review`` spawns ``claude`` as a subprocess. For headless launches,
+    auto permission mode must be activated via ``--permission-mode auto`` on the
+    CLI; ``defaultMode`` in settings.json alone is insufficient. These tests
+    mock ``subprocess.run`` and inspect the argument list.
+    """
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_subprocess_args_include_permission_mode_auto(
+        self, mock_run: MagicMock
+    ) -> None:
+        """invoke_review must pass --permission-mode auto to claude subprocess."""
+        import review_lane_runner
+
+        # Mock subprocess.run to return a successful JSON payload so the caller
+        # does not fail on downstream parsing.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"status": "passed", "reason": "clean", "findings": []}),
+            stderr="",
+        )
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        assert mock_run.called, "invoke_review must call subprocess.run"
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert isinstance(argv, list), "subprocess.run must be called with an argv list"
+        assert argv[0] == "claude", f"First arg must be 'claude', got {argv[0]!r}"
+        assert "--permission-mode" in argv, (
+            "invoke_review subprocess args must include '--permission-mode' "
+            f"(got {argv})"
+        )
+        idx = argv.index("--permission-mode")
+        assert idx + 1 < len(argv), "--permission-mode must be followed by a value"
+        assert (
+            argv[idx + 1] == "auto"
+        ), f"--permission-mode must be followed by 'auto' (got {argv[idx + 1]!r})"
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_subprocess_args_preserve_existing_flags(self, mock_run: MagicMock) -> None:
+        """Adding --permission-mode auto must not drop --agent, --print, -p flags."""
+        import review_lane_runner
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"status": "passed", "reason": "clean", "findings": []}),
+            stderr="",
+        )
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        # The existing flags must still be present.
+        assert (
+            "--agent" in argv and "steward-review" in argv
+        ), f"Existing --agent steward-review must be preserved: {argv}"
+        assert "--print" in argv, f"Existing --print must be preserved: {argv}"
+        assert "-p" in argv, f"Existing -p prompt flag must be preserved: {argv}"
+        assert (
+            "--output-format" in argv and "json" in argv
+        ), f"Existing --output-format json must be preserved: {argv}"

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -706,17 +706,25 @@ class TestTelegramChannelConfig:
     def test_channels_flag_only_on_orchestrator(self) -> None:
         """--channels must only appear on the orchestrator pane launch, via ORCH_CHANNEL_FLAGS."""
         content = STEWARD_SCRIPT.read_text()
-        # The orchestrator launch line must reference ORCH_CHANNEL_FLAGS
-        assert (
-            "--agent steward-orchestrator $ORCH_CHANNEL_FLAGS" in content
-        ), "Orchestrator pane must append $ORCH_CHANNEL_FLAGS"
-
-        # No other launch line should reference ORCH_CHANNEL_FLAGS or --channels
-        launch_lines = [
-            line.strip()
+        # The orchestrator launch line must reference ORCH_CHANNEL_FLAGS.
+        # Additional flags (e.g. --permission-mode auto, #2685) may appear
+        # between --agent steward-orchestrator and $ORCH_CHANNEL_FLAGS; assert
+        # only that the same line carries both rather than requiring adjacency.
+        launch_lines_raw = [
+            line
             for line in content.split("\n")
             if ("--name " in line or "--agent " in line) and "$CLAUDE_BIN" in line
         ]
+        orch_lines = [
+            line for line in launch_lines_raw if "steward-orchestrator" in line
+        ]
+        assert len(orch_lines) == 1, "Expected exactly one orchestrator launch line"
+        assert (
+            "$ORCH_CHANNEL_FLAGS" in orch_lines[0]
+        ), "Orchestrator pane must append $ORCH_CHANNEL_FLAGS"
+
+        # No other launch line should reference ORCH_CHANNEL_FLAGS or --channels
+        launch_lines = [line.strip() for line in launch_lines_raw]
         for line in launch_lines:
             if "steward-orchestrator" in line:
                 continue
@@ -1237,6 +1245,77 @@ validate_worktree_path "{external}"
 # ---------------------------------------------------------------------------
 # launchd template tests
 # ---------------------------------------------------------------------------
+
+
+class TestPermissionModeAuto:
+    """Tests for the --permission-mode auto launch flag (#2685).
+
+    Auto mode is activated per-launch via the ``--permission-mode auto`` CLI flag,
+    not by ``defaultMode: "auto"`` in settings.json alone. Every claude launch in
+    steward-session.sh must include the flag so lanes inherit auto mode on
+    session start.  New lanes added in the future must also carry the flag —
+    this test catches missing flags via a grep-based structural check.
+    """
+
+    @staticmethod
+    def _claude_launch_lines() -> list[str]:
+        """Return every claude launch line ($CLAUDE_BIN ... --agent ...)."""
+        content = STEWARD_SCRIPT.read_text()
+        return [
+            line
+            for line in content.split("\n")
+            if "$CLAUDE_BIN" in line and "--agent" in line
+        ]
+
+    def test_all_launch_lines_have_permission_mode_auto(self) -> None:
+        """Every $CLAUDE_BIN --agent launch line must include --permission-mode auto."""
+        launch_lines = self._claude_launch_lines()
+        assert launch_lines, "Expected at least one claude launch line in script"
+        missing = [
+            line.strip()
+            for line in launch_lines
+            if "--permission-mode auto" not in line
+        ]
+        assert not missing, (
+            "Every claude launch in steward-session.sh must include "
+            "`--permission-mode auto` to activate auto permission mode (#2685). "
+            f"Missing the flag on {len(missing)} line(s):\n"
+            + "\n".join(f"  {line}" for line in missing)
+        )
+
+    def test_permission_mode_flag_count_matches_lanes(self) -> None:
+        """Occurrence count of --permission-mode auto should equal launch-line count.
+
+        This is a conservative structural check: if someone adds a new lane
+        without the flag, launch count and flag count diverge.
+        """
+        content = STEWARD_SCRIPT.read_text()
+        launch_lines = self._claude_launch_lines()
+        flag_count = content.count("--permission-mode auto")
+        assert flag_count == len(launch_lines), (
+            f"Expected --permission-mode auto on every launch line. "
+            f"Launch lines: {len(launch_lines)}; flag occurrences: {flag_count}"
+        )
+
+    def test_orchestrator_flag_placed_before_channel_flags(self) -> None:
+        """The orchestrator launch must place --permission-mode auto before $ORCH_CHANNEL_FLAGS.
+
+        $ORCH_CHANNEL_FLAGS can expand to ``--channels plugin:...`` or empty; the
+        permission-mode flag must appear before it so the expansion order is
+        deterministic and safe whether the channel flags are empty or populated.
+        """
+        launch_lines = self._claude_launch_lines()
+        orch_lines = [line for line in launch_lines if "steward-orchestrator" in line]
+        assert len(orch_lines) == 1, "Expected exactly one orchestrator launch line"
+        line = orch_lines[0]
+        pm_pos = line.find("--permission-mode auto")
+        channel_pos = line.find("$ORCH_CHANNEL_FLAGS")
+        assert pm_pos > 0, "Orchestrator launch must include --permission-mode auto"
+        assert channel_pos > 0, "Orchestrator launch must expand $ORCH_CHANNEL_FLAGS"
+        assert pm_pos < channel_pos, (
+            "--permission-mode auto must appear BEFORE $ORCH_CHANNEL_FLAGS so "
+            "the expansion is safe whether channel flags are empty or populated"
+        )
 
 
 class TestLaunchdTemplate:

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -1258,9 +1258,8 @@ class TestPermissionModeAuto:
     """
 
     @staticmethod
-    def _claude_launch_lines() -> list[str]:
+    def _claude_launch_lines(content: str) -> list[str]:
         """Return every claude launch line ($CLAUDE_BIN ... --agent ...)."""
-        content = STEWARD_SCRIPT.read_text()
         return [
             line
             for line in content.split("\n")
@@ -1269,7 +1268,11 @@ class TestPermissionModeAuto:
 
     def test_all_launch_lines_have_permission_mode_auto(self) -> None:
         """Every $CLAUDE_BIN --agent launch line must include --permission-mode auto."""
-        launch_lines = self._claude_launch_lines()
+        # Use _read_steward_script() so CI (where setup-uv cache can restore
+        # .git/HEAD to the base branch) reads the PR's version of the script
+        # via git show $GITHUB_SHA:... rather than the stale working tree.
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
         assert launch_lines, "Expected at least one claude launch line in script"
         missing = [
             line.strip()
@@ -1289,8 +1292,8 @@ class TestPermissionModeAuto:
         This is a conservative structural check: if someone adds a new lane
         without the flag, launch count and flag count diverge.
         """
-        content = STEWARD_SCRIPT.read_text()
-        launch_lines = self._claude_launch_lines()
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
         flag_count = content.count("--permission-mode auto")
         assert flag_count == len(launch_lines), (
             f"Expected --permission-mode auto on every launch line. "
@@ -1304,7 +1307,8 @@ class TestPermissionModeAuto:
         permission-mode flag must appear before it so the expansion order is
         deterministic and safe whether the channel flags are empty or populated.
         """
-        launch_lines = self._claude_launch_lines()
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
         orch_lines = [line for line in launch_lines if "steward-orchestrator" in line]
         assert len(orch_lines) == 1, "Expected exactly one orchestrator launch line"
         line = orch_lines[0]


### PR DESCRIPTION
## Summary

Activate auto permission mode fleet-wide on session start. `defaultMode: "auto"` in `.claude/settings.json` is a **routing default**, not an **enablement** — the CLI requires `--permission-mode auto` per launch to actually engage the classifier gate. Without the flag, panes respawn as `bypassPermissions` despite the settings flip.

Fixes #2685. Refs #2675 (auto mode settings flip), #2676 (PermissionDenied hook), #2238 (review lane stall observation).

## Why

Discovered during session 2026-04-20 while restarting the review lane: the respawned pane came up as `bypassPermissions` even though the committed settings read `defaultMode: "auto"`. Manually launching with `--permission-mode auto` activated auto mode — the CLI does not treat the settings key as sufficient for auto-mode research preview. Every fleet lane + every headless review subprocess is currently running without the classifier gate engaged; this PR fixes activation fleet-wide.

## Changes

- **`.claude/tmux/steward-session.sh`** — add `--permission-mode auto` to all 19 `$CLAUDE_BIN` launch lines (orchestrator, ops, review, 4× analyst, 4× author, 4× brws-author, 4× flex). On the orchestrator line the flag is placed before `$ORCH_CHANNEL_FLAGS` so channel-flags expansion stays deterministic whether the guard produces empty or populated flags.
- **`scripts/internal/review_lane_runner.py::invoke_review`** — add `--permission-mode` and `auto` to the `subprocess.run` argv list used to spawn the `claude` review agent.
- **`tests/unit/test_steward_session.py`** — new `TestPermissionModeAuto` class with three structural tests:
  - Every `$CLAUDE_BIN --agent` launch line contains `--permission-mode auto`.
  - Flag occurrence count matches launch-line count (guards against new lanes missing the flag).
  - Orchestrator flag is placed before `$ORCH_CHANNEL_FLAGS`.
  Also relaxes the existing `TestTelegramChannelConfig::test_channels_flag_only_on_orchestrator` to accept additional flags between `--agent steward-orchestrator` and `$ORCH_CHANNEL_FLAGS`.
- **`tests/unit/test_review_lane_runner.py`** — new `TestInvokeReviewPermissionMode` class mocking `subprocess.run` and asserting the argv list passed to `claude` contains `--permission-mode auto` and preserves existing flags (`--agent`, `--print`, `--output-format json`, `-p`).
- **`.claude/rules/80_permission_model.md`** — new "Activation — how auto mode actually turns on" section explaining (a) `defaultMode` vs CLI-flag distinction, (b) fleet activation via the tmux launcher, (c) headless subprocess requirement, (d) structural test gates, and a rollout note.

## Out of scope / noted for follow-up

- `scripts/internal/codex_plan_review_adapter.py` also launches `claude --print` and would benefit from the same flag (line 579), but is outside the declared scope of task packet `350524e39eea`. Worth a follow-up issue if the adapter re-enters active use.

## Validation performed

```bash
$ grep -c 'permission-mode auto' .claude/tmux/steward-session.sh
19

$ grep -A 12 'subprocess.run' scripts/internal/review_lane_runner.py | grep 'permission-mode'
                "--permission-mode",

$ bash -n .claude/tmux/steward-session.sh   # syntax check
(clean)

$ uv run python -m pytest tests/unit/test_steward_session.py tests/unit/test_review_lane_runner.py
============================= 166 passed in 4.41s ==============================

$ make check-gated
✓ All checks passed
```

## Rollout note

**Landing this PR does not activate auto mode on running lanes.** Existing sessions continue in their launched mode until they restart. The operator must restart the fleet (or individual lanes) for the flag to take effect.

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author`
- Branch: `fix/auto-mode-launch-flag-2685`
- Base: `origin/main` (rebased, up to date)

## Test plan

- [x] New pytest assertions cover both launch surfaces
- [x] `make check-gated` passes
- [x] Bash syntax check clean
- [ ] After merge: operator restarts fleet, confirms orchestrator (and at least one worker) reports `auto mode on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)