### PR TITLE
fix(ops): capture PR headRefOid via gh, not local git HEAD (#2706)

### DIFF
--- a/scripts/internal/review_driver.py
+++ b/scripts/internal/review_driver.py
@@ -1550,6 +1550,37 @@ def _should_timeout(
     return elapsed > max_runtime_s
 
 
+def _capture_pr_head_sha(pr_number: int) -> str | None:
+    """Return the PR's GitHub-reported ``headRefOid``, or ``None`` on failure.
+
+    Historically the driver read the SHA via ``git rev-parse HEAD`` on the
+    local worktree. When invoked from a worktree whose checkout was not the
+    PR branch (for example, the orchestrator's main checkout), that resolved
+    to the wrong SHA — typically ``main`` — and the pre-merge-review-guard
+    correctly rejected the resulting verdict as a SHA mismatch. See #2706.
+
+    Asking GitHub directly decouples the captured SHA from the worktree's
+    checkout state.
+
+    Force-push semantics: the SHA is captured once, at loop start. If the PR
+    is force-pushed mid-review, the verdict records the pre-force-push SHA
+    and the merge guard will (correctly) reject it against the new PR HEAD.
+    A subsequent driver invocation reinitializes state keyed on the new SHA.
+    """
+    from github_pr_state import get_pr_head_sha
+
+    try:
+        sha = get_pr_head_sha(pr_number)
+    except RuntimeError as exc:
+        logger.warning(
+            "PR #%d: could not fetch headRefOid from GitHub (%s) — proceeding without SHA",
+            pr_number,
+            exc,
+        )
+        return None
+    return sha or None
+
+
 def main() -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="Autonomous review coordinator driver")
@@ -1584,15 +1615,8 @@ def main() -> int:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
-    # Get current HEAD SHA for idempotency tracking
-    head_sha_result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-    )
-    head_sha = (
-        head_sha_result.stdout.strip() if head_sha_result.returncode == 0 else None
-    )
+    # Capture the PR's HEAD SHA (not the local worktree HEAD) — see #2706.
+    head_sha = _capture_pr_head_sha(args.pr)
 
     # Load or initialize state (with SHA-based staleness check)
     loop_state = load_state(args.pr, head_sha=head_sha)

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -14,11 +14,13 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
 
 from review_driver import (
+    _capture_pr_head_sha,
     _create_follow_up_issues,
     _ensure_branch_checkout,
     _format_review_comment,
     _parse_plan_files,
     _should_timeout,
+    _write_verdict_if_applicable,
     check_scope_drift,
     classify_review_mode,
     parse_plan_reference,
@@ -1744,3 +1746,107 @@ class TestEnsureBranchCheckout:
         mock_run.side_effect = OSError("git not found")
         result = _ensure_branch_checkout("main")
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _capture_pr_head_sha (#2706)
+# ---------------------------------------------------------------------------
+
+
+class TestCapturePRHeadSha:
+    """Verify the driver reads PR HEAD from GitHub, not the local worktree.
+
+    Regression test for #2706: when the driver ran from a worktree whose
+    checkout was not the PR branch (e.g. the main checkout), ``git rev-parse
+    HEAD`` returned the local branch SHA — typically ``main`` — and the
+    resulting verdict.json was rejected by the pre-merge-review-guard as a
+    SHA mismatch against the PR's actual head.
+    """
+
+    def test_returns_pr_head_ref_oid(self) -> None:
+        """Happy path: returns the SHA reported by github_pr_state.get_pr_head_sha."""
+        pr_sha = "9ff9639eaa6884e194132fe11f54ad29c0c85c43"
+        with patch("github_pr_state.get_pr_head_sha", return_value=pr_sha):
+            assert _capture_pr_head_sha(2661) == pr_sha
+
+    def test_does_not_invoke_git_rev_parse(self) -> None:
+        """The SHA must come from the GitHub API, not ``git rev-parse HEAD``.
+
+        The original bug (#2706) was exactly this: the driver shelled out to
+        ``git rev-parse HEAD`` and trusted whatever SHA the current worktree
+        happened to be pointing at. Fail hard if any future refactor
+        reintroduces a local git call from this helper.
+        """
+        pr_sha = "9ff9639eaa6884e194132fe11f54ad29c0c85c43"
+        with (
+            patch("github_pr_state.get_pr_head_sha", return_value=pr_sha),
+            patch("review_driver.subprocess.run") as mock_run,
+        ):
+            _capture_pr_head_sha(2661)
+        assert (
+            mock_run.call_count == 0
+        ), "SHA capture must not shell out to git — that was exactly the bug"
+
+    def test_runtime_error_from_gh_returns_none(self) -> None:
+        """If ``gh pr view`` fails, log and return None (do not fall back to local HEAD)."""
+        with patch(
+            "github_pr_state.get_pr_head_sha",
+            side_effect=RuntimeError("gh CLI failed: 403"),
+        ):
+            assert _capture_pr_head_sha(2661) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Guard against an empty SHA leaking into loop state."""
+        with patch("github_pr_state.get_pr_head_sha", return_value=""):
+            assert _capture_pr_head_sha(2661) is None
+
+    def test_captured_sha_flows_into_verdict(self, tmp_path: Path) -> None:
+        """End-to-end: a captured PR SHA propagates through initialize_state
+        and ``_write_verdict_if_applicable`` into the written verdict.
+
+        This is the tightest test of the #2706 fix: the verdict.json consumed
+        by the pre-merge-review-guard contains the PR's headRefOid, not some
+        unrelated local SHA.
+        """
+        from review_driver import initialize_state
+        from review_state import ReviewMode, ReviewState
+
+        from bid_euchre.ops.review_queue import read_verdict
+
+        pr_number = 2661
+        pr_sha = "9ff9639eaa6884e194132fe11f54ad29c0c85c43"
+        local_main_sha = "d72e5ce851c6cff3a7590c6e69fdbf1841fd7301"
+
+        # 1. Simulate driver capture: mock the GitHub lookup to return the
+        #    PR's headRefOid. (If the old code path ran, it would return the
+        #    local main SHA instead — that would flow into the verdict.)
+        with patch("github_pr_state.get_pr_head_sha", return_value=pr_sha):
+            captured = _capture_pr_head_sha(pr_number)
+        assert captured == pr_sha
+        assert captured != local_main_sha, (
+            "Sanity check: the test fixtures must differ so a regression "
+            "that reintroduced the local-HEAD path would be caught"
+        )
+
+        # 2. Feed the captured SHA through state initialization (as main() does).
+        state = initialize_state(
+            pr_number,
+            branch="dependabot/uv/python-multipart-0.0.26",
+            mode=ReviewMode.STANDARD,
+            head_sha=captured,
+        )
+        # Simulate the loop reaching READY_TO_MERGE.
+        state.state = ReviewState.READY_TO_MERGE.value
+
+        # 3. Write the verdict via the same helper the driver uses.
+        with patch(
+            "bid_euchre.ops.review_queue.shared_queue_root", return_value=tmp_path
+        ):
+            _write_verdict_if_applicable(state)
+
+        verdict = read_verdict(pr_number, tmp_path)
+        assert verdict is not None, "Verdict must be written"
+        assert verdict.reviewed_sha == pr_sha, (
+            f"Verdict SHA must be PR head ({pr_sha[:8]}), not local main "
+            f"({local_main_sha[:8]}). This is the #2706 regression guard."
+        )


### PR DESCRIPTION
## Summary

- Replace `git rev-parse HEAD` in `review_driver.main()` with a call to `get_pr_head_sha()` (which uses `gh pr view <N> --json headRefOid`), so `verdict.json` records the PR's actual HEAD SHA instead of whatever the orchestrator's local worktree happens to be checked out on.
- Extract the capture logic into `_capture_pr_head_sha(pr_number)` so it can be tested directly.
- Add five unit tests including a regression guard that fails if any future refactor reintroduces a local `git` call on the SHA-capture path.

Refs #2706 (Tier 2 per `rules/deferred/55_issue_closure.md` — needs verified-close on a live PR after merge).

## Plan

N/A (bounded bug fix, one concept per PR per `rules/deferred/40_prs.md`).

## Why

From #2706: running `review_driver.py --pr <N> --branch <branch> --trigger manual` from the main checkout produced a `verdict.json` whose `reviewed_sha` was the orchestrator's local `main` HEAD, not the PR's HEAD. The pre-merge-review-guard then (correctly) rejected the verdict, blocking `gh pr merge` even though the verdict said `passed`. Operators worked around it by editing `verdict.json` directly — a risky bypass of the integrity check.

The fix decouples the captured SHA from the worktree's checkout state entirely: ask GitHub what the PR's head is.

Force-push semantics are documented in a comment on the new helper: the SHA is captured once at loop start; if the PR is force-pushed mid-review, the verdict records the pre-force-push SHA and the merge guard will (correctly) reject it against the new PR HEAD, triggering a fresh review run keyed on the new SHA (via `load_state`'s staleness check).

## Repro / Validation

**Regression repro (pre-fix):**
```
# From main checkout (not a PR worktree):
uv run python scripts/internal/review_driver.py --pr <any_open_PR> --branch <branch> --trigger manual
cat .claude/runtime/review_queue/pr_<N>/verdict.json | jq .reviewed_sha
# Pre-fix: matches local main HEAD.
# Post-fix: matches gh pr view <N> --json headRefOid --jq .headRefOid.
```

**Unit tests (Tier 1):**
```
uv run python -m pytest tests/unit/test_review_driver.py -v
# 93 passed in 2.00s — including 5 new tests in TestCapturePRHeadSha.
```

**Lint:**
```
uv run ruff check scripts/internal/review_driver.py tests/unit/test_review_driver.py
# All checks passed.
```

**Tier 2 (`make check-gated`):**
- 11829 passed, 1 failed (`tests/unit/test_portability_audit.py::test_non_cosmetic_coupling_below_threshold`: 257 > 253 threshold).
- **Verified pre-existing on `origin/main`** by checking out `origin/main`'s version of the test and rerunning — same 257 vs 253 failure. Not caused by this PR; my change adds no new `src/` cross-module imports.

## Tests

- `TestCapturePRHeadSha::test_returns_pr_head_ref_oid` — happy path via mocked helper
- `TestCapturePRHeadSha::test_does_not_invoke_git_rev_parse` — regression guard against reintroducing the local `git` call
- `TestCapturePRHeadSha::test_runtime_error_from_gh_returns_none` — graceful fallback on `gh` failure
- `TestCapturePRHeadSha::test_empty_string_returns_none` — guard against empty SHA leaking into loop state
- `TestCapturePRHeadSha::test_captured_sha_flows_into_verdict` — end-to-end through `initialize_state` + `_write_verdict_if_applicable` into `verdict.json`

## Worktree proof

\`\`\`
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
$ git worktree list | head -5
# steward-author-d persistent lane worktree (per rules/75_worktree_protection.md)
\`\`\`

Refs #2706