### PR TITLE
fix(ops): monitor escalation skips own supervisor_alerts (#2700)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -1211,6 +1211,15 @@ def escalate_unacked(
         # Don't escalate escalation messages (avoid infinite chains)
         if rec.get("message_type") == "escalation":
             continue
+        # Don't escalate supervisor_alert rollups (#2700) — they are
+        # idempotent summaries of fleet state, re-emitted every monitor
+        # cycle. Escalating them creates a self-feeding cascade where
+        # each new supervisor_alert becomes the next cycle's escalation
+        # trigger. Real HIGH conditions surface through dedicated message
+        # types (blocker, escalation from ops-monitor, approval_stall),
+        # which remain escalation-eligible.
+        if rec.get("message_type") == "supervisor_alert":
+            continue
         # Skip if an active escalation already exists for this message (#1610)
         if mid in already_escalated:
             continue

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -2571,6 +2571,47 @@ class TestEscalateUnacked:
         )
         assert len(escalation_ids) == 1
 
+    def test_escalate_unacked_skips_supervisor_alert(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """supervisor_alert rollups are exempt from escalation (#2700).
+
+        Monitor emits a supervisor_alert every cycle as an idempotent rollup
+        of current fleet state. Escalating unacked rollups creates a
+        self-feeding cascade — each new rollup becomes the next cycle's
+        escalation trigger, producing a HIGH finding which then triggers
+        another rollup. Exempting supervisor_alert matches the existing
+        exemption for ``escalation`` messages. Real SLA-relevant message
+        types (blocker, assignment, etc.) remain escalation-eligible.
+        """
+        # Send one supervisor_alert (should be skipped) and one blocker
+        # (should still escalate).
+        rollup = create_message(
+            "ops", "orch", "supervisor_alert", "Fleet rollup", priority="high"
+        )
+        blocker = create_message(
+            "ops", "orch", "blocker", "Real blocker", priority="high"
+        )
+        send_message(rollup, bus_root, events_dir=events_dir)
+        send_message(blocker, bus_root, events_dir=events_dir)
+
+        escalation_ids = escalate_unacked(
+            "ops", "orch", max_age_minutes=0, bus_root=bus_root, events_dir=events_dir
+        )
+
+        # Only the blocker should have been escalated.
+        assert (
+            len(escalation_ids) == 1
+        ), "supervisor_alert rollup must not be escalated (self-cascade fix)"
+        inbox = read_inbox("orch", bus_root, auto_expire=False, limit=100)
+        escalated_parents = {
+            m.get("parent_message_id")
+            for m in inbox
+            if m["message_id"] == escalation_ids[0]
+        }
+        assert blocker.message_id in escalated_parents
+        assert rollup.message_id not in escalated_parents
+
 
 # ---------------------------------------------------------------------------
 # Priority-grouped inbox read (read_inbox_prioritized)

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -1748,7 +1748,15 @@ class TestCheckEscalations:
         assert call_kwargs[1]["max_age_minutes"] == ESCALATION_AGE_MINUTES
 
     def test_integration_with_real_bus(self, tmp_path: Path) -> None:
-        """End-to-end: ops sends alert, don't ack, verify escalation fires."""
+        """End-to-end: ops sends a blocker, don't ack, verify escalation fires.
+
+        Uses ``message_type="blocker"`` rather than ``supervisor_alert``:
+        per #2700, ``supervisor_alert`` rollups are exempt from escalation
+        because they are idempotent summaries of fleet state re-emitted
+        every cycle. Real SLA-relevant messages (blocker, escalation from
+        ops-monitor, approval_stall) remain escalation-eligible, which is
+        what this integration test now verifies.
+        """
         from bid_euchre.ops.message_bus import (
             create_message,
             send_message,
@@ -1757,11 +1765,12 @@ class TestCheckEscalations:
         bus_root = tmp_path / "bus"
         events_dir = tmp_path / "events"
 
-        # ops sends an alert to orchestrator
+        # ops sends a blocker to orchestrator — still escalation-eligible
+        # because blocker is not a rollup message type.
         msg = create_message(
             from_lane="ops",
             to_lane="orchestrator",
-            message_type="supervisor_alert",
+            message_type="blocker",
             priority="high",
             summary="3 HIGH findings",
         )
@@ -1779,6 +1788,49 @@ class TestCheckEscalations:
         assert findings[0].severity == SEVERITY_HIGH
         assert findings[0].category == "escalation"
         assert len(findings[0].details["escalation_ids"]) >= 1
+
+    def test_integration_supervisor_alert_no_self_cascade(self, tmp_path: Path) -> None:
+        """Unacked supervisor_alerts must NOT trigger a HIGH escalation (#2700).
+
+        Regression for the self-feeding cascade: monitor was emitting a
+        supervisor_alert each cycle, then on the next cycle finding its own
+        prior supervisor_alerts unacked and escalating them — which in turn
+        produced a new HIGH finding, feeding the next cycle.
+        """
+        from bid_euchre.ops.message_bus import (
+            create_message,
+            send_message,
+        )
+
+        bus_root = tmp_path / "bus"
+        events_dir = tmp_path / "events"
+
+        # Simulate two unacked ops→orchestrator supervisor_alerts from
+        # prior monitor cycles.
+        for i in range(2):
+            msg = create_message(
+                from_lane="ops",
+                to_lane="orchestrator",
+                message_type="supervisor_alert",
+                priority="high",
+                summary=f"Monitor cycle {i} rollup",
+            )
+            send_message(msg, bus_root, events_dir=events_dir)
+
+        findings = check_escalations(
+            bus_root=bus_root,
+            events_dir=events_dir,
+            max_age_minutes=0,
+        )
+
+        # No HIGH finding — supervisor_alerts are exempt from escalation
+        assert all(
+            f.severity != SEVERITY_HIGH for f in findings
+        ), "supervisor_alerts must not trigger HIGH escalation (self-cascade)"
+        # Single info finding: "No unacked alerts to escalate."
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+        assert "No unacked" in findings[0].summary
 
     def test_integration_no_escalation_when_acked(self, tmp_path: Path) -> None:
         """End-to-end: ops sends alert, ack it, verify no escalation."""


### PR DESCRIPTION
## Summary
- Exempt `message_type == "supervisor_alert"` from unacked-alert escalation in `escalate_unacked()`.
- Monitor-emitted rollups were feeding their own next-cycle escalation, producing a HIGH-priority cascade (16 escalation msgs + 15 supervisor_alerts observed in #2700 tier snapshot).
- Symmetric to the existing `message_type == "escalation"` skip — same block, same pattern.

## Why (root cause from #2700 analyst shaping)

`escalate_unacked()` (`src/bid_euchre/ops/message_bus.py:1205-1216`) filtered out `escalation` messages but nothing else. `_send_findings_to_orchestrator()` emits a `supervisor_alert` every monitor cycle that has findings. Result — the self-feeding loop:

| Cycle | Monitor action | Orchestrator inbox |
|-------|---------------|--------------------|
| T=0   | emits `supervisor_alert_A` (real finding) | [A pending] |
| T=8m  | escalates A → `escalation_A'`; HIGH finding; emits HIGH `supervisor_alert_B` | [A, A', B] |
| T=16m | escalates **B** → `escalation_B'`; HIGH finding; emits HIGH `supervisor_alert_C` | self-feeds |

`supervisor_alert` rollups are idempotent summaries of current fleet state — the next cycle re-emits them with fresh conditions, so escalating a stale one adds zero new signal. Real SLA-relevant types (`blocker`, `escalation` from ops-monitor, `approval_stall`) remain escalation-eligible.

## Why option (b) over option (a)

Analyst picked option (b) on code evidence: exempt at the filter is a 1-line change adjacent to the existing exemption. Option (a) (walk payload.findings to detect self-referential HIGH) is meta-logic over structured payload and is brittle — any future finding category needs updating. (b) addresses the cause, not the symptom.

## Tests

- `test_escalate_unacked_skips_supervisor_alert` (new, `test_ops_message_bus.py`) — a supervisor_alert and a blocker coexist; only the blocker escalates.
- `test_integration_supervisor_alert_no_self_cascade` (new, `test_ops_monitor.py`) — two unacked supervisor_alerts produce zero HIGH findings (single INFO).
- `test_integration_with_real_bus` (updated, `test_ops_monitor.py`) — previously asserted the buggy cascade behavior (unacked supervisor_alert gets escalated). Now uses `message_type="blocker"` to assert the SLA mechanism still works for non-rollup messages. Explicit callout per analyst shaping.

## Repro / Validation

```bash
# Targeted (Tier 1)
uv run python -m pytest tests/unit/test_ops_message_bus.py -k escalate \
  tests/unit/test_ops_monitor.py -k "escalat or cascade" -v
# 28 passed, 0 failed

# Full module (341 tests)
uv run python -m pytest tests/unit/test_ops_monitor.py tests/unit/test_ops_message_bus.py
# 341 passed in 2.34s

# Tier 2
make check-gated
```

**Tier 2 note:** `make check-gated` reports two pre-existing failures unrelated to this change —
- `test_portability_audit::test_non_cosmetic_coupling_below_threshold` (257 > 253 threshold, reproduces on `origin/main`)
- `test_cpu_gate::test_proceeds_immediately_when_load_is_low` (subprocess timeout under load)

Neither touches the files in this PR. The 341 tests in the two modules changed here all pass.

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
$ git branch --show-current
fix/monitor-escalation-cascade-2700
```

## Scope

Declared (matches task packet 7268571cb3a4):
- `src/bid_euchre/ops/message_bus.py` (+9 lines, the filter)
- `tests/unit/test_ops_message_bus.py` (+41 lines regression test)
- `tests/unit/test_ops_monitor.py` (+58/-3 new regression test + update existing test)

No out-of-scope changes. Task packet scope said "src/bid_euchre/ops/monitor.py (or reconciler file per analyst's pointer)" — analyst pointed to `message_bus.py` which is where `escalate_unacked()` lives. `monitor.py` is unchanged; the helper fix alone suffices.

Fixes #2700

🤖 Generated with [Claude Code](https://claude.com/claude-code)