### PR TITLE
docs(agents,skills): sweep of agent and skill prompt clarifications (#2693 #2698 #2711 #2705)

### DIFF
--- a/.claude/agents/steward-ops.md
+++ b/.claude/agents/steward-ops.md
@@ -36,9 +36,11 @@ an author-lane responsibility by design.
 
 If the repo state contradicts what the dashboard shows, or a lane's
 heartbeat pattern is ambiguous (dead vs. deep-in-a-long-step), surface the
-uncertainty to the orchestrator with the evidence you have rather than
-asserting a nominal or critical status. One round of clarification is
-cheap; a confidently-wrong status drives wrong recovery actions downstream.
+uncertainty to the current caller (the orchestrator when launched as part
+of the fleet, or the human operator when ops is invoked directly with no
+orchestrator present) with the evidence you have rather than asserting a
+nominal or critical status. One round of clarification is cheap; a
+confidently-wrong status drives wrong recovery actions downstream.
 
 ## Primary Status Surface
 

--- a/.claude/skills/fleet-check/SKILL.md
+++ b/.claude/skills/fleet-check/SKILL.md
@@ -64,9 +64,11 @@ Check for completed tasks and dispatch new work:
 # Check task queue for completed items
 uv run python scripts/internal/ops.py task list
 
-# Check per-lane state to find idle lanes (heartbeat-aware, post-#2415)
+# Check per-lane state to find idle lanes (heartbeat-aware, post-#2415).
+# Only true `idle` lanes are dispatchable; `stale` lanes need triage first
+# (they may be mid-work with a lagging heartbeat) — see #2711.
 uv run python scripts/internal/ops.py --json lane status --all | \
-  jq -r '.[] | select(.phase == "idle" or .phase == "stale") | .lane_id'
+  jq -r '.[] | select(.phase == "idle") | .lane_id'
 ```
 
 For each completed task:

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -125,10 +125,11 @@ tmux send-keys -t "$PANE" Enter
 After dispatching `/park`, **wait for the lane to confirm**. Read the pane
 contents and look for the final line of the `/park` skill output, which
 reports the number of cron jobs deleted and that `CronList` is now empty.
-Use the capture-pane skill:
+Use the `/capture-pane` skill (or the underlying `tmux capture-pane`
+invocation it wraps):
 
 ```bash
-uv run python scripts/internal/ops.py capture-pane --lane <lane>
+tmux capture-pane -t steward:<window>.<pane> -p -S -50
 ```
 
 The lane is safely parked when the pane shows:


### PR DESCRIPTION
## Summary

Doc-only sweep collapsing four review-coordinator follow-up findings
(#2693, #2698, #2711, #2705) into one narrow subsystem PR. Precedent:
PR #2696. Triage: #2720 (Category A-Sweep).

## Why

Four one-line prompt-clarification follow-ups against `.claude/agents/`
and `.claude/skills/` had been idle in the queue. Bundling is safe here
because all four touch only docs/prompts, belong to the same narrow
subsystem, and have no behavioral overlap with any in-flight author PR.
#2693 and #2698 both land at `steward-ops.md:37` and are two framings of
the same "direct-run ops needs a fallback caller" concern — a single
edit resolves both; they were verified semantically compatible before
bundling (per the packet's scope guidance).

## Changes

| Issue | File | Change |
|-------|------|--------|
| #2693, #2698 | `.claude/agents/steward-ops.md` | Reframe uncertainty escalation target as "the current caller" — orchestrator when launched as part of the fleet, human operator when ops is invoked directly with no orchestrator present. |
| #2711 | `.claude/skills/fleet-check/SKILL.md` | Drop `stale` from the idle-lane jq selector. Only true `idle` lanes are dispatchable; `stale` lanes need triage first. Added inline comment pointing at #2711. |
| #2705 | `.claude/skills/session-end/SKILL.md` | Replace nonexistent `ops.py capture-pane --lane <lane>` command with the underlying `tmux capture-pane -t steward:<window>.<pane> -p -S -50` invocation that the `/capture-pane` skill wraps. Prose updated to point at the skill. |

## Repro / Validation

- `git diff origin/main..HEAD --stat` → 3 files, 12 insertions, 7 deletions
- `uv run ruff format --check <touched files>` — N/A (markdown, not Python)
- Manual read of each touched file confirms the four findings are resolved.
- No runtime impact — docs only.

## Tests

- No test changes. Docs-only CI path filter will skip heavy jobs; `tests`
  aggregation gate should pass on all-skipped upstream (see
  `.claude/rules/deferred/60_review_gate.md`).

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b`
- `git rev-parse --show-toplevel`: same as above
- `git worktree list` includes this worktree on branch `docs/agent-skill-prompt-sweep-2026-04`

## Closure

Fixes #2693, Fixes #2698, Fixes #2711, Fixes #2705 (all Tier 1 — doc
tweaks with no behavior change; CI + manual read lock the changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)