### PR TITLE
fix(ops): guard _expire_stale_on_read against already-expired messages (#2708)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -470,7 +470,21 @@ def _expire_stale_on_read(
         except (ValueError, TypeError):
             continue
         if current_time - created_ts > ttl:
-            updated = _update_inbox_status(mid, lane_id, "expired", bus_root)
+            try:
+                updated = _update_inbox_status(mid, lane_id, "expired", bus_root)
+            except ValueError:
+                # Race: a concurrent reader/writer already transitioned this
+                # message to a terminal state between our unlocked snapshot
+                # and this update.  The desired end state (terminal) is
+                # already reached — treat as a no-op.  Mirrors the pattern
+                # used in bulk_ack_matching (#2668).  See #2708 for the
+                # incident that motivated this guard.
+                logger.debug(
+                    "Skipped auto-expire of %s on read: race with concurrent "
+                    "writer (message already in terminal state)",
+                    mid,
+                )
+                continue
             if updated:
                 by_id[mid] = updated
                 logger.debug("Auto-expired message %s on read (TTL=%s)", mid, ttl)

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1481,6 +1481,186 @@ class TestTTLAutoExpireOnRead:
         assert len(acked) == 1
         assert acked[0]["status"] == "acked"
 
+    def test_auto_expire_idempotent_on_concurrent_expired(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """read_inbox must not crash when a message is already expired.
+
+        Regression test for #2708: ``_expire_stale_on_read`` formerly
+        re-invoked ``_update_inbox_status(..., "expired")`` based on a
+        stale pre-expire snapshot.  When a concurrent writer (or an
+        earlier ``expired`` record already present in the file) had
+        already transitioned the message, the subsequent call raised
+        ``ValueError: Invalid transition 'expired' -> 'expired'``,
+        making every inbox read fail.
+
+        This simulates the race by appending a ``pending`` record and
+        then an ``expired`` record for the same ``message_id`` before
+        reading.  The reader's ``by_id`` dedup picks the latest record
+        (``expired``), so the skip-set guard covers it — but we assert
+        the contract here to lock in the behavior regardless of who
+        wins the dedup race.
+        """
+        from bid_euchre.ops.message_bus import (
+            _append_jsonl,
+            _inbox_lock_path,
+            _inbox_path,
+        )
+
+        inbox_file = _inbox_path("target", bus_root)
+        lock_file = _inbox_lock_path("target", bus_root)
+
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Race with concurrent expiry",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Simulate a concurrent writer that already transitioned this
+        # message to "expired" before our read.  Append directly via
+        # the inbox writer to bypass the state-machine guard.
+        current_raw = [line for line in inbox_file.read_text().splitlines() if line]
+        latest = json.loads(current_raw[-1])
+        expired_record = {**latest, "status": "expired"}
+        _append_jsonl(inbox_file, expired_record, lock_file)
+
+        pre_lines = len(inbox_file.read_text().splitlines())
+
+        # Read well past the TTL — must NOT raise ValueError.  The
+        # latest record is "expired", so dedup + skip-set already
+        # cover this path — but the guard protects against the case
+        # where a concurrent writer lands between our snapshot and
+        # our update.
+        future_time = time.time() + 100
+        inbox = read_inbox("target", bus_root, now=future_time)
+
+        assert len(inbox) == 1
+        assert inbox[0]["status"] == "expired"
+        # No additional expired record written (idempotent)
+        post_lines = len(inbox_file.read_text().splitlines())
+        assert post_lines == pre_lines
+
+    def test_auto_expire_survives_stale_snapshot_race(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Direct test of the #2708 race path: stale by_id + concurrent expiry.
+
+        Builds a ``by_id`` snapshot that still shows ``pending`` (as
+        the reader would have built before yielding to the concurrent
+        writer), then appends an ``expired`` record to the inbox file
+        (the "concurrent writer" step), then calls
+        ``_expire_stale_on_read`` directly.  Before the fix this raised
+        ``ValueError: Invalid transition 'expired' -> 'expired'``.
+        After the fix the caller's guard swallows the race and
+        continues.
+        """
+        from bid_euchre.ops.message_bus import (
+            _append_jsonl,
+            _expire_stale_on_read,
+            _inbox_lock_path,
+            _inbox_path,
+            _read_inbox_raw,
+        )
+
+        inbox_file = _inbox_path("target", bus_root)
+        lock_file = _inbox_lock_path("target", bus_root)
+
+        msg = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Stale snapshot race",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(msg, bus_root, events_dir=events_dir)
+
+        # Build a by_id snapshot from the file as it exists pre-race.
+        # At this point the message is "pending".
+        raw_pre = _read_inbox_raw("target", bus_root)
+        by_id: dict[str, Any] = {}
+        for rec in raw_pre:
+            mid = rec.get("message_id")
+            if mid:
+                by_id[mid] = rec
+        assert by_id[msg.message_id]["status"] == "pending"
+
+        # Simulate the concurrent writer landing an "expired" record
+        # between our snapshot and our update.
+        latest = dict(raw_pre[-1])
+        expired_record = {**latest, "status": "expired"}
+        _append_jsonl(inbox_file, expired_record, lock_file)
+
+        pre_lines = len(inbox_file.read_text().splitlines())
+
+        # Now call _expire_stale_on_read with the stale by_id.  The
+        # message still looks "pending" from the snapshot's POV, so
+        # the skip-set does NOT filter it out.  Before the fix this
+        # raised ValueError.  After the fix, the ValueError is caught
+        # and the message is left in by_id as-is (terminal state was
+        # already reached by the concurrent writer).
+        future_time = time.time() + 100
+        _expire_stale_on_read(by_id, "target", bus_root, now=future_time)
+
+        # No additional expired record written by the racing call
+        post_lines = len(inbox_file.read_text().splitlines())
+        assert post_lines == pre_lines
+
+    def test_auto_expire_mixed_stale_and_fresh(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Multiple stale messages: mix of already-expired and not — all converge.
+
+        Three TTL-stale messages.  One is pre-expired (simulating a
+        concurrent writer that already transitioned it).  ``read_inbox``
+        must not raise, and all three must end in ``expired``.
+        """
+        from bid_euchre.ops.message_bus import (
+            _append_jsonl,
+            _inbox_lock_path,
+            _inbox_path,
+        )
+
+        inbox_file = _inbox_path("target", bus_root)
+        lock_file = _inbox_lock_path("target", bus_root)
+
+        ids = []
+        for i in range(3):
+            m = create_message(
+                "a",
+                "target",
+                "assignment",
+                f"Stale {i}",
+                payload={"ttl_seconds": 1},
+            )
+            send_message(m, bus_root, events_dir=events_dir)
+            ids.append(m.message_id)
+
+        # Pre-expire the first message via a direct append
+        raw_pre = [
+            json.loads(line) for line in inbox_file.read_text().splitlines() if line
+        ]
+        first_record = next(r for r in raw_pre if r["message_id"] == ids[0])
+        _append_jsonl(
+            inbox_file,
+            {**first_record, "status": "expired"},
+            lock_file,
+        )
+
+        # Read well past the TTL — must not raise
+        future_time = time.time() + 100
+        inbox = read_inbox("target", bus_root, now=future_time)
+
+        # All three messages are present and expired
+        assert len(inbox) == 3
+        statuses = {m["message_id"]: m["status"] for m in inbox}
+        for mid in ids:
+            assert (
+                statuses[mid] == "expired"
+            ), f"Expected {mid} to be expired, got {statuses[mid]}"
+
     def test_no_ttl_never_auto_expires(self, bus_root: Path, events_dir: Path) -> None:
         """Messages with ttl_seconds=None are never auto-expired on read."""
         msg = create_message(


### PR DESCRIPTION
## Summary

- Wraps the `_update_inbox_status(..., "expired")` call inside
  `_expire_stale_on_read` in `try/except ValueError`, treating the
  "message already in terminal state" race as a no-op. Mirrors the
  pattern already used by `bulk_ack_matching` (#2668).
- Adds three regression tests in `TestTTLAutoExpireOnRead` covering
  the concurrent-expired case, the direct stale-snapshot race, and
  the mixed-stale scenario from the issue's acceptance criteria.

## Why

`read_inbox` crashed with `ValueError: Invalid transition 'expired'
-> 'expired'` whenever its pre-snapshot dedup saw `pending` but the
inbox file had already been (or was concurrently being) transitioned
to `expired`. This made every orchestrator inbox read fail — 5 trapped
completion messages and 4 monitoring skills (check-in, monitor,
fleet-check, lane-status) lost their input. The fix is the keystone
that restores orchestrator observability.

The state machine itself is correct; the bug is the unlocked read +
unlocked update seam across multiple processes. Option (b) —
idempotent expiration inside `_update_inbox_status` — was rejected
on blast-radius grounds by analyst-a's shaping (it would weaken the
state-machine guard for all other callers). Option (a), a
caller-side guard localized to the only racy caller, matches the
existing pattern used in `bulk_ack_matching`.

Fixes #2708

## Repro / Validation

Direct repro of the race (now locked in by
`test_auto_expire_survives_stale_snapshot_race`):

```bash
uv run python -m pytest tests/unit/test_ops_message_bus.py::TestTTLAutoExpireOnRead -v
```

Before the fix: `test_auto_expire_survives_stale_snapshot_race`
raises `ValueError: Invalid transition 'expired' -> 'expired'`.
After the fix: all 8 tests in the class pass, including the 3 new ones.

## Tests

- `uv run python -m pytest tests/unit/test_ops_message_bus.py` — 167 passed
- `uv run ruff check src/bid_euchre/ops/message_bus.py tests/unit/test_ops_message_bus.py` — clean
- `uv run ruff format --check` — clean (pre-commit format applied)
- `make check-gated` — ran end-to-end. 11,827 passed. 4 failures are
  pre-existing main-branch issues unrelated to this PR:
  - 3 × `test_cpu_gate` subprocess timeouts (30s) under system load
  - 1 × `test_portability_audit` non-cosmetic coupling drift (257 > 253),
    tracked by #2702

Verified pre-existing by `git stash` + running on clean main
(`test_portability_audit` fails identically without this PR's diff).

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
branch: fix/read-inbox-expired-guard-2708 (based on origin/main @ dcb31a26)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)