### PR TITLE
docs(ops): refresh steward-ops prompt (Wave 1 — valued teammate)

### DIFF
--- a/.claude/agents/steward-ops.md
+++ b/.claude/agents/steward-ops.md
@@ -8,14 +8,37 @@ disallowedTools:
   - Agent
 ---
 
-You are ops, the operator and monitoring lane in the steward dashboard.
+You are the steward-ops lane — the fleet's operator and monitoring surface.
+You keep the dashboard honest: tracking lane health, CI, logs, worktrees,
+and blocked states, then surfacing the next safe action so the orchestrator
+can unblock the fleet.
 
 Operating rules:
 - Monitor status, CI, logs, worktrees, and blocked states.
-- Do not edit code unless explicitly delegated.
 - Classify before retrying.
 - Keep loops bounded and surface the next safe action clearly.
 - Distinguish observed facts from inferred state when reporting status.
+- Edits route to author lanes; ops stays read-only except when the
+  orchestrator explicitly delegates a change. (`Edit`, `Write`, and `Agent`
+  are disabled in the YAML frontmatter above — this is a structural
+  guardrail, not a prose rule.)
+
+## Read-Only Investigation Authority
+
+You have full authority to run read-only investigation across the repo and
+fleet state — `gh`, `git log`, `git status`, log files, dashboard outputs,
+the message bus CLI, tmux pane inspection — without asking for permission.
+This is the primary lane function. When a finding calls for a code change,
+write up the evidence and escalate to the orchestrator; implementation is
+an author-lane responsibility by design.
+
+## Surfacing Uncertainty
+
+If the repo state contradicts what the dashboard shows, or a lane's
+heartbeat pattern is ambiguous (dead vs. deep-in-a-long-step), surface the
+uncertainty to the orchestrator with the evidence you have rather than
+asserting a nominal or critical status. One round of clarification is
+cheap; a confidently-wrong status drives wrong recovery actions downstream.
 
 ## Primary Status Surface
 


### PR DESCRIPTION
## Summary

Executes Wave 1 of `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md` for the ops lane. Companion to PR #2692 (steward-analyst), which merged moments before this PR was opened.

**Plan:** `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md`
**Parent issue:** #2677
**Pilot scope:** `steward-analyst` + `steward-ops` only (Wave 1). Waves 2–4 are gated on operator observation per plan §Migration Strategy.

## Why

Per plan §Research Findings, Anthropic's published guidance:
- Endorses the "capable teammate" framing.
- Warns against aggressive negative framing.
- Recommends positive instructions with rationale.
- Treats uncertainty-surfacing as a trained Claude safety property that prompts should grant explicitly.

The plan's §Current-State Inventory marks `steward-ops` as "the cleanest prompt in the fleet" (1 negation, 2 collaborative tokens), so changes here are deliberately minimal. The primary additions are two explicit affordances (read-only investigation authority, uncertainty-surfacing) that the prompt previously only implied.

## Changes (exact file scope)

- `.claude/agents/steward-ops.md` (only file touched)

Per plan §First-Wave Proposal → `steward-ops`:

- **Lead with role identity** (Principle 1): open with "You are the steward-ops lane — the fleet's operator and monitoring surface" plus one-sentence rationale ("keep the dashboard honest …").
- **Replace "Do not edit code" bullet with positive framing** (Principle 2): new bullet states the positive invariant ("Edits route to author lanes; ops stays read-only …") and points at the structural guardrail in YAML (`Edit`, `Write`, `Agent` disabled) — making clear that enforcement is mechanical, not prose-based (Principle 8).
- **Read-Only Investigation Authority section (new)** (Principle 5): explicit latitude to run `gh`, `git log/status`, log inspection, dashboard outputs, message bus CLI, tmux pane inspection without asking. Mirrors the strong autonomy grant pattern from `steward-review` that the plan's §Good Patterns called out.
- **Surfacing Uncertainty section (new)** (Principle 4): covers the ambiguous-signal case (dashboard vs. repo mismatch; dead lane vs. deep-in-a-long-step). Grants Claude the trained uncertainty-surfacing behavior as first-class lane behavior.

## Preserved (per plan §First-Wave Proposal → steward-ops → Preserve)

- YAML frontmatter — `model: sonnet`, `disallowedTools: [Edit, Write, Agent]`, name, description unchanged.
- Primary Status Surface section (dashboard commands).
- Message Bus section (operator command examples).
- Automated Monitoring (SP-3-08) section (cron loop, monitoring cycle behavior, severity routing, CLI flags).
- Manual Health Check section (What to check, Reporting convention).
- All operator-tooling command examples (explicit non-goal in the plan).

## Non-goals (per plan §Out of Scope)

- Tool frontmatter — unchanged.
- Model assignment (`sonnet`) — unchanged.
- Operator-tooling reference list — preserved verbatim.

## Diff size

`+25 / -2 = 27 lines touched`. The plan's budget for ops is "minor re-ordering + two added sentences"; this is right at the low end because the prompt was already the cleanest in the fleet.

## Validation

- `make check-quiet` → `✓ All checks passed (details: /tmp/make-check-k6afj9)` on full suite.
- `make check-gated` initially showed 3 flakes in `tests/unit/test_cpu_gate.py` (load-aware tests sensitive to concurrent semaphore execution). Standalone re-run: `uv run python -m pytest tests/unit/test_cpu_gate.py -v` → `10 passed`. These are known-flaky load-aware tests unrelated to prompt changes; `make check-quiet` (no concurrency cap) passes cleanly.
- Spot-check re-read end-to-end: preserved sections untouched in content and ordering; new sections read as permission grants, not prohibitions; structural guardrail pointer (YAML frontmatter) reinforces the point without adding negation.

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git branch --show-current
author/agent-prompt-refresh-wave1-ops
$ git diff origin/main --stat
 .claude/agents/steward-ops.md | 27 +++++++++++++++++++++++++--
```

## Test Criteria

- **Pass:** `make check-quiet` passes; diff touches only `.claude/agents/steward-ops.md`; preserved sections unchanged (Primary Status Surface, Message Bus, Automated Monitoring, Manual Health Check); opening paragraph leads with role identity; new sections (Read-Only Investigation Authority, Surfacing Uncertainty) are present.
- **Verification:** `git diff origin/main...HEAD --stat .claude/agents/steward-ops.md` → one file, ~27 lines; the only prose negation count goes from 1 → 0 (the "Do not edit code" bullet is replaced with a positive rephrase that also cites the structural YAML guardrail).

## Issue Wiring

`Refs #2677` (Tier 2 — parent issue closes after Wave 1 observation window completes per plan §Validation).

## Follow-ups (not this PR)

- Observe both Wave 1 lanes (this + #2692) for 7 calendar days per plan.
- Operator writes impression note.
- Sample 10 transcripts across refreshed vs. non-refreshed lanes.
- Decide on Wave 2 (`steward-review`, `steward-orchestrator`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)