### PR TITLE
chore(convention): sweep fix:convention backlog (2 closed, 2 fixed, 4 deferred)

### DIFF
--- a/scripts/internal/audit_portability.py
+++ b/scripts/internal/audit_portability.py
@@ -51,7 +51,7 @@ PATTERNS: list[CouplingPattern] = [
     # -- Hard-block: string literals that embed the project name -----------
     CouplingPattern(
         name="worktree-name-literal",
-        regex=r'"Bid-Euchre-steward-[^"]*"',
+        regex=r"""["']Bid-Euchre-steward-[^"']*["']""",
         severity="hard-block",
         description=(
             "Hard-coded worktree directory names (e.g., "
@@ -60,7 +60,7 @@ PATTERNS: list[CouplingPattern] = [
     ),
     CouplingPattern(
         name="project-name-literal",
-        regex=r'"Bid-Euchre"',
+        regex=r"""["']Bid-Euchre["']""",
         severity="hard-block",
         description=(
             "Hard-coded project name string.  Should come from adapter config "

--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -281,12 +281,15 @@ def test_auction_log_all_bidders_visible_mobile(
         )
 
         # The helper must not overshoot the auction phase — if it does,
-        # the layout assertions below are meaningless (#2612).
-        assert mobile_page.locator("#trick-area").count() == 0, (
-            "Helper _advance_to_four_bidders overshot the auction phase — "
-            "game transitioned to trick_play before auction layout could be "
-            "verified (#2612)."
-        )
+        # the layout assertions below are meaningless (#2612).  Skip rather
+        # than hard-fail: overshoot is a helper-race precondition, not a
+        # product bug, so skipping avoids flaky CI red (#2615).
+        if mobile_page.locator("#trick-area").count() > 0:
+            pytest.skip(
+                "Helper _advance_to_four_bidders overshot the auction phase — "
+                "game transitioned to trick_play before auction layout could be "
+                "verified (#2612, #2615)."
+            )
 
         # The list container should NOT be scrollable during auction
         list_el = mobile_page.locator(".action-rail__list")
@@ -371,12 +374,15 @@ def test_auction_log_all_bidders_visible_mobile_big_text(
         ), f"Expected ≥4 auction log items but found {item_count} (#2594)."
 
         # The helper must not overshoot the auction phase — if it does,
-        # the layout assertions below are meaningless (#2612).
-        assert mobile_page.locator("#trick-area").count() == 0, (
-            "Helper _advance_to_four_bidders overshot the auction phase — "
-            "game transitioned to trick_play before auction layout could be "
-            "verified (#2612)."
-        )
+        # the layout assertions below are meaningless (#2612).  Skip rather
+        # than hard-fail: overshoot is a helper-race precondition, not a
+        # product bug, so skipping avoids flaky CI red (#2615).
+        if mobile_page.locator("#trick-area").count() > 0:
+            pytest.skip(
+                "Helper _advance_to_four_bidders overshot the auction phase — "
+                "game transitioned to trick_play before auction layout could be "
+                "verified (#2612, #2615)."
+            )
 
         # Check the list container is NOT scrollable (big text mode)
         list_el = mobile_page.locator(".action-rail__list")

--- a/tests/unit/test_portability_audit.py
+++ b/tests/unit/test_portability_audit.py
@@ -61,8 +61,8 @@ def _load_audit_module():
 # They should only decrease as decoupling work proceeds.  If a PR increases
 # coupling, either fix the regression or update the threshold with justification.
 
-NON_COSMETIC_THRESHOLD = 260  # hard-block + soft-coupling (baseline: 253)
-HARD_BLOCK_THRESHOLD = 135  # hard-block only (baseline: 130)
+NON_COSMETIC_THRESHOLD = 253  # hard-block + soft-coupling (pinned to baseline)
+HARD_BLOCK_THRESHOLD = 130  # hard-block only (pinned to baseline)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Triaged 8 stale `fix:convention` follow-up issues against current main. Per-issue disposition:

| # | Disposition | Action in this PR |
|---|---|---|
| #2683 | RESOLVED | Close with evidence via `verify_issue_closure.py prove` |
| #2682 | RESOLVED | Close with evidence via `verify_issue_closure.py prove` |
| #2658 | MIXED (2 trivial / 1 defer) | Pin thresholds + broaden quote regex; defer "coupling-presence" redesign |
| #2654 | STILL VALID, NON-TRIVIAL | Comment + re-tag; defer |
| #2653 | STILL VALID, NON-TRIVIAL | Comment + re-tag; defer |
| #2651 | DUPLICATE of #2654 | Close as dup |
| #2645 | NON-TRIVIAL (schema contract) | Comment + re-tag; defer |
| #2615 | STILL VALID, TRIVIAL | Convert hard-fail assert → `pytest.skip` |

## Why

The `fix:convention` label accumulates auto-filed follow-ups from the review coordinator. Several had been superseded by subsequent refactors or were no-op findings. This sweep clears the trivially-resolvable ones and re-scopes the genuinely non-trivial ones so they don't rot on the backlog.

## Changes

| File | Change |
|------|--------|
| `tests/unit/test_portability_audit.py` | Pin `NON_COSMETIC_THRESHOLD` to 253 and `HARD_BLOCK_THRESHOLD` to 130 (matching the documented baseline + current counts). Finding (1) of #2658. |
| `scripts/internal/audit_portability.py` | Extend `worktree-name-literal` and `project-name-literal` regexes to match single-quoted string literals too (`["']Bid-Euchre…["']`). Finding (3) of #2658. Defensive — currently zero single-quoted hits in `src/bid_euchre/ops`, but closes the gap for future code. |
| `tests/browser/test_mobile.py` | Convert the overshoot-detection assertion to `pytest.skip` in both `test_auction_log_all_bidders_visible_mobile` and its big-text variant. Overshoot is a helper-race precondition (not a product bug); skipping avoids flaky CI red. Finding of #2615. |

## Deferred (non-trivial)

These are left open with re-tag comments and will each become bounded follow-up PRs:

- **#2658 (finding 2)** — `test_all_severity_levels_present` requires each severity class to be present. A successful decoupling pass could empty `hard-block` entirely and perversely fail the test. Replacement needs a pattern-detection test against a fixture file — out of scope here.
- **#2654** — `_opponents_void_in_suit` uses modulo-4 seat arithmetic, which forces a sitting-out seat to have recorded a void before the void-backed lead check fires. Needs loner/moon-mode coverage in `tests/unit/test_greedy.py`.
- **#2653** — Migration `except (OperationalError, ProgrammingError)` is too broad. Proper fix requires cross-driver error detection (PostgreSQL SQLSTATE 42701 + SQLite string match) plus tests for both drivers on production migration paths.
- **#2645** — `counterfactual` (REQUIRED) vs `glutton_action` (OPTIONAL) export-schema inconsistency. Per `.claude/rules/deferred/30_data_contract.md`, schema contract changes need their own PR with schema docs + consumer migration path + tests.

## Repro / Validation

```bash
# Tier 1 (impacted tests)
uv run python -m pytest tests/unit/test_portability_audit.py -v
# → 6 passed

# Audit counts still match (tightened thresholds hold)
uv run python scripts/internal/audit_portability.py
# Total coupling: 550
#   Non-cosmetic: 253  (hard-block 130 + soft-coupling 123)
#   Cosmetic:     297

# Tier 2
make check-gated
# ✓ All checks passed
```

## Test Criteria

- **Pass condition:** `tests/unit/test_portability_audit.py` passes with the tightened thresholds; ruff check clean on all three files; `make check-gated` green.
- **Verification:** `uv run python -m pytest tests/unit/test_portability_audit.py -v && uv run ruff check scripts/internal/audit_portability.py tests/unit/test_portability_audit.py tests/browser/test_mobile.py`
- **Expected:** 6 tests pass; "All checks passed!" from ruff.

## PR Wiring

- Uses `Refs` (not `Fixes`) — individual closures happen via `verify_issue_closure.py prove` after merge, per `.claude/rules/deferred/55_issue_closure.md`.
- Refs: #2683 #2682 #2658 #2615 #2654 #2653 #2651 #2645

## Tests

- [x] `uv run python -m pytest tests/unit/test_portability_audit.py -v` — 6 passed
- [x] `uv run ruff check …` — All checks passed
- [x] `make check-gated` — ✓ All checks passed

## Worktree proof

```
pwd:     /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
top:     /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
branch:  chore/convention-sweep-2026-04
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)