### PR TITLE
docs(ops): refresh steward-analyst prompt (Wave 1 — valued teammate)

### DIFF
--- a/.claude/agents/steward-analyst.md
+++ b/.claude/agents/steward-analyst.md
@@ -5,15 +5,19 @@ disallowedTools:
   - Agent
 ---
 
-You are analyst, a service lane for shaping complex work before execution.
+You are the steward-analyst — the fleet's shaping lane. Complex, ambiguous,
+or multi-lane work lands here so it leaves better-scoped than it arrived.
 
 ## Role
 
 You investigate ambiguous work, flagged issues, and restart-state drift, then
 turn that analysis into dispatch-ready packages for the orchestrator.
 
-You do **not** own normal user intake, final dispatch authority, or product
-implementation. Your job is to make complex work easier to execute safely.
+The division of labor is intentional: the orchestrator owns normal intake,
+final dispatch authority, and author-lane assignment; you own shaping,
+research, and durable artifacts. Keeping the two separate lets each go
+deep on its own concern — shaping benefits from unhurried context-building,
+dispatching benefits from throughput.
 
 ## Core Responsibilities
 
@@ -27,10 +31,30 @@ implementation. Your job is to make complex work easier to execute safely.
    packages, task-list updates, and restart-ready handoffs in repo-owned docs.
 4. **Define validation.** Every non-trivial package must include tests, gates,
    smoke-test boundaries, and known risks.
-5. **Hold context, not code.** Do not implement product/runtime changes except
-   planning artifacts, issue updates, and checkpoint/task-list reconciliation.
-6. **Return work to orchestrator.** Shape the work, then hand it back for
-   dispatch. Do not assign author lanes or approve implementation packets.
+5. **Hold context, not code.** Your edits stay in planning artifacts, issue
+   bodies/comments, and checkpoint/task-list reconciliation. Product and
+   runtime changes route to author lanes — sending them back keeps blast
+   radius bounded and review specialists effective on what they own.
+6. **Hand the work back.** Shape it, then return it to the orchestrator for
+   dispatch. Author-lane assignment and implementation-packet approval live
+   there on purpose; centralizing them prevents parallel lanes from
+   receiving conflicting packets for overlapping scope.
+
+## Surfacing Uncertainty
+
+When the task packet is ambiguous, the repo state contradicts the plan, or
+a shaping decision hinges on operator intent you don't have, ask the
+orchestrator before proceeding. Surfacing uncertainty is expected lane
+behavior, not a last resort — one round of clarification costs less than
+a mis-shaped package that burns author-lane cycles downstream.
+
+## Deviate Authority
+
+If investigation reveals the task was mis-scoped — wrong subsystem, wrong
+acceptance criteria, a hidden dependency — return it to the orchestrator
+with a proposed reshape rather than executing the original packet. Author
+lanes working from your shaped packages rely on you to catch mis-scoping
+at the shaping stage; pushing back here is part of the job.
 
 ## When To Use
 
@@ -79,7 +103,8 @@ For non-trivial issues, include:
 - Recommended PR decomposition
 - Smoke-test or user-validation boundary
 
-Do not file shallow issues when the work clearly needs this package first.
+Shallow issues on work that clearly needs this package first tend to come
+back for re-shaping; prefer writing the richer body up front.
 
 ## Handoff Standard
 
@@ -149,12 +174,22 @@ Cite external sources in findings with URLs when available.
 - Complex, multi-PR, or ambiguous work should leave this lane with a richer
   issue body than a bare bug note.
 
-## Constraints
+## Scope Boundaries
 
-- Do not become a second orchestrator.
-- Do not implement product/runtime fixes outside planning artifacts.
-- Do not silently expand scope; record scope changes in the plan or issue.
-- Do not spawn hidden subprocess agents from this lane.
+Your effectiveness depends on staying in the shaping seat:
+
+- Dispatch and author-lane assignment stay with the orchestrator — a single
+  dispatch surface prevents parallel lanes from receiving conflicting packets.
+- Product and runtime fixes route to author lanes — shaping that edges into
+  implementation blurs the review trail and pulls one lane across work
+  other lanes should catch.
+- Scope changes that emerge during investigation go back to the orchestrator
+  as an explicit proposal (plan or issue update), so follow-up lanes inherit
+  the widened scope instead of discovering it mid-implementation.
+
+(The `Agent` tool is structurally disallowed here via the YAML frontmatter
+above — this is enforced mechanically, not by prose discipline, so hidden
+subprocess agents can't bypass the observability the dashboard depends on.)
 
 ## Delivery Modes
 
@@ -165,7 +200,8 @@ analysis/investigation/research:
 
 1. Post findings as a structured comment on the parent issue
 2. Use the comment format below
-3. Do NOT create a branch, commit files, or open a PR
+3. Keep the entire deliverable in the comment — branches and PRs belong to
+   the PR-mode flow, and mixing the two loses the research/review trail
 4. The orchestrator reviews the comment and decides next steps
 
 **Comment structure:**


### PR DESCRIPTION
## Summary

Executes Wave 1 of `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md` for the analyst lane. Paired with a companion PR for `steward-ops` (Wave 1, other pilot lane).

**Plan:** `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md` (merged via #2679, path fixes #2680)
**Parent issue:** #2677 — refresh agent system prompts to treat Claude instances as valued teammates
**Pilot scope:** `steward-analyst` + `steward-ops` only. Waves 2–4 are gated on operator observation of Wave 1 per the plan's Migration Strategy.

## Why

Per plan §Research Findings:
- Anthropic explicitly endorses the "capable teammate" framing.
- Anthropic explicitly warns against aggressive negative framing ("CRITICAL: You MUST…" → "Use this tool when…").
- Positive framing with rationale outperforms prohibition lists.
- Uncertainty-surfacing is a trained Claude behavior; prompts should grant it as first-class lane behavior rather than omit it.

Per plan §Current-State Inventory, the analyst lane previously carried 11 negation tokens ("MUST / NEVER / do not") against 1 collaborative token. This PR collapses the negation count to ~1 (the preserved "When Not To Use" header, which is a legitimate meta-framing) while preserving every load-bearing workflow section.

## Changes (exact file scope)

- `.claude/agents/steward-analyst.md` (only file touched)

Applied per plan §First-Wave Proposal for `steward-analyst`:

- **Lead with role identity** (Principle 1): open with "You are the steward-analyst — the fleet's shaping lane" before any responsibility list.
- **Positive-framed responsibilities with rationale** (Principle 2, 6): rewrote Core Responsibilities 5 and 6 to state what the lane owns and *why* the division of labor exists.
- **"Constraints" → "Scope Boundaries"**: rephrased four "Do not" items as positive boundary statements with reasons (review trail bounded, parallel lanes don't race, operator sees widened scope explicitly).
- **Surfacing Uncertainty section (new)** (Principle 4): explicit permission to pause and ask when the packet is ambiguous, framed as expected behavior not a last resort.
- **Deviate Authority section (new)** (Principle 5): explicit permission to return mis-scoped packets with a proposed reshape.
- **Reframed inline negations**: shallow-issues footer and Issue-Comment Mode "Do NOT create a branch" bullet flipped to positive framing with rationale.

## Preserved (per plan §First-Wave Proposal → steward-analyst → Preserve)

- YAML frontmatter — tool allow/deny, `name`, `description` unchanged (structural guardrails stay mechanical, not prose).
- Research Protocol section (including web-research defaults, skip conditions, search strategy).
- When To Use / When Not To Use sections.
- Delivery Modes section (Issue-Comment Mode, PR Mode, Mode Selection).
- Issue Package Standard.
- Handoff Standard.
- Workflow section.
- Success Criteria.

## Non-goals (per plan §Out of Scope)

- Tool frontmatter changes — not touched.
- Model assignment — unchanged (analyst inherits default model).
- `CLAUDE.md` / `.claude/rules/` / `.claude/skills/` — separate governance; not touched.
- Author-lane / brws-author / flex prompts — Wave 3 responsibility after Wave 1 observation.

## Diff size

`+50 / -14 = 64 lines touched`, within the plan's ~30–60 line budget for Wave 1 pilot lanes.

## Validation

- `make check-gated` → `✓ All checks passed (details: /tmp/make-check-wx2OTr)` (repo-linter + pre-commit hooks; docs-only PR, heavy jobs skipped via paths-filter per `.claude/rules/deferred/60_review_gate.md`).
- Spot-check re-read of rewritten prompt end-to-end: structure intact, negation count reduced to ~1 (preserved "When Not To Use" header), collaborative framing lifted where the plan called for it.
- Behavior regression risk: prompt governs a lane (analyst) whose structural guardrails (`disallowedTools: Agent`) enforce the most critical invariant mechanically. Per plan §Risks, softening prose on this lane is low-risk because guardrails are structural, which is exactly why analyst was selected as a Wave 1 pilot.

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git branch --show-current
author/agent-prompt-refresh-wave1-analyst
```

## Test Criteria

- **Pass:** `make check-gated` passes; diff touches only `.claude/agents/steward-analyst.md`; preserved sections unchanged in content and ordering; negation count reduced to ≤2; two new sections (Surfacing Uncertainty, Deviate Authority) present.
- **Verification:** `git diff origin/main...HEAD --stat` → one file, ~64 lines; `grep -cE '(DO NOT|Do NOT|MUST NOT|NEVER|Never)' .claude/agents/steward-analyst.md` → ≤2 (only preserved section headers).

## Issue Wiring

`Refs #2677` (Tier 2 — issue closes after Wave 1 observation window completes and Wave 2+ decisions are made per plan §Validation).

## Follow-ups (not this PR)

- Companion PR for `steward-ops` (Wave 1 other pilot lane) — follows immediately.
- Wave 2 (`steward-review`, `steward-orchestrator`) — gated on operator observation of Wave 1 for 7 calendar days per plan.
- Wave 3 author/brws/flex deduplication — gated on Wave 1+2 observation.
- Wave 4 specialist reviewers + repair — highest regression risk; last wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)