### PR TITLE
fix(ops): single-pass rewrite for bulk_ack_messages (#2699)

### DIFF
--- a/src/bid_euchre/ops/message_bus.py
+++ b/src/bid_euchre/ops/message_bus.py
@@ -934,12 +934,53 @@ def ack_message(
     return updated
 
 
+def _expire_stale_in_memory(
+    by_id: dict[str, dict[str, Any]],
+    *,
+    now: float | None = None,
+) -> set[str]:
+    """Apply TTL lazy expiry to *by_id* entries in memory (no I/O).
+
+    Pure in-memory variant of :func:`_expire_stale_on_read` — mutates
+    *by_id* in place by replacing TTL-stale non-terminal records with
+    an ``expired`` copy and returns the set of message ids that were
+    transitioned.  Urgent (P0) messages are never auto-expired, matching
+    the side-effecting read-path policy.
+
+    Used by :func:`bulk_ack_messages` so the caller can perform the
+    full read-expire-ack rewrite under a single inbox lock.
+    """
+    current_time = now if now is not None else time.time()
+    skip = {"resolved", "expired", "dead_lettered", "acked"}
+    expired_ids: set[str] = set()
+
+    for mid, rec in list(by_id.items()):
+        if rec.get("status") in skip:
+            continue
+        if rec.get("priority") == "urgent":
+            continue
+        ttl = rec.get("payload", {}).get("ttl_seconds")
+        if ttl is None:
+            continue
+        created = rec.get("created_at", "")
+        try:
+            created_ts = datetime.fromisoformat(created).timestamp()
+        except (ValueError, TypeError):
+            continue
+        if current_time - created_ts > ttl:
+            by_id[mid] = {**rec, "status": "expired"}
+            expired_ids.add(mid)
+
+    return expired_ids
+
+
 def bulk_ack_messages(
     lane_id: str,
     filter_fn: Callable[[dict[str, Any]], bool],
     bus_root: Path | None = None,
     *,
     events_dir: Path | None = None,
+    now: float | None = None,
 ) -> BulkAckResult:
     """Acknowledge all messages in a lane's inbox that match *filter_fn*.
 
@@ -952,82 +993,141 @@ def bulk_ack_messages(
     counts toward ``skipped_terminal`` if the caller expressed interest
     in it via ``filter_fn``.  Unrelated terminal records are ignored.
 
-    A record can also transition to terminal state mid-batch — for
-    example, a concurrent :func:`read_inbox` call can lazily expire a
-    TTL-stale message via :func:`_expire_stale_on_read` between the
-    snapshot and the per-message update.  :func:`_update_inbox_status`
-    raises ``ValueError`` in that case; we treat it as a terminal skip
-    (see #2668).
+    Implementation is a single-pass filter-and-rewrite under the inbox
+    :data:`flock` (see #2699): the raw JSONL is read once into memory,
+    deduplicated to latest-record-per-id, TTL-stale non-terminal
+    records are expired in memory (parity with :func:`read_inbox`),
+    matching ackable records are transitioned to ``acked``, and the
+    file is rewritten atomically via tmp+rename.  Total I/O is
+    **O(N)** regardless of how many records match *filter_fn* —
+    replacing the previous O(N·M) pattern where each match triggered
+    a full re-read via :func:`_update_inbox_status`.
+
+    Because the rewrite is atomic and holds the inbox lock for its
+    duration, concurrent writers (``append_message``,
+    :func:`_update_inbox_status`) cannot interleave with this call.
+    The previous ``ValueError`` mid-batch race path (``#2668``) is
+    therefore no longer reachable from inside this function; callers
+    that rely on the skipped-terminal count still observe the same
+    contract when records are already terminal at snapshot time or
+    get lazily expired in memory before the partition step.
+
+    Note on history: the rewrite stores at most one record per
+    ``message_id`` in the inbox (same dedup semantics as
+    :func:`compact_inbox`).  Full status-transition history continues
+    to live in the global audit trail (``messages.jsonl``) — only
+    ``append_message`` writes there, and it is untouched by this
+    function.  No caller of :func:`_read_inbox_raw` currently depends
+    on multi-record history within a single inbox.
 
     Args:
         lane_id: The lane whose inbox to scan.
         filter_fn: Predicate receiving a message dict; return ``True`` to ack.
         bus_root: Override for bus root directory.
         events_dir: Override for events directory (for testing).
+        now: Override for current time as Unix timestamp, passed to the
+            in-memory lazy-expiry pass (for testing).
 
     Returns:
         :class:`BulkAckResult` with the list of acked records and a
         count of records that matched ``filter_fn`` but could not be
-        acked because they were (or became) terminal.
+        acked because they were terminal at snapshot time (or became
+        terminal via in-memory lazy expiry before the partition step).
     """
     root = shared_bus_root(bus_root)
-    raw = _read_inbox_raw(lane_id, root)
+    inbox = _inbox_path(lane_id, root)
+    lock_path = _inbox_lock_path(lane_id, root)
 
-    # Deduplicate: latest record per message_id wins
-    by_id: dict[str, dict[str, Any]] = {}
-    for rec in raw:
-        mid = rec.get("message_id")
-        if mid:
-            by_id[mid] = rec
+    # Short-circuit when no inbox file exists — nothing to do, no lock needed.
+    if not inbox.exists():
+        return BulkAckResult(acked=[], skipped_terminal=0)
 
+    ack_ts = _now_iso()
     ackable = {"pending", "delivered"}
     acked: list[dict[str, Any]] = []
     skipped_terminal = 0
-    for mid, rec in by_id.items():
-        # Filter first so unrelated terminal records don't inflate the
-        # skipped count.  Only records the caller asked about count.
-        if not filter_fn(rec):
-            continue
 
-        status = rec.get("status")
-        if status in BULK_ACK_TERMINAL_STATUSES:
-            skipped_terminal += 1
-            continue
-        if status not in ackable:
-            # Unknown/unexpected status — skip defensively, surface in log.
-            logger.debug("Skipping %s in bulk-ack: unexpected status %r", mid, status)
-            continue
-
+    # Single atomic read-mutate-rewrite under the inbox lock.
+    # Ensures concurrent writers (including other bulk_ack_messages calls)
+    # are serialized — no mid-batch state drift is possible.
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
         try:
-            updated = _update_inbox_status(
-                mid,
+            # One read of the raw JSONL.
+            raw: list[dict[str, Any]] = []
+            with open(inbox) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        raw.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        logger.warning("Skipping malformed inbox line for %s", lane_id)
+
+            # Deduplicate: latest record per message_id wins.
+            by_id: dict[str, dict[str, Any]] = {}
+            for rec in raw:
+                mid = rec.get("message_id")
+                if mid:
+                    by_id[mid] = rec
+
+            # Apply lazy TTL expiry in-memory before the ack partition,
+            # so the rewrite carries the same side effect that
+            # ``read_inbox -> _expire_stale_on_read`` would have
+            # produced on the same inbox state.
+            _expire_stale_in_memory(by_id, now=now)
+
+            # Partition: filter first so unrelated terminal records
+            # don't inflate the skipped count.
+            for mid, rec in by_id.items():
+                if not filter_fn(rec):
+                    continue
+
+                status = rec.get("status")
+                if status in BULK_ACK_TERMINAL_STATUSES:
+                    skipped_terminal += 1
+                    continue
+                if status not in ackable:
+                    # Unknown/unexpected status — skip defensively.
+                    logger.debug(
+                        "Skipping %s in bulk-ack: unexpected status %r",
+                        mid,
+                        status,
+                    )
+                    continue
+
+                updated = {**rec, "status": "acked", "acked_at": ack_ts}
+                by_id[mid] = updated
+                acked.append(updated)
+
+            # Atomic rewrite via tmp + rename (same pattern as compact_inbox).
+            tmp_path = inbox.with_suffix(".jsonl.tmp")
+            with open(tmp_path, "w") as f:
+                for rec in by_id.values():
+                    f.write(json.dumps(rec, sort_keys=True, default=str) + "\n")
+                f.flush()
+            tmp_path.rename(inbox)
+
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+
+    # Emit events outside the lock — idempotent and out-of-band.
+    for rec in acked:
+        mid = rec.get("message_id")
+        try:
+            from bid_euchre.ops.events import append_event
+
+            append_event(
+                "message_acked",
+                "ops.message_bus",
                 lane_id,
-                "acked",
-                root,
-                extra_fields={"acked_at": _now_iso()},
+                {"message_id": mid, "bulk": True},
+                events_dir=events_dir,
             )
-        except ValueError:
-            # Race: another caller (e.g. concurrent read_inbox triggering
-            # lazy expiry) transitioned the message to a terminal state
-            # between our snapshot and this update.  Count as a terminal
-            # skip rather than aborting the whole batch (see #2668).
-            skipped_terminal += 1
-            continue
-
-        if updated is not None:
-            acked.append(updated)
-            try:
-                from bid_euchre.ops.events import append_event
-
-                append_event(
-                    "message_acked",
-                    "ops.message_bus",
-                    lane_id,
-                    {"message_id": mid, "bulk": True},
-                    events_dir=events_dir,
-                )
-            except Exception:
-                logger.warning("Failed to emit message_acked event for %s", mid)
+        except Exception:
+            logger.warning("Failed to emit message_acked event for %s", mid)
 
     if acked or skipped_terminal:
         logger.info(

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -4677,6 +4677,88 @@ class TestInboxBulkAck:
         assert len(data["acked"]) == 1
         assert data["skipped_terminal"] == 1
 
+    def test_bulk_ack_cli_large_inbox_completes(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Regression for #2699: CLI ``ack-all`` on a large inbox
+        completes in seconds, not minutes. A 2000-message inbox on the
+        pre-#2699 O(N²) path would take 10s+ (and 10min+ on the
+        observed 12K orchestrator inbox). The single-pass rewrite keeps
+        wall-clock bounded at O(N)."""
+        import time as _time
+
+        import ops
+
+        # Seed the inbox directly (JSONL append) — sending 2000 messages
+        # via CLI would dominate the test wall-clock budget.
+        inbox_path = bus_dir / "inbox" / "bulk-perf.jsonl"
+        inbox_path.parent.mkdir(parents=True, exist_ok=True)
+
+        from datetime import datetime, timedelta, timezone
+
+        count = 2000
+        now_dt = datetime.now(timezone.utc)
+        with open(inbox_path, "w") as f:
+            for i in range(count):
+                # Keep created_at within the default 24h TTL window so
+                # the lazy-expiry pass doesn't intercept them.
+                ts = (now_dt - timedelta(minutes=i % 60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+                rec = {
+                    "message_id": f"perf{i:08d}",
+                    "thread_id": None,
+                    "task_id": None,
+                    "from_lane": "orchestrator",
+                    "to_lane": "bulk-perf",
+                    "message_type": "ack",
+                    "priority": "normal",
+                    "status": "pending",
+                    "created_at": ts,
+                    "acked_at": None,
+                    "resolved_at": None,
+                    "requires_human": False,
+                    "summary": f"perf-{i}",
+                    "payload": {
+                        "max_retries": 3,
+                        "retry_count": 0,
+                        "ttl_seconds": 86400,
+                    },
+                    "source_transport": "bus",
+                    "parent_message_id": None,
+                }
+                f.write(json.dumps(rec) + "\n")
+
+        # Drain capsys so the test's own assertion reads only CLI output
+        capsys.readouterr()
+
+        start = _time.perf_counter()
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "bulk-ack",
+                "--lane",
+                "bulk-perf",
+            ]
+        )
+        elapsed = _time.perf_counter() - start
+
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data["acked"]) == count
+        assert data["skipped_terminal"] == 0
+        assert elapsed < 5.0, (
+            f"ack-all on {count} messages took {elapsed:.2f}s "
+            f"(expected <5.0s; O(N²) regression suspected — see #2699)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # review-check

--- a/tests/unit/test_ops_message_bus.py
+++ b/tests/unit/test_ops_message_bus.py
@@ -1163,19 +1163,25 @@ class TestBulkAckMessages:
         assert all(ev["payload"].get("bulk") is True for ev in ack_events)
 
     def test_bulk_ack_with_age_filter(self, bus_root: Path, events_dir: Path) -> None:
-        """Only messages older than cutoff are acked when age filter is used."""
-        from datetime import datetime, timezone
+        """Only messages older than cutoff are acked when age filter is used.
+
+        Uses a synthetic created_at 5h in the past — older than the 4h
+        filter cutoff, but still inside the default 24h TTL so the
+        post-#2699 in-memory lazy-expiry pass does not intercept it.
+        """
+        from datetime import datetime, timedelta, timezone
 
         m1 = create_message("a", "target", "assignment", "Old task")
         m2 = create_message("a", "target", "progress", "New task")
         send_message(m1, bus_root, events_dir=events_dir)
         send_message(m2, bus_root, events_dir=events_dir)
 
-        # Patch m1's created_at to be very old by rewriting the inbox
+        # Patch m1's created_at to 5h ago — beyond the 4h filter cutoff,
+        # but safely inside the 24h DEFAULT_TTL_SECONDS window.
         inbox_path = bus_root / "inbox" / "target.jsonl"
         lines = inbox_path.read_text().strip().split("\n")
         patched: list[str] = []
-        old_ts = datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc).strftime(
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=5)).strftime(
             "%Y-%m-%dT%H:%M:%SZ"
         )
         for line in lines:
@@ -1185,7 +1191,7 @@ class TestBulkAckMessages:
             patched.append(json.dumps(rec))
         inbox_path.write_text("\n".join(patched) + "\n")
 
-        # Cutoff: 4 hours — only m1 (very old) should match
+        # Cutoff: 4 hours — only m1 (5h old) should match
         cutoff_ts = datetime.now(timezone.utc).timestamp() - 4 * 3600
 
         def older_than_cutoff(msg: dict) -> bool:
@@ -1314,49 +1320,52 @@ class TestBulkAckTerminalStates:
         self,
         bus_root: Path,
         events_dir: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Simulate a race where a message transitions to terminal state
-        between the bulk-ack snapshot and the per-message update.  The
-        underlying ``_update_inbox_status`` raises ``ValueError``; bulk-ack
-        must catch it and tally the message as skipped_terminal."""
+        """Observable contract for #2668: a message that is pending in the
+        raw snapshot but transitions to terminal *before* the ack commit
+        is counted as ``skipped_terminal`` rather than aborting the batch.
+
+        Post-#2699 the whole read-mutate-rewrite happens under the inbox
+        flock, so a true concurrent-writer race inside ``bulk_ack_messages``
+        is no longer reachable. The equivalent observable is the in-memory
+        lazy-expiry pass: a TTL-stale pending record is expired before the
+        ack partition, and if the filter still matches it, it lands in
+        ``skipped_terminal`` while the rest of the batch acks cleanly.
+        """
         m1 = create_message("a", "target", "assignment", "Pending 1")
-        m2 = create_message("a", "target", "assignment", "Races to expired")
+        # m2: pending with a very short TTL — will be lazily expired in-memory
+        m2 = create_message(
+            "a",
+            "target",
+            "assignment",
+            "Stale TTL expires mid-batch",
+            payload={"ttl_seconds": 1},
+        )
         m3 = create_message("a", "target", "assignment", "Pending 2")
         send_message(m1, bus_root, events_dir=events_dir)
         send_message(m2, bus_root, events_dir=events_dir)
         send_message(m3, bus_root, events_dir=events_dir)
 
-        # Monkeypatch _update_inbox_status so that the first call for m2
-        # raises ValueError (simulating the race).  Other calls pass
-        # through to the real implementation.
-        import bid_euchre.ops.message_bus as mb
-
-        real_update = mb._update_inbox_status
-
-        def racing_update(*args: Any, **kwargs: Any) -> Any:
-            # Positional signature: message_id, lane_id, new_status, bus_root
-            message_id = args[0] if args else kwargs.get("message_id")
-            new_status = args[2] if len(args) > 2 else kwargs.get("new_status")
-            if message_id == m2.message_id and new_status == "acked":
-                raise ValueError(
-                    f"Invalid transition 'expired' -> 'acked' for "
-                    f"message {message_id!r}; allowed: (terminal)"
-                )
-            return real_update(*args, **kwargs)
-
-        monkeypatch.setattr(mb, "_update_inbox_status", racing_update)
-
+        # Pass ``now`` well past m2's TTL; m1/m3 use the default 24h TTL
+        # so they stay pending. Lazy expiry transitions m2 to expired in
+        # memory before the ack partition — matching the historical race
+        # semantics the old _update_inbox_status mid-batch ValueError
+        # path was defending.
+        future = time.time() + 60  # 60s after the messages were created
         result = bulk_ack_messages(
-            "target", lambda _: True, bus_root, events_dir=events_dir
+            "target", lambda _: True, bus_root, events_dir=events_dir, now=future
         )
-        # m1 and m3 acked; m2 counted as skipped due to race
         assert len(result.acked) == 2
         assert {r["message_id"] for r in result.acked} == {
             m1.message_id,
             m3.message_id,
         }
         assert result.skipped_terminal == 1
+
+        # Side effect: m2 is persisted as expired in the rewritten inbox
+        inbox = read_inbox("target", bus_root, status="expired")
+        assert len(inbox) == 1
+        assert inbox[0]["message_id"] == m2.message_id
 
     def test_bulk_ack_result_is_tuple_unpackable(
         self, bus_root: Path, events_dir: Path
@@ -1371,6 +1380,256 @@ class TestBulkAckTerminalStates:
         )
         assert len(acked) == 1
         assert skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# Bulk ack — single-pass rewrite (#2699)
+# ---------------------------------------------------------------------------
+
+
+class TestBulkAckSinglePass:
+    """Regression tests for #2699 — ``bulk_ack_messages`` must perform
+    exactly one raw-inbox read and one rewrite regardless of match count.
+    """
+
+    def test_bulk_ack_single_read_single_write(
+        self,
+        bus_root: Path,
+        events_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Instrument open() to assert that bulk_ack performs O(1) I/O
+        shape: one read of the inbox, one write of the tmp file,
+        regardless of M matched messages."""
+        import builtins
+
+        import bid_euchre.ops.message_bus as mb
+
+        # Seed 20 pending messages — all will match the filter.
+        for i in range(20):
+            m = create_message("a", "target", "assignment", f"Task {i}")
+            send_message(m, bus_root, events_dir=events_dir)
+
+        # ``_read_inbox_raw`` is NOT called by the new code path — count
+        # calls to prove that.
+        read_raw_calls = {"n": 0}
+        real_read = mb._read_inbox_raw
+
+        def counting_read(lane_id: str, root: Path) -> list[dict[str, Any]]:
+            read_raw_calls["n"] += 1
+            return real_read(lane_id, root)
+
+        monkeypatch.setattr(mb, "_read_inbox_raw", counting_read)
+
+        inbox_path = bus_root / "inbox" / "target.jsonl"
+        tmp_path = inbox_path.with_suffix(".jsonl.tmp")
+        opens = {"read_inbox": 0, "write_tmp": 0}
+        builtin_open = builtins.open
+
+        def counting_open(file, mode="r", *args, **kwargs):
+            path_str = str(file)
+            if path_str == str(inbox_path) and ("r" == mode or mode.startswith("r")):
+                opens["read_inbox"] += 1
+            elif path_str == str(tmp_path) and ("w" in mode):
+                opens["write_tmp"] += 1
+            return builtin_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", counting_open)
+
+        result = bulk_ack_messages(
+            "target", lambda _: True, bus_root, events_dir=events_dir
+        )
+
+        # Fan-out should be irrelevant — read once, rewrite once.
+        assert read_raw_calls["n"] == 0, (
+            "bulk_ack_messages should not call _read_inbox_raw "
+            "(that was the O(N²) regression source in #2699)"
+        )
+        # Exactly one streaming read of the inbox file.
+        assert opens["read_inbox"] == 1
+        # Exactly one write of the tmp file (then atomic rename).
+        assert opens["write_tmp"] == 1
+        # And all 20 messages got acked.
+        assert len(result.acked) == 20
+        assert result.skipped_terminal == 0
+
+    def test_bulk_ack_large_inbox_under_budget(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """5000 pending messages, ack all, wall-clock under 2s.
+
+        Today's O(N²) path would take ~100s+ on 5000 messages because
+        each ack re-reads the growing inbox. The single-pass rewrite
+        makes this a simple O(N) read + O(N) write.
+        """
+        import time as _time
+
+        count = 5000
+        for i in range(count):
+            m = create_message("a", "target", "assignment", f"Task {i}")
+            send_message(m, bus_root, events_dir=events_dir)
+
+        start = _time.perf_counter()
+        result = bulk_ack_messages(
+            "target", lambda _: True, bus_root, events_dir=events_dir
+        )
+        elapsed = _time.perf_counter() - start
+
+        assert len(result.acked) == count
+        assert result.skipped_terminal == 0
+        assert elapsed < 2.0, (
+            f"bulk_ack on {count} messages took {elapsed:.2f}s "
+            f"(expected <2.0s; O(N²) regression suspected)"
+        )
+
+    def test_bulk_ack_preserves_ttl_expiry_side_effect(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """A TTL-stale pending message that is *not* matched by filter_fn
+        must still be transitioned to ``expired`` and persisted in the
+        rewritten inbox — parity with the lazy-expiry side effect that
+        ``read_inbox`` has today."""
+        # m1: stale, matches filter
+        m_match = create_message(
+            "a",
+            "target",
+            "assignment",
+            "alpha expired",
+            payload={"ttl_seconds": 1},
+        )
+        # m2: stale, does NOT match filter — still must be expired
+        m_nomatch = create_message(
+            "a",
+            "target",
+            "assignment",
+            "bravo expired",
+            payload={"ttl_seconds": 1},
+        )
+        # m3: fresh, does NOT match filter — stays pending
+        m_fresh = create_message("a", "target", "progress", "fresh pending")
+        send_message(m_match, bus_root, events_dir=events_dir)
+        send_message(m_nomatch, bus_root, events_dir=events_dir)
+        send_message(m_fresh, bus_root, events_dir=events_dir)
+
+        future = time.time() + 3600  # 1h past — TTL=1 expires both stale msgs
+        result = bulk_ack_messages(
+            "target",
+            lambda msg: "alpha" in msg.get("summary", ""),
+            bus_root,
+            events_dir=events_dir,
+            now=future,
+        )
+
+        # Nothing acked (m_match was expired in-memory before partition,
+        # so it lands in skipped_terminal).
+        assert len(result.acked) == 0
+        assert result.skipped_terminal == 1
+
+        # Read inbox: m_match and m_nomatch now expired, m_fresh pending
+        # (read_inbox also applies lazy expiry, but the rewrite already
+        # persisted the transition, so ordering doesn't matter).
+        expired_recs = read_inbox(
+            "target", bus_root, status="expired", auto_expire=False
+        )
+        assert {r["message_id"] for r in expired_recs} == {
+            m_match.message_id,
+            m_nomatch.message_id,
+        }
+
+        pending_recs = read_inbox(
+            "target", bus_root, status="pending", auto_expire=False
+        )
+        assert len(pending_recs) == 1
+        assert pending_recs[0]["message_id"] == m_fresh.message_id
+
+    def test_bulk_ack_dedup_after_rewrite(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Inbox pre-seeded with 3 records for the same message_id; after
+        bulk_ack, the on-disk inbox contains exactly one record per id.
+
+        The inbox file is append-only in normal operation, but after the
+        single-pass rewrite the latest-wins dedup has been flushed to
+        disk — mirroring ``compact_inbox`` semantics.
+        """
+        m = create_message("a", "target", "assignment", "multi-record")
+        send_message(m, bus_root, events_dir=events_dir)
+
+        # Manually append 2 more records for the same id, simulating
+        # pending -> delivered -> pending retry history.
+        inbox_path = bus_root / "inbox" / "target.jsonl"
+        base = json.loads(inbox_path.read_text().strip().split("\n")[0])
+        with open(inbox_path, "a") as f:
+            f.write(json.dumps({**base, "status": "delivered"}) + "\n")
+            f.write(json.dumps({**base, "status": "pending"}) + "\n")
+
+        # Pre-condition: 3 raw lines for 1 unique id
+        raw_before = [
+            line for line in inbox_path.read_text().split("\n") if line.strip()
+        ]
+        assert len(raw_before) == 3
+
+        result = bulk_ack_messages(
+            "target", lambda _: True, bus_root, events_dir=events_dir
+        )
+        assert len(result.acked) == 1
+
+        # Post-condition: 1 raw line for 1 unique id (deduplicated).
+        raw_after = [
+            line for line in inbox_path.read_text().split("\n") if line.strip()
+        ]
+        assert len(raw_after) == 1
+        rec = json.loads(raw_after[0])
+        assert rec["message_id"] == m.message_id
+        assert rec["status"] == "acked"
+
+    def test_bulk_ack_urgent_not_expired(
+        self, bus_root: Path, events_dir: Path
+    ) -> None:
+        """Urgent (P0) past-TTL pending messages are never auto-expired
+        — parity with :func:`_expire_stale_on_read`. When bulk_ack_messages
+        runs on a past-TTL urgent, it either acks (if matched) or leaves
+        pending (if unmatched), but never transitions to ``expired``.
+        """
+        m_urgent = create_message(
+            "a",
+            "target",
+            "assignment",
+            "urgent stale",
+            priority="urgent",
+            payload={"ttl_seconds": 1},
+        )
+        send_message(m_urgent, bus_root, events_dir=events_dir)
+
+        future = time.time() + 3600  # well past TTL=1
+
+        # Filter does NOT match — urgent stays pending, does not expire.
+        result = bulk_ack_messages(
+            "target",
+            lambda _: False,
+            bus_root,
+            events_dir=events_dir,
+            now=future,
+        )
+        assert len(result.acked) == 0
+        assert result.skipped_terminal == 0
+
+        pending = read_inbox("target", bus_root, status="pending", auto_expire=False)
+        assert len(pending) == 1
+        assert pending[0]["message_id"] == m_urgent.message_id
+
+        # Same precondition but filter matches — urgent is acked normally,
+        # not routed through expiry.
+        result = bulk_ack_messages(
+            "target",
+            lambda _: True,
+            bus_root,
+            events_dir=events_dir,
+            now=future,
+        )
+        assert len(result.acked) == 1
+        assert result.acked[0]["message_id"] == m_urgent.message_id
+        assert result.skipped_terminal == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Rewrote `bulk_ack_messages` as a single atomic read-mutate-rewrite under the inbox flock, eliminating the O(N²) per-match re-read pattern that caused `ack-all` to burn 99.9% CPU for 10+ minutes on the 12K-message orchestrator backlog (regression from PR #1284).
- I/O shape is now O(N) — one streaming read, one tmp+rename rewrite — regardless of how many records match `filter_fn`.
- Added `_expire_stale_in_memory` helper that factors out the pure in-memory half of `_expire_stale_on_read`, so lazy TTL expiry still happens inside the bulk-ack rewrite (criterion 4 in the analyst shaping).

## Why

`bulk_ack_messages` called `_update_inbox_status` per matched message. Each call ran `_read_inbox_raw` against the growing JSONL, producing ~100M JSON parses on a 12K-in/6K-matched run. See analyst-b shaping comment on #2699 for the root-cause analysis.

## Behavior changes

- **I/O shape:** per-match re-reads are gone; the inbox is read once and rewritten once under a single `LOCK_EX`.
- **In-inbox history:** the rewrite deduplicates to latest-record-per-id (same semantics as `compact_inbox`). The global audit trail (`messages.jsonl`) is untouched. No caller of `_read_inbox_raw` currently depends on multi-record history within a single inbox.
- **TTL lazy expiry parity:** a TTL-stale pending record that is unmatched by `filter_fn` is still transitioned to `expired` in the rewrite — parity with what `read_inbox -> _expire_stale_on_read` does today.
- **Race-condition path:** the mid-batch `ValueError` path that #2668 added to handle concurrent lazy-expiry is no longer reachable from inside `bulk_ack_messages`, because the whole operation holds the inbox lock. Observable contract is preserved via the in-memory lazy-expiry step (exercised by the repurposed `test_bulk_ack_handles_race_condition`).

## Repro / Validation

Targeted:

    uv run python -m pytest tests/unit/test_ops_message_bus.py tests/unit/test_ops_cli.py -v
    # → 339 passed

Performance sanity (included as a pytest):

    uv run python -m pytest tests/unit/test_ops_message_bus.py::TestBulkAckSinglePass -v
    # 5K-message ack in <2s; single-read single-write instrumentation

CLI regression test: 2000-message inbox via `ops inbox bulk-ack` completes in <5s.

## Tests

**New — `TestBulkAckSinglePass` (5 tests):**
- `test_bulk_ack_single_read_single_write` — instruments `open()` to prove the inbox path is read once and the tmp path written once, regardless of M matched messages.
- `test_bulk_ack_large_inbox_under_budget` — 5000 pending messages, wall-clock budget <2s.
- `test_bulk_ack_preserves_ttl_expiry_side_effect` — TTL-stale pending records expire even when the filter doesn't match them.
- `test_bulk_ack_dedup_after_rewrite` — inbox file is deduplicated after bulk-ack (multi-record history collapses to latest-record-per-id).
- `test_bulk_ack_urgent_not_expired` — urgent (P0) past-TTL pending records are never auto-expired, regardless of filter match.

**New — CLI regression:**
- `test_bulk_ack_cli_large_inbox_completes` — 2000-message inbox, CLI ack-all, <5s budget.

**Existing tests preserved (17 pass unchanged):**
- All 6 `TestBulkAckMessages` tests (one updated to use a 5h-old timestamp instead of a 2020 timestamp so it stays inside the default 24h TTL window).
- All 6 `TestBulkAckTerminalStates` tests (one repurposed — see Behavior changes).
- All 4 existing `TestInboxBulkAck` CLI tests.

## Worktree proof

    $ pwd
    /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
    $ git rev-parse --show-toplevel
    /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
    $ git branch --show-current
    fix/ack-all-single-pass-2699

## CI note

The pre-existing `test_non_cosmetic_coupling_below_threshold` portability audit failure (count 257 vs threshold 253) predates this branch — confirmed by running the test against a fresh `origin/main` worktree before rebasing. This PR adds zero new coupling hits in the changed files (`audit_portability` output for `message_bus.py` / the two test files is empty). Filing / reusing a follow-up is tracked separately from #2699.

## Closure

`Refs #2699` (Tier 2 — fix requires operational verification on a ≥5K real inbox per the analyst shaping §Manual proving. After merge, run:

    time uv run python scripts/internal/ops.py inbox ack-all --lane <lane>

on a large real inbox (e.g. orchestrator) and target <5s wall-clock with <10% CPU-seconds.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)