### PR TITLE
docs(ops): update fleet-check/check-in/monitor skills to use lane-status CLI (#2415 follow-up)

### DIFF
--- a/.claude/skills/check-in/SKILL.md
+++ b/.claude/skills/check-in/SKILL.md
@@ -100,10 +100,34 @@ Examples:
 
 ### Phase 2 — Lane Health
 
-6. **Check dashboard state:**
+6. **Classify per-lane state with the heartbeat-aware CLI** (preferred for
+   per-lane liveness; see #2415 and PR #2695), then read the aggregate
+   dashboard for fleet-wide signals:
    ```bash
+   # Per-lane phase classification (Signal 0 heartbeat + process-tree reconciler)
+   uv run python scripts/internal/ops.py lane status --all
+
+   # Aggregate fleet view — token economy, attention items, task-queue totals,
+   # warnings. Ignore dashboard's per-lane `stale!` / `active` flag for
+   # classification decisions (it uses the older 30-minute registry heuristic
+   # that mis-labels working lanes as stale during long validation runs,
+   # #2415 F1). PR 3/3 of #2415 will swap dashboard onto the same classifier.
    uv run python scripts/internal/ops.py --json dashboard --no-probe
    ```
+
+   `lane status` distinguishes `likely_active`, `stale`, `idle`, and
+   `unknown` even when a lane is mid-way through a long `make check-quiet`
+   run — use its output (not `dashboard`'s `[stale!]` flag) for dispatch
+   and recovery decisions.
+
+   > **Known limitation — pre-#2686 sessions.** The heartbeat writer hook
+   > shipped in PR #2686 (2026-04-21). Sessions launched **before** that
+   > restart do not write heartbeats; `lane status` will fall back to
+   > stale registry evidence and may show `stale!` for those lanes even
+   > though the pane is alive. This primarily affects the control-plane
+   > lanes (orchestrator, ops, review) until each one restarts.
+   > Cross-check with `capture-pane` when a long-running lane unexpectedly
+   > reports stale.
 
 7. **Inspect attention items and warnings.** Look for:
    - Lanes with no recent activity (potential stalls)

--- a/.claude/skills/fleet-check/SKILL.md
+++ b/.claude/skills/fleet-check/SKILL.md
@@ -64,8 +64,9 @@ Check for completed tasks and dispatch new work:
 # Check task queue for completed items
 uv run python scripts/internal/ops.py task list
 
-# Check fleet status for idle lanes
-uv run python scripts/internal/ops.py fleet
+# Check per-lane state to find idle lanes (heartbeat-aware, post-#2415)
+uv run python scripts/internal/ops.py --json lane status --all | \
+  jq -r '.[] | select(.phase == "idle" or .phase == "stale") | .lane_id'
 ```
 
 For each completed task:
@@ -73,16 +74,28 @@ For each completed task:
 2. Update any governing plan checkpoints
 3. Identify the next dispatchable task
 
-For each idle lane:
+For each idle lane (from `lane status` output above, not `dashboard`):
 1. Check if there are approved task packets in the queue
 2. Dispatch if scope is clear and lane is healthy
+
+> **Do not use `dashboard`'s `[stale!]` flag to infer idle-ness.** The
+> dashboard classifier relies on a 30-minute `last_active` registry
+> heuristic, which mis-classifies working lanes as stale during long
+> validation runs (#2415 F1). `lane status --all` uses the Signal 0
+> heartbeat + process-tree reconciler and gets it right.
 
 ### Step 4 -- Full Check-In
 
 Run the standard check-in cycle for situational awareness:
 
 ```bash
-# Lane health via dashboard
+# Per-lane health via the heartbeat-aware classifier (preferred for
+# per-lane liveness classification — see #2415, PR #2695)
+uv run python scripts/internal/ops.py lane status --all
+
+# Aggregate dashboard — still the right tool for token economy,
+# attention items, task-queue totals, and warnings. Do NOT read per-lane
+# liveness from here; it uses the older 30-minute `last_active` heuristic.
 uv run python scripts/internal/ops.py dashboard
 
 # Open PRs status
@@ -91,6 +104,15 @@ gh pr list --state open --json number,title,headRefName --limit 20
 # Any stuck lanes
 # (Use /capture-pane --stuck if needed)
 ```
+
+> **Known limitation — pre-#2686 sessions.** The heartbeat writer
+> (`.claude/runtime/lane_status/<lane>.json`) shipped in PR #2686 on
+> 2026-04-21. Sessions that launched **before** that restart do not write
+> heartbeats. For those lanes, `lane status` falls back to stale registry
+> evidence and may show `stale!` even though the pane is alive. This
+> primarily affects the control-plane lanes (orchestrator, ops, review)
+> until each one restarts. Cross-check with `capture-pane` when a
+> long-running lane unexpectedly reports stale.
 
 ### Step 5 -- Remote Status Update (Optional)
 
@@ -136,3 +158,6 @@ This replaces the previous three-cron pattern:
 - `.claude/skills/monitor/SKILL.md` -- ops lane monitoring (complementary)
 - `.claude/skills/delegate-task/SKILL.md` -- task dispatch workflow
 - `.claude/skills/lane-status/SKILL.md` -- lane health assessment
+- Issue #2415 + PR #2686 (heartbeat writer) + PR #2695 (`lane status`
+  consumer CLI) -- the Signal 0 heartbeat infrastructure that replaces
+  the old registry-based stale classification

--- a/.claude/skills/lane-status/SKILL.md
+++ b/.claude/skills/lane-status/SKILL.md
@@ -15,7 +15,40 @@ prompt, token count, and model info — even when the session is actively
 working. Reading only the last few lines of a pane capture will
 systematically misclassify active lanes as idle. This skill prevents that.
 
-## Assessment Procedure
+## Quickest path — heartbeat-aware CLI
+
+For the common case of "is lane X working or idle right now?", prefer the
+shipped CLI consumer from PR #2695:
+
+```bash
+# Single lane
+uv run python scripts/internal/ops.py lane status <lane-id>
+
+# All registered lanes, fixed-width table
+uv run python scripts/internal/ops.py lane status --all
+
+# All lanes, JSON (for scripting / filtering)
+uv run python scripts/internal/ops.py --json lane status --all
+
+# Hook / cron context — skip the subprocess-spawning process-tree reconciler
+uv run python scripts/internal/ops.py lane status --all --no-process-tree
+```
+
+The CLI renders a fixed-width table with columns `LANE`, `PHASE`, `FRESH`,
+`LAST_TOOL`, `SUMMARY`, where `PHASE` ∈ `{active, likely_active, stale,
+blocked, idle, unknown}`. It is powered by Signal 0 (the heartbeat file at
+`<worktree>/.claude/runtime/lane_status/<lane>.json` written by the PR
+#2686 PostToolUse hook) plus a process-tree reconciler that upgrades
+`stale`/`idle` to `likely_active` when a live tmux pane or `claude` child
+process is detected.
+
+The manual 3-signal procedure below is still correct for edge cases:
+classifying approval-blocked lanes, deciding whether a dirty worktree
+represents active work or a stall, or cross-checking when a lane reports
+`stale` but you suspect the pre-#2686 heartbeat blind spot (sessions that
+launched before 2026-04-21).
+
+## Assessment Procedure (manual, 3-signal)
 
 For each lane, gather THREE signals and cross-reference them:
 

--- a/.claude/skills/monitor/SKILL.md
+++ b/.claude/skills/monitor/SKILL.md
@@ -57,6 +57,23 @@ The monitor outputs a structured summary:
 | Lane idle > 30min | LOW | Candidate for new task dispatch |
 | Telegram push failure | LOW | Logged; retry next cycle |
 
+If the cycle output or a downstream step needs more detail on a specific
+lane's state, prefer the heartbeat-aware classifier over `dashboard`:
+
+```bash
+# Subprocess-free — safe for hook / batch contexts
+uv run python scripts/internal/ops.py lane status --all --no-process-tree
+```
+
+The `--no-process-tree` flag skips the tmux/pgrep reconciler and relies on
+Signal 0 (the heartbeat file written by the PR #2686 writer hook) plus the
+cached fallback evidence, per PR #2695's hook-safe design. Use the full
+(non-`--no-process-tree`) variant only from an interactive shell; the
+reconciler spawns subprocesses that are inappropriate for a monitoring
+cron. `dashboard`'s `[stale!]` flag still uses the older 30-minute
+`last_active` heuristic (#2415 F1) — do not consume it for per-lane
+liveness classification.
+
 ### Step 3 -- Escalate if needed
 
 If critical findings are detected, the monitor sends supervisor alerts to the
@@ -103,6 +120,10 @@ and the cron job references it by name, not by inline command.
 ## References
 
 - `scripts/internal/ops.py monitor` -- CLI implementation
+- `scripts/internal/ops.py lane status` -- heartbeat-aware per-lane
+  classifier (PR #2695, consumer for the PR #2686 writer)
 - `.claude/skills/check-in/SKILL.md` -- orchestrator-side periodic check
 - `.claude/skills/fleet-check/SKILL.md` -- orchestrator consolidated cron
 - `.claude/rules/deferred/60_review_gate.md` -- review status context
+- Issue #2415 -- heartbeat infrastructure (F1 failure mode: working lanes
+  mis-classified as stale during long validation runs)


### PR DESCRIPTION
## Summary

Swap per-lane liveness classification in the orchestrator and ops monitoring
skills from `ops.py dashboard`'s registry-based 30-minute `last_active`
heuristic (the F1 failure mode from #2415) to the new heartbeat-aware
`ops.py lane status` CLI shipped in PR #2695.

Docs-only — no code, no data-contract impact.

## Why

Direct comparison from session 2026-04-21 (cited in the task packet):

| Lane | `dashboard` says | `lane status` says | Reality |
|------|------------------|-------------------|---------|
| flex-a | `[stale!]` 2h ago | `likely_active` — last Bash 17s ago | Active (just acked ping) |
| author-b/c/d | `[stale!]` 2h ago | `likely_active` — heartbeat 58-61m | Active (background work) |
| flex-b | `[stale!]` 2h ago | `likely_active` — TaskUpdate 57m | Active |

The dashboard classifier mis-classifies working lanes as stale during long
validation runs because none of S1-S5 advances between events. `lane status`
uses Signal 0 (the heartbeat file written by the PR #2686 hook) plus a
process-tree reconciler and gets it right. This PR updates the skills so
the orchestrator / ops agent reads the correct signal.

## Changes per file

- **`.claude/skills/fleet-check/SKILL.md`**
  - Step 3 uses `lane status --all --json | jq` to filter idle candidates
    instead of reading from `dashboard`.
  - Step 4 runs `lane status --all` for per-lane classification while
    keeping `dashboard` for aggregate signals (token economy, attention
    items, task-queue totals, warnings) where it is still the right tool.
  - Adds a known-limitation note: sessions launched before PR #2686 do not
    write heartbeats; control-plane lanes may show `stale!` until restart.

- **`.claude/skills/check-in/SKILL.md`**
  - Phase 2 lane-health step now prefers `lane status --all` for
    classification; dashboard still used for aggregates. Same pre-#2686
    limitation note.

- **`.claude/skills/monitor/SKILL.md`**
  - Adds `lane status --all --no-process-tree` as the subprocess-free path
    for hook / cron contexts (per PR #2695's hook-safe design).

- **`.claude/skills/lane-status/SKILL.md`**
  - Adds a forward reference to the shipped CLI at the top (`lane status
    [<lane-id>|--all] [--json] [--no-process-tree]`) with column shape and
    phase vocabulary (`active / likely_active / stale / blocked / idle /
    unknown`).
  - Manual 3-signal procedure remains documented for edge cases (approval
    blocks, dirty-worktree interpretation, cross-checking the pre-#2686
    heartbeat blind spot).

## Out of scope

- Modifying the `dashboard` command itself to use the new classifier —
  that is PR 3/3 of analyst-b's #2415 plan and belongs to a separate packet.
- Retiring the dashboard classifier — still needed for aggregate views.
- Changing the writer hook, registry, or heartbeat schema.

## Repro / Validation

No runtime behaviour changes. CLI surface referenced in the edits was
verified against the shipped implementation:

```
$ uv run python scripts/internal/ops.py lane status --help
usage: ops.py lane status [-h] [--lane LANE_FLAG] [--all] [--no-process-tree]
                          [lane_id]

$ uv run python scripts/internal/ops.py lane status --all
LANE            PHASE          FRESH        LAST_TOOL  SUMMARY
--------------------------------------------------------------

$ uv run python scripts/internal/ops.py --json lane status --all
[]

$ make docs-check
Docs freshness check passed.
```

## Tests

- `make docs-check` — passes.
- `make check-gated` — 11,824 passed, 1 pre-existing failure
  (`test_non_cosmetic_coupling_below_threshold`, non_cosmetic=257 >
  threshold=253). Confirmed the same failure exists on `origin/main` at
  `40696721` without my changes; tracked separately as issue #2702. This PR
  is docs-only and cannot introduce Python coupling.

## Worktree Proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-c
$ git branch --show-current
docs/lane-status-skill-updates-2415
```

## Scope

Refs #2415 (Tier 2 — final close waits on PR 3/3 dashboard cutover, which is
the sibling packet not in scope for this PR).
Task packet: `91b090880685` (flex-c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)