### PR TITLE
feat(ops): lane-status consumer — Signal 0 heartbeat + CLI (PR 2/3, #2415)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -72,8 +72,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from _repo_utils import find_repo_root
 
@@ -2992,13 +2993,210 @@ def cmd_lane(args: argparse.Namespace) -> int:
             print("Error: tmux capture-pane timed out", file=sys.stderr)
             return 1
 
+    elif action == "status":
+        return _cmd_lane_status(args)
+
     else:
         print(
             "Usage: ops.py lane refresh <lane-id> | --all-idle\n"
             "       ops.py lane check-approvals\n"
-            "       ops.py lane peek <lane-id> [--lines N]"
+            "       ops.py lane peek <lane-id> [--lines N]\n"
+            "       ops.py lane status [--lane <id>|--all] [--json] "
+            "[--no-process-tree]"
         )
         return 1
+
+
+def _cmd_lane_status(args: argparse.Namespace) -> int:
+    """Render structured per-lane status (issue #2415, PR 2/3).
+
+    Reads aggregate lane status + the PR #2686 heartbeat writer output and
+    prints a table (or JSON) with phase, freshness, last tool, and a
+    summary line per lane.  Subprocess-free by default aside from the
+    opt-in process-tree reconciler (on by default for this CLI; suppress
+    with ``--no-process-tree``).
+    """
+    from bid_euchre.ops.lane_heartbeat import read_heartbeat
+    from bid_euchre.ops.status import aggregate_status
+
+    # ``lane_id`` is the positional arg; ``--lane`` is the kwarg alias.
+    # Accept either.  Collision (both set with different values) is an error.
+    positional_lane: str | None = getattr(args, "lane_id", None)
+    flag_lane: str | None = getattr(args, "lane_flag", None)
+    if positional_lane and flag_lane and positional_lane != flag_lane:
+        print(
+            "Error: lane id given via positional and --lane disagree",
+            file=sys.stderr,
+        )
+        return 1
+    lane_filter: str | None = positional_lane or flag_lane
+    show_all: bool = bool(getattr(args, "all", False))
+    as_json: bool = bool(args.json)
+    # Process-tree reconciler defaults ON for the CLI (analyst-b design §3
+    # hybrid: CLI is the opt-in consumer that pays the subprocess cost).
+    # Operators can disable it via --no-process-tree for subprocess-free
+    # queries (e.g. inside a hook or high-frequency monitoring loop).
+    check_process_tree: bool = not bool(getattr(args, "no_process_tree", False))
+
+    if not show_all and not lane_filter:
+        print(
+            "Error: either a lane id, --all, or --lane <id> is required",
+            file=sys.stderr,
+        )
+        return 1
+
+    report = aggregate_status(
+        args.runtime_dir,
+        check_worktree=False,
+        check_process_tree=check_process_tree,
+    )
+
+    # Heartbeat dir resolution is per-lane.  PR #2686's hook writes into
+    # each lane's own worktree, so the orchestrator must read from
+    # ``<worktree_path>/.claude/runtime/lane_status`` for every other
+    # lane.  ``_resolve_heartbeat_dir`` encapsulates that precedence
+    # (worktree_path > runtime_dir > CWD default).
+    from bid_euchre.ops.status import _resolve_heartbeat_dir
+
+    # Filter lanes per CLI flags
+    if lane_filter and not show_all:
+        lanes_subset = [lane for lane in report.lanes if lane.lane_id == lane_filter]
+        if not lanes_subset:
+            print(f"Error: lane '{lane_filter}' not found in registry", file=sys.stderr)
+            return 1
+    else:
+        lanes_subset = list(report.lanes)
+
+    # Build row data: one dict per lane
+    rows: list[dict[str, Any]] = []
+    for lane in lanes_subset:
+        heartbeat_dir = _resolve_heartbeat_dir(
+            lane.worktree_path or None,
+            args.runtime_dir,
+        )
+        hb = read_heartbeat(lane.lane_id, runtime_dir=heartbeat_dir)
+        hb_age_s: int | None = None
+        hb_last_tool: str | None = None
+        hb_phase: str | None = None
+        if hb is not None:
+            updated = _parse_iso(hb.updated_at)
+            if updated is not None:
+                hb_age_s = int(
+                    max(0.0, (datetime.now(timezone.utc) - updated).total_seconds())
+                )
+            hb_last_tool = hb.last_tool
+            hb_phase = hb.phase
+
+        rows.append(
+            {
+                "lane_id": lane.lane_id,
+                "lane_class": lane.lane_class,
+                "phase": lane.state,
+                "has_active_session": lane.has_active_session,
+                "liveness_source": lane.liveness_source,
+                "attention_needed": lane.attention_needed,
+                "attention_reason": lane.attention_reason,
+                "current_task_id": lane.current_task_id,
+                "current_task_title": lane.current_task_title,
+                "heartbeat": {
+                    "present": hb is not None,
+                    "age_seconds": hb_age_s,
+                    "last_tool": hb_last_tool,
+                    "phase": hb_phase,
+                }
+                if hb is not None
+                else {"present": False},
+                "summary": _lane_summary(lane, hb_last_tool, hb_age_s),
+            }
+        )
+
+    if as_json:
+        print(json.dumps(rows, indent=2, default=str))
+        return 0
+
+    # Text render: fixed-width columns.  Widened lane_id to 15 chars to
+    # fit `brws-author-*` and similar.
+    header = f"{'LANE':<15} {'PHASE':<14} {'FRESH':<12} " f"{'LAST_TOOL':<10} SUMMARY"
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        age = (
+            row["heartbeat"].get("age_seconds")
+            if row["heartbeat"].get("present")
+            else None
+        )
+        fresh = _format_age(age) if age is not None else "—"
+        last_tool = (
+            (row["heartbeat"].get("last_tool") or "—")
+            if row["heartbeat"].get("present")
+            else "—"
+        )
+        marker = "!" if row["attention_needed"] else " "
+        print(
+            f"{row['lane_id']:<15} "
+            f"{row['phase']:<13}{marker} "
+            f"{fresh:<12} "
+            f"{last_tool:<10} "
+            f"{row['summary']}"
+        )
+    return 0
+
+
+def _format_age(seconds: int | None) -> str:
+    """Format an age in seconds compactly (e.g. ``45s``, ``3m12s``, ``1h2m``)."""
+    if seconds is None:
+        return "—"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        m, s = divmod(seconds, 60)
+        return f"{m}m{s}s"
+    h, rem = divmod(seconds, 3600)
+    m = rem // 60
+    return f"{h}h{m}m"
+
+
+def _parse_iso(text: str) -> Any:
+    """Local ISO-8601 parser tolerant of ``Z`` suffix.
+
+    Mirrors ``lane_heartbeat._parse_iso`` to avoid importing a
+    module-private helper.  Returns a timezone-aware datetime or ``None``.
+    """
+    if not isinstance(text, str) or not text:
+        return None
+    candidate = text
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(candidate)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _lane_summary(lane: Any, last_tool: str | None, hb_age_s: int | None) -> str:
+    """Build a short human-readable summary line for a lane.
+
+    Priority:
+    1. Blocked / attention_needed: surface the attention_reason.
+    2. In-progress task: ``"<task_title> (task <id>)"``.
+    3. Fresh heartbeat: ``"heartbeat <tool> <age>"``.
+    4. Idle: default label.
+    """
+    if lane.attention_needed and lane.attention_reason:
+        return lane.attention_reason
+    if lane.current_task_title:
+        tid = lane.current_task_id or "?"
+        return f"{lane.current_task_title} (task {tid})"
+    if last_tool is not None and hb_age_s is not None:
+        return f"heartbeat {last_tool} {_format_age(hb_age_s)}"
+    if lane.liveness_source == "registry":
+        return "session active"
+    if lane.state == "idle":
+        return "no active session"
+    return lane.state
 
 
 def cmd_workers(args: argparse.Namespace) -> int:
@@ -4502,6 +4700,44 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=80,
         help="Number of scrollback lines to capture (default: 80)",
+    )
+
+    # ``lane status`` — structured per-lane state (issue #2415, PR 2/3).
+    # Consumes the PR #2686 heartbeat writer and optionally the
+    # process-tree reconciler.
+    lane_status_parser = lane_sub.add_parser(
+        "status",
+        help=(
+            "Structured per-lane state (heartbeat + process-tree reconciler). "
+            "Issue #2415, PR 2/3."
+        ),
+    )
+    lane_status_parser.add_argument(
+        "lane_id",
+        nargs="?",
+        default=None,
+        help="Lane ID to query (e.g. author-a). Omit with --all.",
+    )
+    lane_status_parser.add_argument(
+        "--lane",
+        dest="lane_flag",
+        default=None,
+        help="Alias for the positional lane_id argument.",
+    )
+    lane_status_parser.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        help="Render status for every registered lane.",
+    )
+    lane_status_parser.add_argument(
+        "--no-process-tree",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the process-tree reconciler (disables tmux + pgrep "
+            "subprocesses). Use when only the heartbeat signal is needed."
+        ),
     )
 
     # workers (Platform-7: worker pool lifecycle management)

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -557,32 +557,9 @@ def _probe_fallback_liveness(
     stale_candidate: _LivenessProbe | None = None
     stale_age: float = float("inf")
 
-    # --- Signal 0: Lane heartbeat file (PostToolUse writer, PR #2686) ---
-    # The heartbeat is updated after every tool call, so a lane running
-    # `make check-quiet` for 30 min produces a fresh heartbeat per
-    # intermediate sub-command.  This is the primary signal that fixes
-    # issue #2415 F1 (lanes flipping to `[stale!]` while actively working).
-    #
-    # Cross-worktree resolution: PR #2686's hook CDs to ``$CLAUDE_PROJECT_DIR``
-    # before writing, so each lane's heartbeat file lives under its own
-    # worktree at ``<worktree_path>/.claude/runtime/lane_status/<lane>.json``.
-    # When the orchestrator (or any other lane) reads another lane's
-    # heartbeat, it must look at *that lane's* worktree — not its own.
-    # ``worktree_path`` comes from the worktree registry entry for the
-    # target lane.  When ``worktree_path`` is absent (unregistered lane,
-    # tests with no registry), we fall back to ``runtime_dir`` / CWD so
-    # self-reads and unit tests keep working.
-    #
-    # Missing file ⇒ fall through to S1-S5 (back-compat with sessions that
-    # predate the writer).  Malformed/unparseable ⇒ same.  See
-    # lane_heartbeat.read_heartbeat for the graceful-degradation contract.
-    #
-    # If neither ``worktree_path`` nor ``runtime_dir`` was supplied, skip
-    # Signal 0 entirely.  Falling through to ``read_heartbeat``'s CWD-relative
-    # default would leak the current process's own heartbeat directory into
-    # probe results — e.g. pytest running in a lane worktree would read that
-    # lane's hook-written heartbeats for every lane_id being probed, which
-    # poisons unit tests that rely on a clean idle baseline.
+    # Signal 0: lane heartbeat (PR #2686 writer). See docstring §0.
+    # Skip when neither worktree_path nor runtime_dir is supplied to avoid
+    # leaking the caller's CWD-relative default into probe results.
     heartbeat_dir = _resolve_heartbeat_dir(worktree_path, runtime_dir)
     hb = (
         read_heartbeat(lane_id, runtime_dir=heartbeat_dir)
@@ -756,26 +733,8 @@ def _probe_fallback_liveness(
                 exc_info=True,
             )
 
-    # --- Reconciler: Process-tree probe (opt-in, upgrade-only) ---
-    # If all data-driven signals indicate stale/idle, consult the OS
-    # process tree as a last-line reconciler.  This catches two failure
-    # modes that the data signals can't see:
-    #
-    # 1. The PostToolUse heartbeat hook silently stopped firing (Claude
-    #    Code upgrade, settings drift, hook crash) but validation is
-    #    still running.  `make check-quiet` will live-persist in pgrep
-    #    even if no heartbeat file has been written for an hour.
-    # 2. A lane has been working on a single long Bash call (typically
-    #    `make check-quiet` or a long `pytest`) that exceeds
-    #    ``stale_minutes``.  The heartbeat is fresh in this case too, but
-    #    this reconciler is the authoritative fallback when the heartbeat
-    #    writer has stalled.
-    #
-    # The reconciler is opt-in (``check_process_tree=False`` by default)
-    # because it requires 1-2 subprocesses per lane and would add
-    # noticeable latency to frequent dashboard renders.  The
-    # ``ops.py lane status`` CLI enables it; the dashboard does not
-    # (see analyst-b design §3 back-compat note).
+    # Reconciler: opt-in process-tree probe (see docstring). Upgrade-only —
+    # never downgrades a fresh signal. Catches stalled-heartbeat-but-live cases.
     if check_process_tree:
         try:
             if _probe_process_tree(

--- a/src/bid_euchre/ops/status.py
+++ b/src/bid_euchre/ops/status.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from bid_euchre.ops.lane_heartbeat import read_heartbeat
+
 logger = logging.getLogger("ops.status")
 
 DEFAULT_RUNTIME_DIR = Path(".claude/runtime")
@@ -447,6 +449,31 @@ class _LivenessProbe:
     detail: str  # human-readable explanation
 
 
+def _resolve_heartbeat_dir(
+    worktree_path: str | None,
+    runtime_dir: Path | None,
+) -> Path | None:
+    """Resolve the lane_status directory for heartbeat reads.
+
+    Precedence (issue #2415, PR 2/3):
+
+    1. If ``worktree_path`` is supplied, use
+       ``<worktree_path>/.claude/runtime/lane_status``.  This is the
+       cross-worktree read path — the orchestrator reading another
+       lane's heartbeat, where PR #2686's hook wrote it.
+    2. If ``runtime_dir`` is supplied (but no worktree_path), use
+       ``<runtime_dir>/lane_status``.  This matches unit tests and
+       self-reads where the caller already knows the local runtime root.
+    3. Otherwise return ``None`` so ``read_heartbeat`` falls through to
+       its own CWD-based default (``.claude/runtime/lane_status``).
+    """
+    if worktree_path:
+        return Path(worktree_path) / ".claude" / "runtime" / "lane_status"
+    if runtime_dir is not None:
+        return runtime_dir / "lane_status"
+    return None
+
+
 def _probe_fallback_liveness(
     lane_id: str,
     *,
@@ -458,11 +485,21 @@ def _probe_fallback_liveness(
     stale_minutes: int,
     worktree_path: str | None = None,
     check_worktree: bool = True,
+    runtime_dir: Path | None = None,
+    check_process_tree: bool = False,
+    tmux_session: str = "steward",
 ) -> _LivenessProbe:
     """Check repo-local signals for lane activity beyond registry session_id.
 
     Examines (in priority order):
 
+    0. **Lane heartbeat file** — if
+       ``.claude/runtime/lane_status/<lane_id>.json`` was written within
+       ``stale_minutes``, the lane recorded a PostToolUse tick recently.
+       This is the primary fix for issue #2415 failure mode F1: a lane
+       running ``make check-quiet`` emits a heartbeat after every tool
+       call and stays ``likely_active`` through the duration of the run.
+       Introduced as consumer of PR #2686's writer.
     1. **Recent events** — if the lane has an event within ``stale_minutes``,
        it was recently active.
     2. **In-progress tasks** — if the lane has an in-progress task with a
@@ -475,6 +512,15 @@ def _probe_fallback_liveness(
        ``subprocess.TimeoutExpired``, etc.) are caught and the signal is
        silently skipped so that a subprocess failure never blocks status
        aggregation.
+
+    After all signals have been evaluated, the probe optionally runs a
+    **process-tree reconciler** (opt-in via ``check_process_tree=True``).
+    If no signal yielded a fresh determination, and the lane's pane shell
+    has a live ``make``/``pytest``/``ruff`` child process, the probe
+    upgrades to ``likely_active`` with ``source="process_tree"``.  This
+    catches the "heartbeat hook silently stalled but validation is still
+    running" case (analyst-b design §3 hybrid). The reconciler never
+    downgrades a fresh signal — it only upgrades stale/idle results.
 
     Returns a ``_LivenessProbe`` indicating whether the lane is likely live,
     stale (evidence exists but is aging), or genuinely idle.
@@ -492,6 +538,16 @@ def _probe_fallback_liveness(
             subprocess is used as the lowest-priority liveness signal.
         check_worktree: If False, skip the dirty-worktree subprocess check
             entirely.  Default True.
+        runtime_dir: Runtime directory root (e.g. ``.claude/runtime``).
+            Used to locate the heartbeat directory
+            (``<runtime_dir>/lane_status``).  When ``None``, the heartbeat
+            reader falls back to its own default.
+        check_process_tree: Opt-in flag to consult the pane's OS process
+            tree as a reconciler.  Defaults to ``False`` so dashboard
+            renders remain subprocess-free.  Enabled by the
+            ``ops.py lane status`` CLI.
+        tmux_session: tmux session name to resolve the pane target for
+            the process-tree probe.  Default ``"steward"``.
 
     Returns:
         ``_LivenessProbe`` with the determination.
@@ -500,6 +556,62 @@ def _probe_fallback_liveness(
 
     stale_candidate: _LivenessProbe | None = None
     stale_age: float = float("inf")
+
+    # --- Signal 0: Lane heartbeat file (PostToolUse writer, PR #2686) ---
+    # The heartbeat is updated after every tool call, so a lane running
+    # `make check-quiet` for 30 min produces a fresh heartbeat per
+    # intermediate sub-command.  This is the primary signal that fixes
+    # issue #2415 F1 (lanes flipping to `[stale!]` while actively working).
+    #
+    # Cross-worktree resolution: PR #2686's hook CDs to ``$CLAUDE_PROJECT_DIR``
+    # before writing, so each lane's heartbeat file lives under its own
+    # worktree at ``<worktree_path>/.claude/runtime/lane_status/<lane>.json``.
+    # When the orchestrator (or any other lane) reads another lane's
+    # heartbeat, it must look at *that lane's* worktree — not its own.
+    # ``worktree_path`` comes from the worktree registry entry for the
+    # target lane.  When ``worktree_path`` is absent (unregistered lane,
+    # tests with no registry), we fall back to ``runtime_dir`` / CWD so
+    # self-reads and unit tests keep working.
+    #
+    # Missing file ⇒ fall through to S1-S5 (back-compat with sessions that
+    # predate the writer).  Malformed/unparseable ⇒ same.  See
+    # lane_heartbeat.read_heartbeat for the graceful-degradation contract.
+    #
+    # If neither ``worktree_path`` nor ``runtime_dir`` was supplied, skip
+    # Signal 0 entirely.  Falling through to ``read_heartbeat``'s CWD-relative
+    # default would leak the current process's own heartbeat directory into
+    # probe results — e.g. pytest running in a lane worktree would read that
+    # lane's hook-written heartbeats for every lane_id being probed, which
+    # poisons unit tests that rely on a clean idle baseline.
+    heartbeat_dir = _resolve_heartbeat_dir(worktree_path, runtime_dir)
+    hb = (
+        read_heartbeat(lane_id, runtime_dir=heartbeat_dir)
+        if heartbeat_dir is not None
+        else None
+    )
+    if hb is not None:
+        hb_updated = _parse_iso_timestamp(hb.updated_at)
+        if hb_updated is not None:
+            age = max(0.0, (now - hb_updated).total_seconds())
+            last_tool_label = hb.last_tool or "?"
+            if age <= threshold_seconds:
+                return _LivenessProbe(
+                    is_likely_live=True,
+                    is_stale=False,
+                    source="heartbeat",
+                    detail=(f"heartbeat {int(age)}s ago (last_tool={last_tool_label})"),
+                )
+            if stale_candidate is None or age < stale_age:
+                stale_age = age
+                stale_candidate = _LivenessProbe(
+                    is_likely_live=False,
+                    is_stale=True,
+                    source="heartbeat",
+                    detail=(
+                        f"heartbeat {int(age / 60)}m ago "
+                        f"(>{stale_minutes}m threshold)"
+                    ),
+                )
 
     # --- Signal 1: Recent events for this lane ---
     last_event = _find_last_event_for_lane(events, lane_id)
@@ -644,6 +756,49 @@ def _probe_fallback_liveness(
                 exc_info=True,
             )
 
+    # --- Reconciler: Process-tree probe (opt-in, upgrade-only) ---
+    # If all data-driven signals indicate stale/idle, consult the OS
+    # process tree as a last-line reconciler.  This catches two failure
+    # modes that the data signals can't see:
+    #
+    # 1. The PostToolUse heartbeat hook silently stopped firing (Claude
+    #    Code upgrade, settings drift, hook crash) but validation is
+    #    still running.  `make check-quiet` will live-persist in pgrep
+    #    even if no heartbeat file has been written for an hour.
+    # 2. A lane has been working on a single long Bash call (typically
+    #    `make check-quiet` or a long `pytest`) that exceeds
+    #    ``stale_minutes``.  The heartbeat is fresh in this case too, but
+    #    this reconciler is the authoritative fallback when the heartbeat
+    #    writer has stalled.
+    #
+    # The reconciler is opt-in (``check_process_tree=False`` by default)
+    # because it requires 1-2 subprocesses per lane and would add
+    # noticeable latency to frequent dashboard renders.  The
+    # ``ops.py lane status`` CLI enables it; the dashboard does not
+    # (see analyst-b design §3 back-compat note).
+    if check_process_tree:
+        try:
+            if _probe_process_tree(
+                lane_id,
+                tmux_session=tmux_session,
+                runtime_dir=runtime_dir,
+            ):
+                return _LivenessProbe(
+                    is_likely_live=True,
+                    is_stale=False,
+                    source="process_tree",
+                    detail="active validation process in lane pane tree",
+                )
+        except Exception as exc:  # noqa: BLE001
+            # Subprocess / tmux resolution failures must not block status
+            # aggregation.  Same policy as the dirty-worktree signal above.
+            logger.debug(
+                "process-tree probe failed for %s, skipping reconciler: %s",
+                lane_id,
+                exc,
+                exc_info=True,
+            )
+
     # --- No fresh evidence found ---
     if stale_candidate is not None:
         return stale_candidate
@@ -656,6 +811,42 @@ def _probe_fallback_liveness(
     )
 
 
+def _probe_process_tree(
+    lane_id: str,
+    *,
+    tmux_session: str = "steward",
+    runtime_dir: Path | None = None,
+) -> bool:
+    """Reconciler: return True if the lane's pane has a live validation proc.
+
+    Delegates to :func:`bid_euchre.ops.monitor._detect_background_validation`,
+    which uses ``tmux display-message`` + ``pgrep -P`` to discover
+    ``make``/``pytest``/``ruff`` children of the lane's shell PID.  The
+    implementation is kept in ``monitor`` so the approval-stall detector
+    and status probe share a single code path for process-tree lookup.
+
+    Args:
+        lane_id: The lane identifier.
+        tmux_session: tmux session name (default: ``"steward"``).
+        runtime_dir: Override for the runtime directory root.
+
+    Returns:
+        ``True`` if a validation process is detected.  ``False`` on any
+        failure (no pane, no subprocess tools available, timeout) — the
+        reconciler is strictly upgrade-only and must never be the cause
+        of a negative state change.
+    """
+    from bid_euchre.ops.monitor import _detect_background_validation
+
+    return bool(
+        _detect_background_validation(
+            lane_id,
+            tmux_session=tmux_session,
+            runtime_dir=runtime_dir,
+        )
+    )
+
+
 def synthesize_lane_activity(
     lanes_data: list[dict[str, Any]],
     sessions_by_lane: dict[str, dict[str, Any]],
@@ -665,6 +856,8 @@ def synthesize_lane_activity(
     now: datetime | None = None,
     stale_minutes: int = STALE_MINUTES,
     check_worktree: bool = True,
+    runtime_dir: Path | None = None,
+    check_process_tree: bool = False,
 ) -> list[LaneStatus]:
     """Synthesize lane-activity view from existing repo-local state.
 
@@ -673,10 +866,14 @@ def synthesize_lane_activity(
     current task, PR linkage, and attention flags.
 
     When ``has_active_session`` is False for a lane, the function runs a
-    fallback liveness probe checking recent events, in-progress tasks,
-    session metadata, and registry timestamps. Lanes with fresh evidence
-    are marked ``"likely_active"``; lanes with stale evidence become
-    ``"stale"``; lanes with no evidence remain ``"idle"``.
+    fallback liveness probe checking (in order): the lane heartbeat file
+    (PR #2686 writer), recent events, in-progress tasks, session metadata,
+    and registry timestamps. Lanes with fresh evidence are marked
+    ``"likely_active"``; lanes with stale evidence become ``"stale"``;
+    lanes with no evidence remain ``"idle"``.  When ``check_process_tree``
+    is True, a process-tree reconciler upgrades stale/idle lanes to
+    ``"likely_active"`` (with ``liveness_source="process_tree"``) if a
+    validation process is running in the lane's pane tree.
 
     Args:
         lanes_data: Worktree registry entries.
@@ -689,6 +886,13 @@ def synthesize_lane_activity(
         check_worktree: If False, skip the dirty-worktree subprocess probe
             in the fallback liveness check.  Useful for fast status queries
             when 7+ worktrees would each spawn a ``git status`` subprocess.
+        runtime_dir: Runtime directory root (e.g. ``.claude/runtime``).
+            Threaded through to the heartbeat reader and process-tree
+            reconciler.  When ``None`` each helper uses its own default.
+        check_process_tree: Opt-in reconciler flag.  Defaults to ``False``
+            for render-path callers (dashboard) to avoid the
+            ``tmux display-message`` + ``pgrep`` subprocess cost per lane.
+            The ``ops.py lane status`` CLI enables it.
 
     Returns:
         List of enriched LaneStatus objects.
@@ -751,6 +955,8 @@ def synthesize_lane_activity(
                 now=now,
                 stale_minutes=stale_minutes,
                 check_worktree=check_worktree,
+                runtime_dir=runtime_dir,
+                check_process_tree=check_process_tree,
             )
             probe_detail = probe.detail
             if probe.is_likely_live:
@@ -966,6 +1172,7 @@ def aggregate_status(
     runtime_dir: Path | None = None,
     *,
     check_worktree: bool = True,
+    check_process_tree: bool = False,
 ) -> StatusReport:
     """Build a unified status report across lanes, sessions, and tasks.
 
@@ -974,6 +1181,10 @@ def aggregate_status(
         check_worktree: If False, skip dirty-worktree subprocess probes
             in the fallback liveness check.  Saves ~1 ``git status``
             subprocess per idle lane (7+ with all protected worktrees).
+        check_process_tree: If True, enable the process-tree reconciler
+            in the fallback liveness check.  Costs 1 ``tmux
+            display-message`` + 1 ``pgrep`` per stale/idle lane and is
+            disabled by default.  Enabled by ``ops.py lane status``.
 
     Returns:
         StatusReport with categorized entries and warnings.
@@ -1037,6 +1248,8 @@ def aggregate_status(
         tasks_by_lane,
         events,
         check_worktree=check_worktree,
+        runtime_dir=runtime_dir,
+        check_process_tree=check_process_tree,
     )
 
     # Session metadata files are preserved for resume/audit — they are

--- a/tests/unit/test_ops_cli_lane_status.py
+++ b/tests/unit/test_ops_cli_lane_status.py
@@ -1,0 +1,490 @@
+"""CLI shape tests for ``ops.py lane status`` (issue #2415, PR 2/3).
+
+Verifies that the ``lane status`` subcommand:
+
+- Renders a table header + per-lane row when ``--all`` is passed.
+- Renders a single lane's row when a lane id is given positionally
+  or via ``--lane``.
+- Emits a JSON array when the top-level ``--json`` flag is combined
+  with ``lane status``.
+- Reports clear exit codes (``1``) for missing args, unknown lanes,
+  and positional/flag collisions.
+- Surfaces heartbeat fields (``age_seconds``, ``last_tool``,
+  ``phase``) in the JSON payload when a per-lane heartbeat file is
+  present in the lane's worktree.
+- Skips the tmux/pgrep reconciler when ``--no-process-tree`` is
+  passed (important for subprocess-free monitoring loops).
+
+These tests are complementary to ``test_ops_status_heartbeat.py``,
+which covers the underlying Signal-0 probe.  This file exercises the
+CLI integration surface: argparse wiring, row formatting, JSON
+encoding, and error reporting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ``ops.py`` lives under ``scripts/internal`` (not on the package path).
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+
+
+@pytest.fixture(autouse=True)
+def _add_scripts_path() -> None:
+    """Make ``scripts/internal/ops.py`` importable as ``ops``."""
+    path_str = str(SCRIPTS_DIR)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Path:
+    """Minimal runtime layout expected by ``aggregate_status``."""
+    rd = tmp_path / "runtime"
+    for sub in (
+        "worktree_registry",
+        "session_metadata",
+        "task_state",
+        "events",
+        "scheduler",
+    ):
+        (rd / sub).mkdir(parents=True)
+    return rd
+
+
+def _write_registry_entry(
+    runtime_dir: Path,
+    *,
+    lane_id: str,
+    lane_class: str,
+    worktree_path: Path,
+) -> None:
+    """Write a v2 worktree registry entry for a lane."""
+    entry = {
+        "schema_version": 2,
+        "lane_id": lane_id,
+        "lane_class": lane_class,
+        "worktree_path": str(worktree_path),
+        "role": lane_class,
+        "display_name": lane_id,
+        "legacy_role": lane_class,
+        "tmux_session": "steward",
+        "tmux_window": lane_id,
+        "tmux_pane": "0",
+        "session_handle": None,
+        "visibility": None,
+    }
+    path = runtime_dir / "worktree_registry" / f"{lane_id}.json"
+    path.write_text(json.dumps(entry))
+
+
+def _write_heartbeat(
+    worktree_path: Path,
+    *,
+    lane_id: str,
+    age_seconds: int,
+    last_tool: str = "Bash",
+    phase: str = "implementing",
+) -> None:
+    """Write a heartbeat JSON into a lane's worktree at a pinned age."""
+    hb_dir = worktree_path / ".claude" / "runtime" / "lane_status"
+    hb_dir.mkdir(parents=True, exist_ok=True)
+    updated = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    payload = {
+        "schema_version": 1,
+        "lane_id": lane_id,
+        "pid": 99999,
+        "session_id": "test-session",
+        "updated_at": updated.isoformat().replace("+00:00", "Z"),
+        "last_tool": last_tool,
+        "phase": phase,
+        "extras": {"cwd": str(worktree_path)},
+    }
+    (hb_dir / f"{lane_id}.json").write_text(json.dumps(payload))
+
+
+@pytest.fixture()
+def two_lane_fixture(runtime_dir: Path, tmp_path: Path) -> dict[str, Any]:
+    """Two registered lanes; author-a has a fresh heartbeat, author-b is
+    idle (no heartbeat file).  Both worktree directories exist.
+    """
+    wt_a = tmp_path / "Bid-Euchre-steward-author-a"
+    wt_b = tmp_path / "Bid-Euchre-steward-author-b"
+    wt_a.mkdir()
+    wt_b.mkdir()
+    _write_registry_entry(
+        runtime_dir, lane_id="author-a", lane_class="author", worktree_path=wt_a
+    )
+    _write_registry_entry(
+        runtime_dir, lane_id="author-b", lane_class="author", worktree_path=wt_b
+    )
+    _write_heartbeat(wt_a, lane_id="author-a", age_seconds=30, last_tool="Edit")
+    return {"wt_a": wt_a, "wt_b": wt_b}
+
+
+# ---------------------------------------------------------------------------
+# --all text rendering
+# ---------------------------------------------------------------------------
+
+
+class TestLaneStatusAll:
+    """``ops.py lane status --all`` — table shape."""
+
+    def test_prints_header_and_one_row_per_lane(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "--all",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Header columns
+        assert "LANE" in out
+        assert "PHASE" in out
+        assert "FRESH" in out
+        assert "LAST_TOOL" in out
+        assert "SUMMARY" in out
+        # One row per lane
+        assert "author-a" in out
+        assert "author-b" in out
+        # Fresh heartbeat leaks last_tool into row
+        assert "Edit" in out
+
+    def test_all_respects_no_process_tree_and_stays_subprocess_free(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+    ) -> None:
+        """``--no-process-tree`` ⇒ no tmux/pgrep subprocesses are spawned
+        from the probe path."""
+        import ops
+
+        with patch(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            side_effect=AssertionError("reconciler must not run"),
+        ):
+            rc = ops.main(
+                [
+                    "--runtime-dir",
+                    str(runtime_dir),
+                    "lane",
+                    "status",
+                    "--all",
+                    "--no-process-tree",
+                ]
+            )
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Single-lane filter (positional and --lane alias)
+# ---------------------------------------------------------------------------
+
+
+class TestLaneStatusFilter:
+    """Single-lane selection via positional or ``--lane`` alias."""
+
+    def test_positional_lane_id_filters_output(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "author-a",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "author-a" in out
+        assert "author-b" not in out
+
+    def test_flag_alias_matches_positional(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "--lane",
+                "author-b",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "author-b" in out
+        assert "author-a" not in out
+
+    def test_unknown_lane_returns_error(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "ghost-lane",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "ghost-lane" in err
+        assert "not found" in err.lower()
+
+    def test_positional_and_flag_collision_errors(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Passing both positional + ``--lane`` with different values must
+        fail loudly rather than silently preferring one."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "author-a",
+                "--lane",
+                "author-b",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "disagree" in err.lower() or "conflict" in err.lower()
+
+    def test_no_args_returns_error(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Neither ``--all`` nor a lane id is a usage error."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "lane",
+                "status",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "required" in err.lower() or "lane" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# JSON output shape
+# ---------------------------------------------------------------------------
+
+
+class TestLaneStatusJson:
+    """``--json`` flag emits a valid JSON array with the documented schema."""
+
+    def test_json_all_is_valid_array(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--json",
+                "lane",
+                "status",
+                "--all",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        ids = {row["lane_id"] for row in parsed}
+        assert ids == {"author-a", "author-b"}
+
+    def test_json_single_lane_is_valid_array_of_one(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--json",
+                "lane",
+                "status",
+                "author-b",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["lane_id"] == "author-b"
+
+    def test_json_row_surfaces_heartbeat_fields(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--json",
+                "lane",
+                "status",
+                "author-a",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        row = parsed[0]
+        # Documented top-level fields
+        for field in (
+            "lane_id",
+            "lane_class",
+            "phase",
+            "has_active_session",
+            "liveness_source",
+            "attention_needed",
+            "heartbeat",
+            "summary",
+        ):
+            assert field in row, f"missing field {field!r} in row keys={list(row)}"
+        # Heartbeat sub-object is populated because author-a has a
+        # fresh file at age=30s.
+        hb = row["heartbeat"]
+        assert hb["present"] is True
+        assert hb["last_tool"] == "Edit"
+        assert hb["phase"] == "implementing"
+        # age is non-negative integer seconds (we wrote at 30s; clock
+        # may have advanced during the test, so accept >= 30 as well).
+        assert isinstance(hb["age_seconds"], int)
+        assert hb["age_seconds"] >= 0
+
+    def test_json_row_for_lane_without_heartbeat(
+        self,
+        runtime_dir: Path,
+        two_lane_fixture: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A lane with no heartbeat file reports ``heartbeat.present = False``."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--json",
+                "lane",
+                "status",
+                "author-b",
+                "--no-process-tree",
+            ]
+        )
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        row = parsed[0]
+        assert row["lane_id"] == "author-b"
+        assert row["heartbeat"] == {"present": False}
+
+
+# ---------------------------------------------------------------------------
+# Parser wiring (defensive guards)
+# ---------------------------------------------------------------------------
+
+
+class TestLaneStatusParser:
+    """Guard against accidental removal of subparser / flags."""
+
+    def test_subparser_registered(self) -> None:
+        """``lane status`` is reachable from the top-level parser."""
+        import ops
+
+        parser = ops.build_parser()
+        # Parse a minimal invocation that the parser will accept without
+        # actually running the command (we use a fake runtime-dir and
+        # trust the ``rc`` path above for behaviour tests).
+        ns = parser.parse_args(["lane", "status", "author-a", "--no-process-tree"])
+        assert ns.command == "lane"
+        assert ns.lane_action == "status"
+        assert ns.lane_id == "author-a"
+        assert ns.no_process_tree is True
+
+    def test_all_flag_exposed(self) -> None:
+        import ops
+
+        parser = ops.build_parser()
+        ns = parser.parse_args(["lane", "status", "--all"])
+        assert ns.all is True
+
+    def test_lane_flag_alias_exposed(self) -> None:
+        import ops
+
+        parser = ops.build_parser()
+        ns = parser.parse_args(["lane", "status", "--lane", "author-c"])
+        assert ns.lane_flag == "author-c"

--- a/tests/unit/test_ops_status_heartbeat.py
+++ b/tests/unit/test_ops_status_heartbeat.py
@@ -1,0 +1,659 @@
+"""Tests for Signal 0 (lane heartbeat) and process-tree reconciler in status.py.
+
+Covers the consumer half of issue #2415 (PR 2/3) — the writer half (PR #2686)
+is exercised by ``tests/unit/test_lane_heartbeat.py``.  These tests verify
+that:
+
+- A fresh heartbeat file produces ``state = "likely_active"`` with
+  ``liveness_source = "heartbeat"``.
+- A stale heartbeat (exists but past threshold) contributes a stale
+  candidate, which may be overridden by fresher signals from S1-S5 or by
+  the process-tree reconciler.
+- A missing / malformed heartbeat file falls through to S1-S5 so
+  back-compat with pre-PR-2686 sessions is preserved.
+- The process-tree reconciler only upgrades stale/idle results to
+  ``likely_active`` and never downgrades a fresh signal.
+- Reads respect cross-worktree heartbeat-file locations (each lane's hook
+  writes into its own worktree).
+
+Tests use ``tmp_path`` to build a realistic per-lane heartbeat layout and
+monkey-patch ``_detect_background_validation`` to avoid invoking tmux/pgrep.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bid_euchre.ops.lane_heartbeat import write_heartbeat
+from bid_euchre.ops.status import (
+    _LivenessProbe,
+    _probe_fallback_liveness,
+    _resolve_heartbeat_dir,
+    synthesize_lane_activity,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def now_utc() -> datetime:
+    """Frozen reference time for deterministic freshness math."""
+    return datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def lane_worktree(tmp_path: Path) -> Path:
+    """Create a per-lane worktree layout with .claude/runtime/lane_status."""
+    wt = tmp_path / "Bid-Euchre-steward-author-b"
+    (wt / ".claude" / "runtime" / "lane_status").mkdir(parents=True)
+    return wt
+
+
+def _write_lane_heartbeat(
+    worktree: Path,
+    lane_id: str,
+    *,
+    updated_at: str,
+    last_tool: str | None = "Bash",
+    phase: str | None = "implementing",
+    pid: int = 12345,
+) -> Path:
+    """Write a heartbeat JSON file directly for controlled aging in tests.
+
+    We sidestep ``write_heartbeat`` because the writer always uses
+    ``datetime.now(utc)`` and we need to pin the timestamp to a known past
+    value to exercise the stale path.
+    """
+    path = worktree / ".claude" / "runtime" / "lane_status" / f"{lane_id}.json"
+    payload = {
+        "schema_version": 1,
+        "lane_id": lane_id,
+        "pid": pid,
+        "session_id": "test-session",
+        "updated_at": updated_at,
+        "last_tool": last_tool,
+        "phase": phase,
+        "extras": {"cwd": str(worktree)},
+    }
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _resolve_heartbeat_dir precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolveHeartbeatDir:
+    """Heartbeat directory precedence: worktree > runtime_dir > CWD default."""
+
+    def test_worktree_path_wins(self, tmp_path: Path) -> None:
+        wt = tmp_path / "lane-worktree"
+        wt.mkdir()
+        resolved = _resolve_heartbeat_dir(str(wt), Path("/somewhere/else"))
+        assert resolved == wt / ".claude" / "runtime" / "lane_status"
+
+    def test_runtime_dir_fallback(self, tmp_path: Path) -> None:
+        rt = tmp_path / "runtime"
+        rt.mkdir()
+        resolved = _resolve_heartbeat_dir(None, rt)
+        assert resolved == rt / "lane_status"
+
+    def test_none_none_defers_to_reader(self) -> None:
+        """With no worktree and no runtime_dir, return None so read_heartbeat's
+        own default (CWD-relative) takes effect."""
+        assert _resolve_heartbeat_dir(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# Signal 0: fresh/stale/missing heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestSignalZeroFresh:
+    """Fresh heartbeat → likely_active with liveness_source='heartbeat'."""
+
+    def test_fresh_heartbeat_wins_over_stale_event(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # Heartbeat 30s ago ⇒ fresh. Event 60min ago ⇒ stale.
+        # Expectation: probe returns 'likely_active' via heartbeat,
+        # not stale via events.
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(seconds=30)).isoformat(),
+        )
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": (now_utc - timedelta(minutes=60)).isoformat(),
+            }
+        ]
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=events,
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is True
+        assert probe.is_stale is False
+        assert probe.source == "heartbeat"
+        assert "last_tool=Bash" in probe.detail
+
+    def test_boundary_exactly_at_threshold_is_fresh(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # is_fresh uses <= threshold_seconds. At exactly 30min it should
+        # still be considered fresh per the documented boundary.
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(minutes=30)).isoformat(),
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "heartbeat"
+
+
+class TestSignalZeroStale:
+    """Stale heartbeat contributes a stale candidate, not a fresh result."""
+
+    def test_stale_heartbeat_only_yields_stale_candidate(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # Heartbeat 45min ago ⇒ past 30min threshold. No other signals.
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(minutes=45)).isoformat(),
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is False
+        assert probe.is_stale is True
+        assert probe.source == "heartbeat"
+
+    def test_stale_heartbeat_with_fresher_event_prefers_event(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # Heartbeat 45min ago (stale). Event 10min ago (fresh).
+        # Expectation: probe returns 'likely_active' via events (S1 short
+        # circuits once a fresh signal is found).
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(minutes=45)).isoformat(),
+        )
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": (now_utc - timedelta(minutes=10)).isoformat(),
+            }
+        ]
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=events,
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "events"
+
+
+class TestSignalZeroMissingOrMalformed:
+    """Missing / malformed heartbeat ⇒ fall-through preserves S1-S5 behavior."""
+
+    def test_missing_heartbeat_falls_through_to_events(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # No heartbeat file at all. Event 10min ago drives the probe.
+        events = [
+            {
+                "lane_id": "author-b",
+                "event_type": "ci_success",
+                "timestamp": (now_utc - timedelta(minutes=10)).isoformat(),
+            }
+        ]
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=events,
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "events"
+
+    def test_malformed_heartbeat_treated_as_missing(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # File exists but contains garbage JSON. read_heartbeat returns
+        # None, so the probe falls through to S1-S5.
+        path = lane_worktree / ".claude" / "runtime" / "lane_status" / "author-b.json"
+        path.write_text("{ this is not json")
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is False
+        assert probe.is_stale is False
+        assert probe.source is None
+
+    def test_heartbeat_with_bad_timestamp_contributes_no_signal(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        # Valid JSON but unparseable updated_at — treat as if we had no
+        # heartbeat (both fresh and stale paths guard on _parse_iso).
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at="not-a-timestamp",
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        # No signal ⇒ genuinely idle.
+        assert probe.is_likely_live is False
+        assert probe.is_stale is False
+        assert probe.source is None
+
+
+# ---------------------------------------------------------------------------
+# Process-tree reconciler (opt-in, upgrade-only)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessTreeReconciler:
+    """Reconciler only upgrades stale/idle; never downgrades a fresh signal."""
+
+    def test_reconciler_disabled_by_default(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With check_process_tree=False (default), the reconciler never
+        runs even when pgrep would return a live pytest."""
+
+        calls: list[str] = []
+
+        def fake_detect(*_args: Any, **_kwargs: Any) -> bool:
+            calls.append("detect")
+            return True
+
+        monkeypatch.setattr(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            fake_detect,
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+            # check_process_tree defaults to False
+        )
+        assert probe.is_likely_live is False
+        assert probe.source is None
+        assert calls == []
+
+    def test_reconciler_upgrades_idle_to_likely_active(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No heartbeat, no events, but pytest is running ⇒
+        likely_active via process_tree."""
+
+        monkeypatch.setattr(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            lambda *a, **kw: True,
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+            check_process_tree=True,
+        )
+        assert probe.is_likely_live is True
+        assert probe.is_stale is False
+        assert probe.source == "process_tree"
+
+    def test_reconciler_upgrades_stale_heartbeat_to_process_tree(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Hook-stalled (stale heartbeat) but make/pytest still alive ⇒
+        liveness_source flips to process_tree."""
+
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(minutes=45)).isoformat(),
+        )
+        monkeypatch.setattr(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            lambda *a, **kw: True,
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+            check_process_tree=True,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "process_tree"
+
+    def test_reconciler_never_runs_when_fresh_signal_exists(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fresh heartbeat short-circuits before the reconciler is reached.
+        Protects the "upgrade-only" invariant: with a fresh signal the
+        reconciler never runs — not even to re-confirm."""
+
+        calls: list[str] = []
+
+        def should_not_be_called(*_args: Any, **_kwargs: Any) -> bool:
+            calls.append("detect")
+            return False
+
+        monkeypatch.setattr(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            should_not_be_called,
+        )
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(seconds=10)).isoformat(),
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+            check_process_tree=True,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "heartbeat"
+        assert calls == [], "Reconciler must not run when a fresh data signal exists"
+
+    def test_reconciler_failure_is_swallowed(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the process-tree probe raises, the probe must still return
+        a stale/idle result — subprocess errors cannot corrupt status."""
+
+        def boom(*_args: Any, **_kwargs: Any) -> bool:
+            raise RuntimeError("tmux not available")
+
+        monkeypatch.setattr(
+            "bid_euchre.ops.monitor._detect_background_validation",
+            boom,
+        )
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now_utc,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+            check_process_tree=True,
+        )
+        # With no other signals and reconciler-raise, the probe returns
+        # the default idle result.
+        assert probe.is_likely_live is False
+        assert probe.is_stale is False
+        assert probe.source is None
+
+
+# ---------------------------------------------------------------------------
+# synthesize_lane_activity integration
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeWithHeartbeat:
+    """End-to-end: heartbeat signal propagates into LaneStatus."""
+
+    def test_lane_becomes_likely_active_from_fresh_heartbeat(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(seconds=5)).isoformat(),
+        )
+        lanes = [
+            {
+                "lane_id": "author-b",
+                "lane_class": "author",
+                "worktree_path": str(lane_worktree),
+                "branch": "feat/x",
+                "class": "persistent",
+                "session_id": None,
+                "last_active": None,
+            }
+        ]
+        result = synthesize_lane_activity(
+            lanes, {}, {}, [], now=now_utc, check_worktree=False
+        )
+        lane = result[0]
+        assert lane.state == "likely_active"
+        assert lane.liveness_source == "heartbeat"
+        assert lane.attention_needed is False
+
+    def test_lane_without_heartbeat_preserves_legacy_idle(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        """Regression guard: when no heartbeat file exists and no other
+        signal fires, the lane stays at its prior classification (idle)."""
+        lanes = [
+            {
+                "lane_id": "author-b",
+                "lane_class": "author",
+                "worktree_path": str(lane_worktree),  # no heartbeat written
+                "branch": "feat/x",
+                "class": "persistent",
+                "session_id": None,
+                "last_active": None,
+            }
+        ]
+        result = synthesize_lane_activity(
+            lanes, {}, {}, [], now=now_utc, check_worktree=False
+        )
+        lane = result[0]
+        assert lane.state == "idle"
+        assert lane.liveness_source is None
+
+    def test_fresh_heartbeat_suppresses_stale_attention(
+        self,
+        lane_worktree: Path,
+        now_utc: datetime,
+    ) -> None:
+        """Core F1 fix: a lane whose only non-heartbeat signals are >30min
+        stale must render as likely_active (not stale) and not raise the
+        attention flag.  This is the failure mode that drove #2415."""
+        _write_lane_heartbeat(
+            lane_worktree,
+            "author-b",
+            updated_at=(now_utc - timedelta(seconds=20)).isoformat(),
+        )
+        lanes = [
+            {
+                "lane_id": "author-b",
+                "lane_class": "author",
+                "worktree_path": str(lane_worktree),
+                "branch": "feat/x",
+                "class": "persistent",
+                "session_id": None,
+                # last_active 60min ago — would have flipped to stale pre-PR-2
+                "last_active": (now_utc - timedelta(minutes=60)).isoformat(),
+            }
+        ]
+        result = synthesize_lane_activity(
+            lanes, {}, {}, [], now=now_utc, check_worktree=False
+        )
+        lane = result[0]
+        assert lane.state == "likely_active"
+        assert lane.attention_needed is False
+
+
+# ---------------------------------------------------------------------------
+# write_heartbeat round-trip (integration smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteReadRoundTrip:
+    """End-to-end: real write_heartbeat feeds the probe correctly."""
+
+    def test_fresh_write_reads_as_likely_active(
+        self,
+        lane_worktree: Path,
+    ) -> None:
+        hb_dir = lane_worktree / ".claude" / "runtime" / "lane_status"
+        write_heartbeat(
+            "author-b",
+            tool_name="Bash",
+            phase="implementing",
+            runtime_dir=hb_dir,
+        )
+        now = datetime.now(timezone.utc)
+        probe = _probe_fallback_liveness(
+            "author-b",
+            session=None,
+            lane_tasks=[],
+            events=[],
+            last_active_ts=None,
+            now=now,
+            stale_minutes=30,
+            worktree_path=str(lane_worktree),
+            check_worktree=False,
+        )
+        assert probe.is_likely_live is True
+        assert probe.source == "heartbeat"
+
+
+# ---------------------------------------------------------------------------
+# _LivenessProbe sanity
+# ---------------------------------------------------------------------------
+
+
+def test_liveness_probe_shape_unchanged() -> None:
+    """Guard against accidental API drift on the probe result type.
+
+    PR 3/3 and downstream consumers depend on these four attributes."""
+    probe = _LivenessProbe(
+        is_likely_live=True, is_stale=False, source="heartbeat", detail="x"
+    )
+    assert probe.is_likely_live is True
+    assert probe.is_stale is False
+    assert probe.source == "heartbeat"
+    assert probe.detail == "x"


### PR DESCRIPTION
## Summary

Consumer half of issue #2415. Reads the PR #2686 heartbeat writer output
and surfaces it through the status aggregation pipeline + a new `lane status`
CLI. Fixes failure mode **F1**: lanes flipping to `[stale!]` while actively
working through long validation runs (`make check-quiet`, etc.) because none
of S1-S5 advanced during the pause between events.

- **`src/bid_euchre/ops/status.py`** — insert **Signal 0** at the top of
  `_probe_fallback_liveness`. A fresh
  `<worktree>/.claude/runtime/lane_status/<lane>.json` (age ≤ `stale_minutes`)
  wins over stale S1-S5; a stale heartbeat contributes a stale candidate
  that fresher signals can override. Cross-worktree reads use the target
  lane's registry `worktree_path` so the orchestrator (or any other lane)
  reads *that* lane's heartbeat file, not its own. Skips Signal 0 entirely
  when neither `worktree_path` nor `runtime_dir` is supplied to avoid
  leaking the caller's CWD-relative heartbeat dir into unit-test results.
- **`src/bid_euchre/ops/status.py`** — add a **process-tree reconciler**
  (opt-in via `check_process_tree`). Delegates to
  `monitor._detect_background_validation` — only upgrades stale/idle to
  `likely_active` with `source="process_tree"`, never downgrades a fresh
  signal. Implements the analyst-b hybrid design (a)+(c).
- **`scripts/internal/ops.py`** — new `lane status [<lane_id>|--lane <id>|--all]
  [--json] [--no-process-tree]` subcommand. Renders a fixed-width table or
  JSON array with `phase`, `fresh`, `last_tool`, and a one-line summary.
  Process-tree reconciler defaults ON for CLI use; hooks / dashboards use
  `--no-process-tree` to stay subprocess-free.

## Plan Reference

N/A — session-scoped follow-up to issue #2415. This is PR 2/3 of the 3-PR
sequence explicitly scoped in the issue body:

- **PR 1/3** — heartbeat writer (merged as #2686)
- **PR 2/3** — this PR (status.py Signal 0 + `lane-status` CLI consumer)
- **PR 3/3** — dashboard UI rewrite (pending, separate scope)

## Why

PR #2686 landed the heartbeat **writer** but no consumer existed — the
writer's output was invisible to status aggregation. PR 3/3 (dashboard UI
rewrite) will layer onto this CLI / probe output.

## Repro

```bash
# Against a running fleet runtime — shows cross-worktree heartbeat resolution
uv run python scripts/internal/ops.py \
    --runtime-dir /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/runtime \
    lane status --all --no-process-tree
```

Expected shape (abridged):

```
LANE            PHASE          FRESH        LAST_TOOL  SUMMARY
--------------------------------------------------------------
author-b        likely_active  4s           Bash       #2415 PR 2/3: ... (task 94a6904d0ebc)
author-c        likely_active  4m52s        Bash       #2169 Slice C: ... (task ebb92d45b2fb)
author-d        likely_active  1m45s        Bash       #2677 execute agent prompt refresh ... (task 7cb8467405ee)
analyst-a       stale        ! -            -          stale heartbeat/evidence (registry last_active 70m ago (>30m threshold))
```

JSON mode:

```bash
uv run python scripts/internal/ops.py \
    --runtime-dir /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/.claude/runtime \
    --json lane status --all --no-process-tree | jq '.[0]'
```

## Tests

**New files:**

- `tests/unit/test_ops_status_heartbeat.py` — **20 tests** covering
  fresh/stale/missing/malformed heartbeats, reconciler upgrade semantics
  (never downgrades fresh), `synthesize_lane_activity` integration with
  fresh heartbeat + 60-min-stale `last_active` (direct F1 regression
  guard), cross-worktree resolution precedence, real `write_heartbeat`
  round-trip, and a `_LivenessProbe` shape API guard for PR 3.
- `tests/unit/test_ops_cli_lane_status.py` — **14 tests** covering table
  shape (`--all`), single-lane filter (positional + `--lane` alias),
  unknown-lane error exit code, positional/flag collision error,
  missing-arg error, JSON-array shape, heartbeat sub-object presence,
  `--no-process-tree` subprocess-free path, argparse wiring guards.

## Validation Performed

```
$ uv run python -m pytest tests/unit/test_ops_status_heartbeat.py \
    tests/unit/test_ops_cli_lane_status.py \
    tests/unit/test_ops_status.py tests/unit/test_lane_heartbeat.py
228 passed in 0.80s
```

```
$ git fetch origin main && git rebase origin/main
Successfully rebased and updated refs/heads/feat/lane-status-consumer-2415.

$ make check-gated
All checks passed (details: /tmp/make-check-SfsFdl)
```

**Live cross-worktree smoke** (validated author-b/c/d all show their
individual heartbeat ages correctly, confirming the registry
`worktree_path` -> `.claude/runtime/lane_status/` resolution):

```
$ uv run python scripts/internal/ops.py --runtime-dir .../Bid-Euchre/.claude/runtime \
    lane status --all --no-process-tree
author-b   likely_active  4s     Bash   #2415 PR 2/3: lane-status consumer ...
author-c   likely_active  4m52s  Bash   #2169 Slice C: TaskPacket routing metadata ...
author-d   likely_active  1m45s  Bash   #2677 execute agent prompt refresh ...
```

## Follow-up commits

- `229d2e41` — collapse Signal 0 / reconciler prose comments after the X3
  precheck flagged two 26-line and 20-line documentation blocks as
  "large commented-out code". The docstring for `_probe_fallback_liveness`
  already documents both features. No behaviour change; 228 tests still pass.

## Worktree Proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git worktree list
...
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b   HEAD [feat/lane-status-consumer-2415]
```

## Scope

Refs #2415 (Tier 2 — verified close will land with PR 3/3 dashboard UI
switchover).

- **In scope:** Signal 0 probe, process-tree reconciler, `lane status` CLI,
  unit tests.
- **Out of scope:** Dashboard UI rewrite (PR 3/3), hook changes (PR #2686
  already landed), promoting the reconciler to always-on for non-CLI
  consumers.

Generated with Claude Code.