### PR TITLE
fix(ops): orchestrator-side reconcile for dispatched packets (#2701)

### DIFF
--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -49,6 +49,48 @@ req = ReviewRequest(
 write_request(req, emit_event=True)
 " 2>/dev/null || true
 
+  # --- #2701 — write PR number back onto the active dispatched packet ---
+  # This feeds the orchestrator-side reconcile_dispatched_packets() pass in
+  # monitor.py.  Without this, the reconciler has no way to map a packet
+  # to a PR state on the auto-merge.yml path (which bypasses the local
+  # post-merge-notify.sh hook entirely).
+  #
+  # Resolve the calling lane the same way post-merge-notify.sh does so
+  # the two hooks agree on ownership. Best-effort — a failure here never
+  # blocks PR creation.
+  LANE_ID=""
+  if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
+    LANE_ID=$(echo "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
+  fi
+  if [ -z "$LANE_ID" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
+    case "$DIR_NAME" in
+      *steward-author-scratch) LANE_ID="author-scratch" ;;
+      *steward-author-b)       LANE_ID="author-b" ;;
+      *steward-author-c)       LANE_ID="author-c" ;;
+      *steward-author-d)       LANE_ID="author-d" ;;
+      *steward-author)         LANE_ID="author-a" ;;
+      *steward-brws-author-a)  LANE_ID="brws-author-a" ;;
+      *steward-brws-author-b)  LANE_ID="brws-author-b" ;;
+      *steward-brws-author-c)  LANE_ID="brws-author-c" ;;
+      *steward-brws-author-d)  LANE_ID="brws-author-d" ;;
+      *steward-flex-a)         LANE_ID="flex-a" ;;
+      *steward-flex-b)         LANE_ID="flex-b" ;;
+      *steward-flex-c)         LANE_ID="flex-c" ;;
+      *steward-flex-d)         LANE_ID="flex-d" ;;
+      *steward-review)         LANE_ID="review" ;;
+      *steward-ops)            LANE_ID="ops" ;;
+    esac
+  fi
+
+  if [ -n "$LANE_ID" ]; then
+    # packet_id='-' triggers lane-based resolution in the CLI.
+    # Exit 0 is expected on "no dispatched packet" — the hook also
+    # fires for ops-lane manual PRs that have no packet at all.
+    uv run python scripts/internal/ops.py task update-metadata "-" \
+      --lane "$LANE_ID" --pr-number "$PR_NUM" >/dev/null 2>&1 || true
+  fi
+
   # Inform the agent that a review was enqueued (informational only —
   # no longer triggers /reviewing-changes).
   cat <<'EOF'

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -41,6 +41,7 @@ Usage:
     uv run python scripts/internal/ops.py task approve PACKET_ID [--json]
     uv run python scripts/internal/ops.py task dispatch PACKET_ID LANE_ID [--approve] [--json]
     uv run python scripts/internal/ops.py task accept PACKET_ID --lane LANE [--json]
+    uv run python scripts/internal/ops.py task update-metadata PACKET_ID [--pr-number N] [--lane LANE] [--json]
     uv run python scripts/internal/ops.py inbox [--lane LANE] [--status STATUS] [--type TYPE] [--thread THREAD] [--prioritized] [--json]
     uv run python scripts/internal/ops.py inbox stats [--json]
     uv run python scripts/internal/ops.py inbox ack MSG_ID --lane LANE [--json]
@@ -1938,9 +1939,71 @@ def cmd_task(args: argparse.Namespace) -> int:
                 print("  (archived)")
         return 0
 
+    elif action == "update-metadata":
+        # #2701 — pr_number write-back from post-pr-review.sh.
+        from bid_euchre.ops.task_queue import update_packet_metadata
+
+        packet_id = args.packet_id
+        lane = getattr(args, "lane", None)
+        pr_number = getattr(args, "pr_number", None)
+
+        # packet_id == '-' means "resolve the active dispatched packet
+        # for --lane". Hooks use this to avoid re-implementing lookup.
+        if packet_id == "-":
+            if not lane:
+                print(
+                    "--lane is required when packet_id is '-'.",
+                    file=sys.stderr,
+                )
+                return 1
+            dispatched = tq.list_packets(status="dispatched", owner=lane)
+            if not dispatched:
+                # Not an error — the hook can fire for PRs that don't
+                # correspond to a dispatched packet (e.g., ops-lane
+                # manual PRs). Exit 0 with a clear message.
+                if not args.json:
+                    print(f"No dispatched packet for lane {lane!r} — skipped.")
+                else:
+                    print(json.dumps({"updated": None, "reason": "no_packet"}))
+                return 0
+            if len(dispatched) > 1:
+                # Scope-lock invariant says one dispatched packet per lane;
+                # pick the most recently dispatched to be deterministic.
+                dispatched.sort(
+                    key=lambda p: (p.metadata or {}).get("dispatched_at", p.created_at),
+                    reverse=True,
+                )
+            packet_id = dispatched[0].packet_id
+
+        updates: dict[str, Any] = {}
+        if pr_number is not None:
+            updates["pr_number"] = pr_number
+
+        if not updates:
+            print(
+                "No metadata updates specified (use --pr-number).",
+                file=sys.stderr,
+            )
+            return 1
+
+        updated = update_packet_metadata(packet_id, updates, task_queue_root)
+        if updated is None:
+            print(f"Packet {packet_id!r} not found.", file=sys.stderr)
+            return 1
+
+        if args.json:
+            from dataclasses import asdict
+
+            print(json.dumps(asdict(updated), indent=2, default=str))
+        else:
+            keys = ", ".join(sorted(updates.keys()))
+            print(f"Updated metadata on {updated.packet_id}: {keys}")
+        return 0
+
     else:
         print(
-            "Usage: ops.py task {list|show|create|approve|dispatch|accept|complete}",
+            "Usage: ops.py task "
+            "{list|show|create|approve|dispatch|accept|complete|update-metadata}",
             file=sys.stderr,
         )
         return 1
@@ -4549,6 +4612,35 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         choices=["merged", "abandoned", "rolled_back", "blocked", "other"],
         help="Outcome: final disposition of the packet's shipped output.",
+    )
+
+    # task update-metadata (#2701 — pr_number write-back from hooks)
+    task_update_metadata_parser = task_sub.add_parser(
+        "update-metadata",
+        help=(
+            "Merge metadata keys into an existing packet. Used by the "
+            "post-pr-review.sh hook to record pr_number so the orchestrator "
+            "reconciler can complete the packet when the PR is merged."
+        ),
+    )
+    task_update_metadata_parser.add_argument(
+        "packet_id", help="The packet ID to update"
+    )
+    task_update_metadata_parser.add_argument(
+        "--pr-number",
+        type=int,
+        default=None,
+        dest="pr_number",
+        help="Write the PR number onto packet.metadata.pr_number.",
+    )
+    task_update_metadata_parser.add_argument(
+        "--lane",
+        default=None,
+        help=(
+            "If provided without packet_id == '-', resolve the active "
+            "dispatched packet owned by this lane and update it. Pass "
+            "packet_id='-' to force resolution by --lane."
+        ),
     )
 
     # inbox (Platform-3 message bus)

--- a/src/bid_euchre/ops/monitor.py
+++ b/src/bid_euchre/ops/monitor.py
@@ -638,22 +638,104 @@ def check_recently_merged_prs(
 # ---------------------------------------------------------------------------
 
 
-def check_merged_dispatches(
+def _query_pr_state(pr_number: int | str) -> str | None:
+    """Query GitHub for a PR's state.
+
+    Returns the raw state string (e.g., ``"MERGED"``, ``"OPEN"``, ``"CLOSED"``)
+    or ``None`` if the query fails for any reason. Kept as a module-level
+    helper so tests can monkeypatch it directly.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "state",
+                "--jq",
+                ".state",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    state = result.stdout.strip()
+    return state or None
+
+
+def _send_reconcile_message(
+    *,
+    from_lane: str,
+    message_type: str,
+    summary: str,
+    task_id: str,
+    payload: dict[str, Any],
+) -> None:
+    """Emit a durable message from the reconciler to the orchestrator.
+
+    Best-effort — failures are logged but never re-raised so a single
+    message-bus hiccup does not cascade into the monitor cycle. The
+    orchestrator's next reconcile pass is idempotent because the packet
+    status has already transitioned to a terminal state.
+    """
+    try:
+        from bid_euchre.ops.message_bus import create_message, send_message
+
+        msg = create_message(
+            from_lane=from_lane or "orchestrator",
+            to_lane="orchestrator",
+            message_type=message_type,
+            summary=summary,
+            task_id=task_id,
+            payload=payload,
+        )
+        send_message(msg)
+    except Exception as exc:  # pragma: no cover — best-effort
+        logger.warning(
+            "reconcile_dispatched_packets: send %s for %s failed: %s",
+            message_type,
+            task_id,
+            exc,
+        )
+
+
+def reconcile_dispatched_packets(
     runtime_dir: Path | None = None,
 ) -> list[MonitorFinding]:
-    """Complete dispatched packets whose PRs have already been merged.
+    """Reconcile dispatched packets against GitHub PR state (#2701).
 
-    When GitHub auto-merges a PR (server-side), the PostToolUse hook in
-    ``post-merge-notify.sh`` never fires because no ``gh pr merge`` runs in
-    a Claude session.  This check scans dispatched packets that carry a
-    ``metadata.pr_number``, queries GitHub for each PR's merge state, and
-    auto-completes any that are merged.
+    Author-side ``post-merge-notify.sh`` only fires when a human or author
+    lane runs ``gh pr merge`` locally.  When a PR is merged via the
+    ``auto-merge.yml`` workflow (fleet path), no PostToolUse hook fires in
+    any Claude session and dispatched packets stay ``dispatched`` until an
+    operator reaps them manually.  This reconciler closes the loop.
+
+    For each ``dispatched`` packet that carries ``metadata.pr_number``:
+
+    - ``MERGED`` → transition to ``completed`` and emit a ``completion``
+      message with ``payload.reconciled=True``.
+    - ``CLOSED`` (not merged) → transition to ``failed`` and emit a
+      ``completion`` message with ``payload.status="failed"`` and
+      ``payload.reason="pr_closed_without_merge"``.
+    - ``OPEN`` / other → leave untouched.
+
+    Packets without ``metadata.pr_number`` are skipped silently — the
+    ``post-pr-review.sh`` hook populates that key when the PR is created,
+    so absence indicates either a legacy packet or a lane that failed to
+    run the hook.
 
     Args:
         runtime_dir: Override for the runtime directory root.
 
     Returns:
-        List of findings (one per auto-completed packet, plus errors).
+        List of findings — one INFO per transition, plus WARN findings
+        for query/transition errors.
     """
     findings: list[MonitorFinding] = []
 
@@ -681,41 +763,50 @@ def check_merged_dispatches(
     for pkt in dispatched:
         pr_number = (getattr(pkt, "metadata", None) or {}).get("pr_number")
         if pr_number is None:
+            # No PR yet recorded for this packet — skip. The
+            # post-pr-review.sh hook will populate pr_number on the next
+            # ``gh pr create`` for this lane.
             continue
 
-        # Query GitHub for the PR's merge state
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--json",
-                    "state",
-                    "--jq",
-                    ".state",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            if result.returncode != 0:
+        state = _query_pr_state(pr_number)
+        if state is None:
+            # gh failure or unavailable — skip this packet; retry next tick.
+            continue
+
+        owner = pkt.owner or "orchestrator"
+
+        if state == "MERGED":
+            try:
+                transition_status(pkt.packet_id, "completed", task_queue_root)
+            except Exception as exc:
+                findings.append(
+                    MonitorFinding(
+                        category="merged_dispatch",
+                        severity=SEVERITY_WARN,
+                        summary=(
+                            f"Failed to auto-complete packet {pkt.packet_id!r} "
+                            f"(PR #{pr_number}): {exc}"
+                        ),
+                        details={
+                            "packet_id": pkt.packet_id,
+                            "error": str(exc),
+                        },
+                    )
+                )
                 continue
-            state = result.stdout.strip()
-        except (
-            FileNotFoundError,
-            subprocess.TimeoutExpired,
-            OSError,
-        ):
-            continue
 
-        if state != "MERGED":
-            continue
-
-        # Auto-complete the packet
-        try:
-            transition_status(pkt.packet_id, "completed", task_queue_root)
+            _send_reconcile_message(
+                from_lane=owner,
+                message_type="completion",
+                summary=(f"PR #{pr_number} merged (reconciled) — task complete"),
+                task_id=pkt.packet_id,
+                payload={
+                    "pr_number": pr_number,
+                    "packet_id": pkt.packet_id,
+                    "status": "completed",
+                    "reconciled": True,
+                },
+            )
             findings.append(
                 MonitorFinding(
                     category="merged_dispatch",
@@ -728,23 +819,81 @@ def check_merged_dispatches(
                         "packet_id": pkt.packet_id,
                         "pr_number": pr_number,
                         "owner": pkt.owner,
+                        "reconciled": True,
                     },
                 )
             )
-        except Exception as exc:
+
+        elif state == "CLOSED":
+            try:
+                transition_status(pkt.packet_id, "failed", task_queue_root)
+            except Exception as exc:
+                findings.append(
+                    MonitorFinding(
+                        category="merged_dispatch",
+                        severity=SEVERITY_WARN,
+                        summary=(
+                            f"Failed to mark packet {pkt.packet_id!r} "
+                            f"failed (PR #{pr_number} closed): {exc}"
+                        ),
+                        details={
+                            "packet_id": pkt.packet_id,
+                            "error": str(exc),
+                        },
+                    )
+                )
+                continue
+
+            reason = "pr_closed_without_merge"
+            _send_reconcile_message(
+                from_lane=owner,
+                message_type="completion",
+                summary=(
+                    f"PR #{pr_number} closed without merge (reconciled) — "
+                    f"task failed"
+                ),
+                task_id=pkt.packet_id,
+                payload={
+                    "pr_number": pr_number,
+                    "packet_id": pkt.packet_id,
+                    "status": "failed",
+                    "reason": reason,
+                    "reconciled": True,
+                },
+            )
             findings.append(
                 MonitorFinding(
                     category="merged_dispatch",
                     severity=SEVERITY_WARN,
                     summary=(
-                        f"Failed to auto-complete packet {pkt.packet_id!r} "
-                        f"(PR #{pr_number}): {exc}"
+                        f"Marked packet {pkt.packet_id!r} failed "
+                        f"(PR #{pr_number} closed without merge)"
                     ),
-                    details={"packet_id": pkt.packet_id, "error": str(exc)},
+                    details={
+                        "packet_id": pkt.packet_id,
+                        "pr_number": pr_number,
+                        "owner": pkt.owner,
+                        "reason": reason,
+                        "reconciled": True,
+                    },
                 )
             )
 
+        # OPEN and any other state: leave packet dispatched.
+
     return findings
+
+
+def check_merged_dispatches(
+    runtime_dir: Path | None = None,
+) -> list[MonitorFinding]:
+    """Deprecated alias for :func:`reconcile_dispatched_packets` (#2701).
+
+    Retained so external callers that imported ``check_merged_dispatches``
+    under the pre-#2701 name keep working. New code should call
+    :func:`reconcile_dispatched_packets` directly.
+    """
+    return reconcile_dispatched_packets(runtime_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -1929,7 +2078,8 @@ def run_monitoring_cycle(
     5. Stalled lane detection (acked but idle), with optional recovery
     6. Approval-stall detection (lanes blocked on tool-approval prompts)
     7. Recently merged PR detection (new merges since last cycle)
-    8. Auto-complete dispatched packets whose PRs were merged externally
+    8. Reconcile dispatched packets against GitHub PR state (#2701)
+       — MERGED → completed, CLOSED → failed
     9. Auto-dispatch approved packets to idle lanes
     10. Fleet-level idle check — auto-shutoff recommendation (#1572)
 
@@ -1977,9 +2127,12 @@ def run_monitoring_cycle(
     if not skip_pr_check:
         findings.extend(check_recently_merged_prs(runtime_dir))
 
-    # 8. Auto-complete dispatched packets whose PRs were merged externally
+    # 8. Reconcile dispatched packets against GitHub PR state (#2701):
+    #    auto-complete on MERGED, mark failed on CLOSED. This is the only
+    #    completion path for the auto-merge.yml workflow (no local
+    #    ``gh pr merge`` means no PostToolUse hook).
     if not skip_pr_check:
-        findings.extend(check_merged_dispatches(runtime_dir))
+        findings.extend(reconcile_dispatched_packets(runtime_dir))
 
     # 9. Auto-dispatch approved packets to idle lanes
     if not no_auto_dispatch:

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -40,6 +40,7 @@ VALID_STATUSES = frozenset(
         "approved",
         "dispatched",
         "completed",
+        "failed",
         "rejected",
         "redirected",
     }
@@ -163,8 +164,11 @@ VALID_TRANSITIONS: dict[str, frozenset[str]] = {
     "pending": frozenset({"previewing", "approved", "rejected", "redirected"}),
     "previewing": frozenset({"approved", "rejected", "redirected"}),
     "approved": frozenset({"dispatched", "rejected"}),
-    "dispatched": frozenset({"completed"}),
+    # ``failed`` is entered by the orchestrator-side reconciler when a PR
+    # associated with a dispatched packet is closed without merging (#2701).
+    "dispatched": frozenset({"completed", "failed"}),
     "completed": frozenset(),  # terminal
+    "failed": frozenset(),  # terminal
     "rejected": frozenset(),  # terminal
     "redirected": frozenset(),  # terminal
 }

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -3939,6 +3939,229 @@ class TestTaskComplete:
             )
 
 
+class TestTaskUpdateMetadata:
+    """Verify ``task update-metadata`` CLI subcommand (#2701)."""
+
+    def test_writes_pr_number_onto_packet(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Updating a packet writes pr_number into its metadata."""
+        import ops
+
+        from bid_euchre.ops.task_queue import load_packet, transition_status
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "UM test",
+                "--owner",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        created = json.loads(capsys.readouterr().out)
+        packet_id = created["packet_id"]
+
+        tq_root = runtime_dir / "task_queue"
+        transition_status(packet_id, "approved", tq_root)
+        transition_status(packet_id, "dispatched", tq_root)
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                packet_id,
+                "--pr-number",
+                "1234",
+            ]
+        )
+        assert rc == 0
+
+        pkt = load_packet(packet_id, tq_root)
+        assert pkt is not None
+        assert pkt.metadata["pr_number"] == 1234
+        # Status unchanged by metadata update
+        assert pkt.status == "dispatched"
+
+    def test_dash_packet_id_resolves_by_lane(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Passing packet_id='-' with --lane resolves the dispatched packet."""
+        import ops
+
+        from bid_euchre.ops.task_queue import load_packet, transition_status
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "Dash-resolve test",
+                "--owner",
+                "author-b",
+            ]
+        )
+        assert rc == 0
+        created = json.loads(capsys.readouterr().out)
+        packet_id = created["packet_id"]
+
+        tq_root = runtime_dir / "task_queue"
+        transition_status(packet_id, "approved", tq_root)
+        transition_status(packet_id, "dispatched", tq_root)
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                "-",
+                "--lane",
+                "author-b",
+                "--pr-number",
+                "9999",
+            ]
+        )
+        assert rc == 0
+
+        pkt = load_packet(packet_id, tq_root)
+        assert pkt is not None
+        assert pkt.metadata["pr_number"] == 9999
+
+    def test_dash_without_lane_fails(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """packet_id='-' requires --lane."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                "-",
+                "--pr-number",
+                "1",
+            ]
+        )
+        assert rc == 1
+        assert "--lane is required" in capsys.readouterr().err
+
+    def test_no_dispatched_packet_for_lane_exits_zero(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When no dispatched packet matches --lane, command exits 0 silently.
+
+        The hook fires for any ``gh pr create`` — including ops/manual PRs
+        that do not belong to any dispatched packet. Returning 0 keeps the
+        hook non-fatal.
+        """
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                "-",
+                "--lane",
+                "author-c",
+                "--pr-number",
+                "1",
+            ]
+        )
+        assert rc == 0
+
+    def test_nonexistent_packet_returns_error(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Unknown packet_id (literal, not '-') returns exit 1."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                "nonexistent_pkt",
+                "--pr-number",
+                "1",
+            ]
+        )
+        assert rc == 1
+
+    def test_update_metadata_without_fields_fails(
+        self, runtime_dir: Path, plans_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Must pass at least one update flag (--pr-number)."""
+        import ops
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "update-metadata",
+                "some-pkt",
+            ]
+        )
+        assert rc == 1
+        assert "No metadata updates specified" in capsys.readouterr().err
+
+    def test_update_metadata_subparser_exists(self) -> None:
+        """Verify the 'task update-metadata' subparser is properly registered."""
+        import ops
+
+        parser = ops.build_parser()
+
+        task_subparser = None
+        for action in parser._subparsers._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                task_subparser = action.choices.get("task")
+                break
+
+        assert task_subparser is not None, "Expected 'task' subcommand"
+
+        update_subparser = None
+        for action in task_subparser._subparsers._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                update_subparser = action.choices.get("update-metadata")
+                break
+
+        assert (
+            update_subparser is not None
+        ), "Expected 'task update-metadata' subcommand"
+
+
 class TestPriorityChoicesContract:
     """Verify CLI --priority choices stay in sync with VALID_PRIORITIES."""
 

--- a/tests/unit/test_ops_monitor.py
+++ b/tests/unit/test_ops_monitor.py
@@ -37,6 +37,7 @@ from bid_euchre.ops.monitor import (
     evaluate_alert_push,
     format_findings_json,
     format_findings_text,
+    reconcile_dispatched_packets,
     run_monitoring_cycle,
 )
 
@@ -1662,6 +1663,240 @@ class TestCheckMergedDispatches:
         assert len(findings) == 1
         assert findings[0].severity == SEVERITY_WARN
         assert "Failed to auto-complete" in findings[0].summary
+
+
+# ---------------------------------------------------------------------------
+# reconcile_dispatched_packets tests (#2701)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileDispatchedPackets:
+    """Tests for the orchestrator-side dispatched packet reconciler."""
+
+    def test_merged_pr_completes_and_emits_message(self, tmp_path: Path) -> None:
+        """MERGED → packet.status=completed + completion message queued."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(
+            packet_id="pkt-merged-1",
+            owner="author-a",
+            metadata={"pr_number": 42},
+        )
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+                return_value="MERGED",
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch(
+                "bid_euchre.ops.message_bus.create_message",
+            ) as mock_create,
+            patch(
+                "bid_euchre.ops.message_bus.send_message",
+            ) as mock_send,
+        ):
+            mock_create.return_value = MagicMock()
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        mock_transition.assert_called_once_with(
+            "pkt-merged-1", "completed", runtime_dir / "task_queue"
+        )
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["to_lane"] == "orchestrator"
+        assert kwargs["message_type"] == "completion"
+        assert kwargs["task_id"] == "pkt-merged-1"
+        assert kwargs["payload"]["pr_number"] == 42
+        assert kwargs["payload"]["status"] == "completed"
+        assert kwargs["payload"]["reconciled"] is True
+        mock_send.assert_called_once()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+        assert findings[0].details["reconciled"] is True
+
+    def test_closed_pr_marks_failed_and_emits_message(self, tmp_path: Path) -> None:
+        """CLOSED → packet.status=failed with reason + completion message."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(
+            packet_id="pkt-closed-1",
+            owner="author-b",
+            metadata={"pr_number": 55},
+        )
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+                return_value="CLOSED",
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch(
+                "bid_euchre.ops.message_bus.create_message",
+            ) as mock_create,
+            patch(
+                "bid_euchre.ops.message_bus.send_message",
+            ) as mock_send,
+        ):
+            mock_create.return_value = MagicMock()
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        mock_transition.assert_called_once_with(
+            "pkt-closed-1", "failed", runtime_dir / "task_queue"
+        )
+        mock_create.assert_called_once()
+        payload = mock_create.call_args.kwargs["payload"]
+        assert payload["status"] == "failed"
+        assert payload["reason"] == "pr_closed_without_merge"
+        assert payload["reconciled"] is True
+        mock_send.assert_called_once()
+
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_WARN
+        assert findings[0].details["reason"] == "pr_closed_without_merge"
+
+    def test_open_pr_unchanged(self, tmp_path: Path) -> None:
+        """OPEN → packet unchanged, no message emitted."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(metadata={"pr_number": 99})
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+                return_value="OPEN",
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch("bid_euchre.ops.message_bus.send_message") as mock_send,
+        ):
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        assert len(findings) == 0
+        mock_transition.assert_not_called()
+        mock_send.assert_not_called()
+
+    def test_no_pr_number_skipped(self, tmp_path: Path) -> None:
+        """Packet without metadata.pr_number is skipped gracefully."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(metadata={})
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+            ) as mock_query,
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch("bid_euchre.ops.message_bus.send_message") as mock_send,
+        ):
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        assert len(findings) == 0
+        mock_query.assert_not_called()
+        mock_transition.assert_not_called()
+        mock_send.assert_not_called()
+
+    def test_gh_query_failure_skips_packet(self, tmp_path: Path) -> None:
+        """If _query_pr_state returns None, packet is left dispatched."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(metadata={"pr_number": 111})
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+                return_value=None,
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch("bid_euchre.ops.message_bus.send_message") as mock_send,
+        ):
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        assert len(findings) == 0
+        mock_transition.assert_not_called()
+        mock_send.assert_not_called()
+
+    def test_message_send_failure_does_not_rollback_transition(
+        self, tmp_path: Path
+    ) -> None:
+        """send_message failure is swallowed — packet stays completed."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        pkt = _make_dispatched_pkt(metadata={"pr_number": 200})
+
+        with (
+            patch(
+                "bid_euchre.ops.task_queue.list_packets",
+                return_value=[pkt],
+            ),
+            patch(
+                "bid_euchre.ops.monitor._query_pr_state",
+                return_value="MERGED",
+            ),
+            patch(
+                "bid_euchre.ops.task_queue.transition_status",
+            ) as mock_transition,
+            patch(
+                "bid_euchre.ops.message_bus.send_message",
+                side_effect=OSError("bus unavailable"),
+            ),
+        ):
+            findings = reconcile_dispatched_packets(runtime_dir)
+
+        mock_transition.assert_called_once()
+        # INFO finding still produced — message failure is logged, not
+        # surfaced as a finding to avoid infinite escalation.
+        assert len(findings) == 1
+        assert findings[0].severity == SEVERITY_INFO
+
+    def test_check_merged_dispatches_is_alias(self, tmp_path: Path) -> None:
+        """The pre-#2701 name forwards to reconcile_dispatched_packets."""
+        runtime_dir = tmp_path / "runtime"
+        (runtime_dir / "task_queue").mkdir(parents=True)
+
+        with patch(
+            "bid_euchre.ops.monitor.reconcile_dispatched_packets",
+            return_value=[],
+        ) as mock_new:
+            check_merged_dispatches(runtime_dir)
+
+        mock_new.assert_called_once_with(runtime_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ops_task_queue.py
+++ b/tests/unit/test_ops_task_queue.py
@@ -482,12 +482,34 @@ class TestLifecycleTransitions:
                 ), f"Transition {source!r} -> {target!r}: target is not a valid status"
 
     def test_terminal_states_have_no_transitions(self) -> None:
-        """Terminal states (completed, rejected, redirected) cannot transition."""
-        for terminal in ("completed", "rejected", "redirected"):
+        """Terminal states cannot transition onward."""
+        for terminal in ("completed", "failed", "rejected", "redirected"):
             assert VALID_TRANSITIONS[terminal] == frozenset(), (
                 f"{terminal!r} should be terminal but allows: "
                 f"{VALID_TRANSITIONS[terminal]}"
             )
+
+    def test_dispatched_to_failed_allowed(self, tmp_path: Path) -> None:
+        """#2701 — reconciler transitions dispatched → failed on CLOSED PR."""
+        pkt = create_packet("Task", "d")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
+
+        updated = transition_status(pkt.packet_id, "failed", tmp_path)
+        assert updated is not None
+        assert updated.status == "failed"
+
+    def test_failed_is_terminal(self, tmp_path: Path) -> None:
+        """Once failed, the packet cannot re-enter an earlier state."""
+        pkt = create_packet("Task", "d")
+        save_packet(pkt, tmp_path)
+        transition_status(pkt.packet_id, "approved", tmp_path)
+        transition_status(pkt.packet_id, "dispatched", tmp_path)
+        transition_status(pkt.packet_id, "failed", tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid transition"):
+            transition_status(pkt.packet_id, "completed", tmp_path)
 
     def test_archive_packet(self, tmp_path: Path) -> None:
         pkt = create_packet("Task", "d")
@@ -634,7 +656,7 @@ class TestCompletePacket:
         assert (archive_dir / f"{pkt.packet_id}.result.json").exists()
 
     def test_complete_with_failed_result(self, tmp_path: Path) -> None:
-        """Failed result archives packet with dispatched status + result sidecar."""
+        """Failed result transitions packet to failed + archives with result sidecar."""
         pkt = create_packet("Task", "d", owner="author-a")
         save_packet(pkt, tmp_path)
         transition_status(pkt.packet_id, "approved", tmp_path)
@@ -643,14 +665,15 @@ class TestCompletePacket:
         result = create_result(pkt.packet_id, "failed", "Tests failed")
         final = complete_packet(result, tmp_path)
 
-        # Packet returned with its last valid status (dispatched)
+        # Packet transitioned to terminal 'failed' status (dispatched → failed
+        # is a valid transition; see #2701 reconcile_dispatched_packets).
         assert final is not None
-        assert final.status == "dispatched"
+        assert final.status == "failed"
 
         # Packet is archived
         assert load_packet(pkt.packet_id, tmp_path) is None
 
-        # Result sidecar in archive records the actual failure
+        # Result sidecar in archive records the failure
         archive_dir = tmp_path / "archive"
         result_path = archive_dir / f"{pkt.packet_id}.result.json"
         assert result_path.exists()


### PR DESCRIPTION
## Summary

- Add `reconcile_dispatched_packets()` to the monitor cycle — queries `gh pr view` for each dispatched packet's `metadata.pr_number`, transitions MERGED → completed and CLOSED → failed, and emits completion/failure messages to the orchestrator with `reconciled=True`.
- Feed the reconciler by writing `metadata.pr_number` onto the active dispatched packet at PR-create time in `.claude/hooks/post-pr-review.sh`, via a new `task update-metadata` CLI subcommand that supports `packet_id='-'` for lane-based resolution.
- Extend the task-queue state machine: add `"failed"` to `VALID_STATUSES` and permit `dispatched → failed` (terminal).

## Why

The `.github/workflows/auto-merge.yml` workflow runs `gh pr merge` on a GitHub Actions runner, which bypasses the local `post-merge-notify.sh` PostToolUse hook entirely. Packets dispatched to author lanes whose PRs merge via auto-merge stay in `status=dispatched` indefinitely — the lane never self-parks and the orchestrator never learns the task completed. This fix closes the loop orchestrator-side.

The existing #1474 local-merge hook path remains primary; reconcile is the safety-net for the auto-merge.yml path.

Implements analyst-c's shaping on #2701.

## Repro / Validation

```bash
# Tier 1 — targeted
uv run python -m pytest tests/unit/test_ops_monitor.py tests/unit/test_ops_task_queue.py tests/unit/test_ops_cli.py -v
# → 453 passed

# Tier 2 — full validation
make check-gated
# → All checks passed (details: /tmp/make-check-eb88Um)
```

## Tests

New test classes / cases added:

- `tests/unit/test_ops_monitor.py::TestReconcileDispatchedPackets` — 7 tests: MERGED completes + emits message, CLOSED marks failed + emits message, OPEN unchanged, no pr_number skipped, gh failure retried next tick, send failure doesn't rollback transition, `check_merged_dispatches` alias.
- `tests/unit/test_ops_cli.py::TestTaskUpdateMetadata` — 7 tests: direct packet_id update, `-` lane resolution, missing `--lane`, no-dispatched-packet silent zero, nonexistent packet error, no fields error, subparser registration.
- `tests/unit/test_ops_task_queue.py` — added `test_dispatched_to_failed_allowed`, `test_failed_is_terminal`; updated `test_terminal_states_have_no_transitions` and `test_complete_with_failed_result` to reflect the new `failed` terminal status.

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git branch --show-current
fix/reconcile-dispatched-packets-2701
```

Refs: #2701