### PR TITLE
feat(ops): add lane × model × effort rollups to token economy (Slice B)

### DIFF
--- a/plans/sessions/2026-04-20_token_economy_slice_b_report.md
+++ b/plans/sessions/2026-04-20_token_economy_slice_b_report.md
@@ -1,0 +1,172 @@
+# Token Economy — Slice B Baseline Report
+
+> Companion artifact for `plans/sessions/2026-04-20_token_economy_slice_b.md`
+> (shaping plan merged as #2713). Captures the store snapshot immediately
+> after the Slice B telemetry extension landed, before any post-Slice-B
+> `usage import --force` rescans.
+>
+> Issue umbrella: #2169 (Token economy observability rollouts).
+
+## Scope
+
+Slice B extends the token-economy schema from v2 → v3 with three new
+dimensions attached to every `SessionRecord`:
+
+- `model` — majority-by-output-tokens assistant model (or `unknown`)
+- `model_mix` — per-model token share, populated only when >1 models observed
+- `effort` — declared effort signal (baseline: always `unknown` until
+  Slices D/E wire `TaskPacket.effort_hint` through to session records)
+- `cache_creation_tokens` / `cache_read_tokens` — carried alongside
+  input/output totals (baseline: `0` unless JSONL contributes them)
+
+Five new rollup APIs (`model_summary`, `effort_summary`,
+`lane_model_summary`, `lane_effort_summary`, `model_outcome_summary`),
+three CLI subcommands (`usage by-model`, `usage by-effort`,
+`usage by-model-outcome`), and a dashboard `by_model` panel round out
+the surface.
+
+## Snapshot (2026-04-21, post-merge baseline)
+
+Captured against the shared store at `.claude/runtime/usage/` via the
+ops CLI. The store was populated by the pre-Slice-B scanner — every
+session reads back with `model = "unknown"` and `effort = "unknown"`.
+This is the expected v2 → v3 read-compat baseline; the `unknown`
+bucket becomes the disclosed fallback, not a coercion.
+
+### Reconcile totals
+
+```
+$ uv run python scripts/internal/ops.py usage reconcile
+Token Economy Totals Reconciliation
+  Surface          Sessions         Tokens    Commits
+  summary              2152     43,536,275       1059
+  lanes (Σ)            2152     43,536,275       1059
+  throughput           2152     43,536,275       1059
+  by-model (Σ)            —     43,536,275          —
+  Attribution gap:     0
+  Token parity delta:  +0
+  Commit parity delta: +0
+  Model parity delta:  +0
+Totals parity: [OK] summary, lanes, throughput agree
+```
+
+The new `by-model (Σ)` row ties to `summary` exactly (token parity
+delta `+0`). `Sessions` / `Commits` are dashed because the by-model
+rollup is a directional split of session tokens (mixed-model sessions
+are counted once on the majority row; tokens fan out proportionally),
+so those columns are not comparable under the Slice A parity guard.
+
+### by-model baseline
+
+```
+$ uv run python scripts/internal/ops.py usage by-model
+Per-Model Token Usage (Slice B)
+  Model              Sessions       Tokens  % total  Commits
+  unknown                2152   43,536,275   100.0%     1059
+  — total —                     43,536,275
+  [disclosure] Unknown-model fraction: 100.0% of tokens are in the
+  `unknown` bucket (legacy session-meta or pre-Slice-B JSONL rows).
+  Run `usage import --force` to rescan.
+```
+
+The disclosure line fires automatically when unknown ≥ 10% of tokens.
+After operators run `usage import --force`, post-Slice-B JSONL rows
+will populate the model field from `msg.model`; the `unknown` bucket
+will then contain only session-meta-sourced rows and any pre-Slice-B
+JSONL lines that were never rescanned.
+
+### by-effort baseline
+
+```
+$ uv run python scripts/internal/ops.py usage by-effort
+Per-Effort Token Usage (Slice B)
+  Effort         Sessions       Tokens  % total  Commits
+  unknown            2152   43,536,275   100.0%     1059
+  [disclosure] No sessions carry a declared effort signal yet
+  (Slice B baseline). The effort dimension becomes populated once
+  TaskPacket effort_hint → session effort wiring lands (Slices D/E).
+```
+
+Slice B is the schema carrier for `effort`; the producer side lands
+in Slice D (#2715, merged 2026-04-20) and Slice E (#2721, merged
+2026-04-21). The `unknown` bucket stays at 100% in this baseline
+because no session records were retroactively updated with effort.
+
+### Summary trailer
+
+```
+$ uv run python scripts/internal/ops.py usage summary | tail
+  By model:              unknown 100%
+Totals parity: [OK] summary, lanes, throughput agree
+```
+
+The `By model:` trailer is the compact single-line disclosure that
+operators see by default; it folds >4 buckets into `other` and
+suppresses itself if only `unknown` is present after Slice B becomes
+the steady-state scanner (for the baseline it intentionally shows
+`unknown 100%` as the v2→v3 read-back signal).
+
+## Null-Safety Contract (verified)
+
+Per §2.4 of the shaping plan, the `unknown` bucket is a first-class
+label and is never coerced. Test coverage in
+`tests/unit/test_token_economy.py::TestSliceBModelCapture::test_null_safe_unknown_bucket`
+locks this in. Dashboard rendering in
+`tests/unit/test_ops_dashboard.py::TestDashboardByModelPanel::test_dashboard_by_model_suppressed_when_only_unknown`
+suppresses the `by_model` panel when only `unknown` is present so
+operators don't see a degenerate "one bar at 100% unknown" panel
+after the v2→v3 read-back baseline.
+
+## Parity Guard (Slice A §4.0 compatible)
+
+Byte-exact output of existing CLI surfaces (`usage summary`,
+`usage lanes`, `usage throughput`, `usage reconcile` Slice-A columns)
+is preserved. Slice B additions are **additive**:
+
+- New single-line trailer on `usage summary` ("By model: …")
+- New `by-model (Σ)` totals row + `Model parity delta` line on
+  `usage reconcile`
+- Three new subcommands (`by-model`, `by-effort`, `by-model-outcome`)
+- New `by_model` key on the `token_economy` dashboard payload
+
+No existing column, sort order, rounding rule, or delta formula changed.
+
+## Schema read-back
+
+The `SessionRecord` schema bump (v2 → v3) uses `.get(...)` semantics
+throughout the decoder: a v2 row reads back as a v3 record with
+`model=None` mapped to the `unknown` bucket, `model_mix={}`,
+`effort=None → unknown`, and `cache_creation_tokens = cache_read_tokens = 0`.
+Test
+`tests/unit/test_token_economy.py::TestSliceBModelCapture::test_schema_version_bump_read_compat`
+locks the forward/backward behavior.
+
+## Validation performed
+
+- Tier 1 (targeted):
+  - `uv run python -m pytest tests/unit/test_token_economy.py` → **79 passed**
+  - `uv run python -m pytest tests/unit/test_ops_token_economy.py` → **99 passed**
+  - `uv run python -m pytest tests/unit/test_ops_dashboard.py` → **55 passed**
+  - `uv run python -m pytest tests/unit/test_ops_cli.py` → **172 passed**
+  - Combined run across all four files: **405 passed in 40.96s**
+- Tier 2 (`make check-gated`): run pre-PR (see PR body for evidence).
+
+## Follow-ups (not in this slice)
+
+- Slice D/E producer wiring backfills `effort` for new sessions; a
+  future report will show non-zero effort buckets once enough sessions
+  carry an effort signal.
+- Dashboard `by_model` panel only rolls up >4 into `other`; if the
+  operator pool grows past ~6 distinct model SKUs regularly, the
+  fold threshold may want to move to a config knob (follow-up issue,
+  not this PR).
+- No migration script is provided. Operators can rescan retroactively
+  by running `usage import --force` once the Slice B scanner is the
+  sole producer — that populates `model` from JSONL `msg.model` and
+  drops the `unknown` fraction on the by-model trailer. Session-meta
+  rows (no JSONL available) will remain `unknown` permanently, which
+  is intentional (§2.4 null-safety contract).
+
+## Outcome
+
+PR: TBD (opens in this session with branch `ops/token-economy-slice-b`).

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -3430,6 +3430,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
 
     elif action == "summary":
         from bid_euchre.ops.token_economy import (
+            model_summary,
             reconcile_totals,
             store_status,
             usage_summary,
@@ -3439,6 +3440,9 @@ def cmd_usage(args: argparse.Namespace) -> int:
         status = store_status(output_dir=out_dir)
         result = usage_summary(output_dir=out_dir)
         parity = reconcile_totals(output_dir=out_dir)
+        # Slice B (§4.4): one-line by-model trailer. Pulled lazily so the
+        # summary path does not slow the CLI on empty stores.
+        by_model = model_summary(output_dir=out_dir) if result.session_count else []
 
         if args.json:
             from dataclasses import asdict
@@ -3447,6 +3451,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
                 "store_status": asdict(status),
                 "summary": asdict(result),
                 "reconciliation": asdict(parity),
+                "by_model": [asdict(b) for b in by_model],
             }
             print(json.dumps(payload, indent=2, default=str))
         else:
@@ -3481,6 +3486,22 @@ def cmd_usage(args: argparse.Namespace) -> int:
             print(f"    Assistant msgs:    {result.total_assistant_messages}")
             print(f"    Assist/User:       {result.assistant_user_ratio:.1f}x")
             print(f"    Tool errors:       {result.total_tool_errors}")
+            # Slice B (§4.4): condensed by-model trailer. Keep it to one
+            # logical line so existing consumers that tail the summary for
+            # final parity output are unaffected.
+            if by_model:
+                total_by_model_tokens = sum(b.total_tokens for b in by_model)
+                top = by_model[:3]
+                if total_by_model_tokens > 0:
+                    parts = []
+                    for b in top:
+                        pct = b.total_tokens / total_by_model_tokens * 100.0
+                        parts.append(f"{b.model} {pct:.0f}%")
+                    trailer = ", ".join(parts)
+                    if len(by_model) > 3:
+                        trailer = f"{trailer}, … ({len(by_model) - 3} more)"
+                    print()
+                    print(f"  By model:              {trailer}")
             # Parity footer: surfaces silent drift across CLI surfaces.
             print()
             print(_format_parity_footer(parity))
@@ -3633,6 +3654,13 @@ def cmd_usage(args: argparse.Namespace) -> int:
                 f"  {'throughput':<14s} {parity.throughput_sessions:>10d} "
                 f"{parity.throughput_tokens:>14,d} {parity.throughput_commits:>10d}"
             )
+            # Slice B (v3): by-model totals row. Sessions/commits columns
+            # are dashed because the by-model rollup is a directional split
+            # that does not own the session count (lanes does).
+            print(
+                f"  {'by-model (Σ)':<14s} {'—':>10s} "
+                f"{parity.by_model_tokens:>14,d} {'—':>10s}"
+            )
             print()
             print(
                 f"  Incomplete sessions (expected, excluded from throughput): "
@@ -3641,14 +3669,202 @@ def cmd_usage(args: argparse.Namespace) -> int:
             print(f"  Attribution gap:     {parity.attribution_gap}")
             print(f"  Token parity delta:  {parity.token_parity_delta:+,d}")
             print(f"  Commit parity delta: {parity.commit_parity_delta:+d}")
+            print(
+                f"  Model parity delta:  " f"{parity.by_model_token_parity_delta:+,d}"
+            )
             print()
             print(_format_parity_footer(parity))
+        return 0
+
+    elif action == "by-model":
+        from bid_euchre.ops.token_economy import model_summary, usage_summary
+
+        out_dir = getattr(args, "output_dir", None)
+        buckets = model_summary(output_dir=out_dir)
+        total_tokens = sum(b.total_tokens for b in buckets)
+        unknown_tokens = sum(b.total_tokens for b in buckets if b.model == "unknown")
+        unknown_fraction = unknown_tokens / total_tokens if total_tokens > 0 else 0.0
+
+        if args.json:
+            from dataclasses import asdict
+
+            payload = {
+                "buckets": [asdict(b) for b in buckets],
+                "total_tokens": total_tokens,
+                "unknown_fraction": unknown_fraction,
+            }
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            # Cross-check against the whole-store reference so operators can
+            # tell at a glance whether the split covers the full store.
+            summary = usage_summary(output_dir=out_dir)
+            if not buckets:
+                print(
+                    "No token economy data. "
+                    "Run: ops.py usage import && ops.py usage attribute"
+                )
+            else:
+                print("Per-Model Token Usage (Slice B)")
+                print("=" * 80)
+                print(
+                    f"  {'Model':<32s} {'Sessions':>8s} {'Tokens':>12s} "
+                    f"{'% total':>8s} {'Commits':>8s}"
+                )
+                print("-" * 80)
+                for b in buckets:
+                    pct = (
+                        (b.total_tokens / total_tokens * 100.0)
+                        if total_tokens > 0
+                        else 0.0
+                    )
+                    commits = f"{b.git_commits:d}" if b.git_commits is not None else "—"
+                    print(
+                        f"  {b.model:<32s} {b.session_count:>8d} "
+                        f"{b.total_tokens:>12,d} {pct:>7.1f}% {commits:>8s}"
+                    )
+                print("-" * 80)
+                print(
+                    f"  {'— total —':<32s} {'':>8s} "
+                    f"{total_tokens:>12,d} {'':>8s} {'':>8s}"
+                )
+                if unknown_fraction > 0.10:
+                    print(
+                        f"  [disclosure] Unknown-model fraction: "
+                        f"{unknown_fraction:.1%} of tokens are in the "
+                        f"`unknown` bucket (legacy session-meta or "
+                        f"pre-Slice-B JSONL rows). Run "
+                        f"`usage import --force` to rescan."
+                    )
+                # Cross-check: tokens covered vs tokens in store.
+                if total_tokens != summary.total_tokens:
+                    delta = summary.total_tokens - total_tokens
+                    print(
+                        f"  [parity] by-model total ({total_tokens:,}) "
+                        f"differs from summary total "
+                        f"({summary.total_tokens:,}) by {delta:+,}. "
+                        f"See `usage reconcile`."
+                    )
+        return 0
+
+    elif action == "by-effort":
+        from bid_euchre.ops.token_economy import effort_summary
+
+        out_dir = getattr(args, "output_dir", None)
+        buckets = effort_summary(output_dir=out_dir)
+        total_tokens = sum(b.total_tokens for b in buckets)
+
+        if args.json:
+            from dataclasses import asdict
+
+            payload = {
+                "buckets": [asdict(b) for b in buckets],
+                "total_tokens": total_tokens,
+            }
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            if not buckets:
+                print(
+                    "No token economy data. "
+                    "Run: ops.py usage import && ops.py usage attribute"
+                )
+            else:
+                print("Per-Effort Token Usage (Slice B)")
+                print("=" * 70)
+                print(
+                    f"  {'Effort':<20s} {'Sessions':>8s} {'Tokens':>12s} "
+                    f"{'% total':>8s} {'Commits':>8s}"
+                )
+                print("-" * 70)
+                for b in buckets:
+                    pct = (
+                        (b.total_tokens / total_tokens * 100.0)
+                        if total_tokens > 0
+                        else 0.0
+                    )
+                    commits = f"{b.git_commits:d}" if b.git_commits is not None else "—"
+                    print(
+                        f"  {b.effort:<20s} {b.session_count:>8d} "
+                        f"{b.total_tokens:>12,d} {pct:>7.1f}% {commits:>8s}"
+                    )
+                print("-" * 70)
+                print(
+                    f"  {'— total —':<20s} {'':>8s} "
+                    f"{total_tokens:>12,d} {'':>8s} {'':>8s}"
+                )
+                # At Slice B baseline, every row is `unknown` — disclose the
+                # dimension status so operators don't mistake that for drift.
+                if len(buckets) == 1 and buckets[0].effort == "unknown":
+                    print(
+                        "  [disclosure] No sessions carry a declared effort "
+                        "signal yet (Slice B baseline). The effort dimension "
+                        "becomes populated once TaskPacket effort_hint → "
+                        "session effort wiring lands (Slices D/E)."
+                    )
+        return 0
+
+    elif action == "by-model-outcome":
+        from bid_euchre.ops.token_economy import model_outcome_summary
+
+        out_dir = getattr(args, "output_dir", None)
+        events_dir = getattr(args, "events_dir", None)
+        rows = model_outcome_summary(
+            output_dir=out_dir,
+            events_dir=events_dir,
+        )
+
+        if args.json:
+            from dataclasses import asdict
+
+            # Stable schema: wrap in an object so future fields (e.g., a
+            # store-level disclosure footer) can be added without breaking
+            # consumers that parse the rows array.
+            payload = {
+                "rows": [asdict(r) for r in rows],
+                "caveat": (
+                    "Directional, not inferential: lane-day granularity "
+                    "means outcome counts are attributed to all models "
+                    "present on the same (lane, day) in proportion to "
+                    "session share. See Slice B §2.5."
+                ),
+            }
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            if not rows:
+                print(
+                    "No model × outcome data. Ensure both session_usage and "
+                    "events are populated."
+                )
+            else:
+                print("Per-Model Work Outcomes (Slice B — directional)")
+                print("=" * 90)
+                print(
+                    f"  {'Model':<32s} {'LaneDays':>8s} {'Sessions':>8s} "
+                    f"{'Tokens':>12s} {'Tasks':>6s} {'Shipped':>7s} "
+                    f"{'Churned':>7s}"
+                )
+                print("-" * 90)
+                for r in rows:
+                    print(
+                        f"  {r.model:<32s} {r.lane_days:>8d} "
+                        f"{r.session_count:>8d} {r.total_tokens:>12,d} "
+                        f"{r.task_completed_count:>6d} "
+                        f"{r.shipped_count:>7d} {r.churned_count:>7d}"
+                    )
+                print("-" * 90)
+                print(
+                    "  [caveat] Directional, not inferential. Lane-day "
+                    "granularity means outcome counts are attributed to "
+                    "every model present on that (lane, day) in proportion "
+                    "to session share. Do not cite these numbers as "
+                    "per-packet causation. See Slice B §2.5."
+                )
         return 0
 
     else:
         print(
             "Usage: ops.py usage {import|attribute|summary|lanes|throughput|"
-            "anti-patterns|status|reconcile}",
+            "anti-patterns|status|reconcile|by-model|by-effort|"
+            "by-model-outcome}",
             file=sys.stderr,
         )
         return 1
@@ -5017,6 +5233,52 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Token economy store directory (default: .claude/runtime/token_economy/)",
+    )
+
+    # Slice B (issue #2169): lane × model × effort rollups.
+    # All three subcommands below are additive — existing subcommands keep
+    # their current output shape (byte-for-byte) so the Slice A reconcile
+    # parity gate continues to pass.
+    usage_by_model_parser = usage_sub.add_parser(
+        "by-model",
+        help="Aggregate sessions by observed model (Slice B)",
+    )
+    usage_by_model_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Token economy store directory (default: .claude/runtime/token_economy/)",
+    )
+
+    usage_by_effort_parser = usage_sub.add_parser(
+        "by-effort",
+        help="Aggregate sessions by declared effort dimension (Slice B)",
+    )
+    usage_by_effort_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Token economy store directory (default: .claude/runtime/token_economy/)",
+    )
+
+    usage_by_model_outcome_parser = usage_sub.add_parser(
+        "by-model-outcome",
+        help=(
+            "Model × work-outcome rollup at lane-day granularity "
+            "(directional, not inferential — see Slice B §2.5)"
+        ),
+    )
+    usage_by_model_outcome_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Token economy store directory (default: .claude/runtime/token_economy/)",
+    )
+    usage_by_model_outcome_parser.add_argument(
+        "--events-dir",
+        type=Path,
+        default=None,
+        help="Event log directory (default: .claude/runtime/events/)",
     )
 
     # away (Platform-9b: operator away-mode detection and queue reorder)

--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -563,6 +563,79 @@ def _format_lane_line(
     )
 
 
+def _format_dashboard_by_model(by_model: dict[str, Any] | None) -> list[str]:
+    """Render the token-economy ``By model`` sub-section.
+
+    Slice B (#2169) rules:
+
+    1. Suppress the panel entirely when no non-``unknown`` bucket exists
+       — a store that contains only legacy session-meta / pre-Slice-B
+       JSONL rows would otherwise render as "unknown 100%" which is
+       noise, not signal.
+    2. Render at most four non-``unknown`` buckets. Any remaining
+       non-``unknown`` buckets are folded into a single ``other`` row so
+       the section stays bounded as the model zoo grows (haiku,
+       synthetic-classifier-N, …).
+    3. The ``unknown`` bucket is always shown when it exists and carries
+       tokens — the operator must be able to see how much of the fleet
+       cannot yet be attributed.
+    """
+    if not isinstance(by_model, dict):
+        return []
+    buckets = by_model.get("buckets") or []
+    if not buckets:
+        return []
+    non_unknown = [b for b in buckets if b.get("model") != "unknown"]
+    if not non_unknown:
+        return []
+
+    total_tokens = by_model.get("total_tokens") or 0
+    # Sort non-unknown by total_tokens descending (model_summary already
+    # sorts; we re-sort defensively in case the CLI or JSON consumer
+    # reordered the list).
+    non_unknown = sorted(
+        non_unknown, key=lambda b: b.get("total_tokens") or 0, reverse=True
+    )
+
+    visible = non_unknown[:4]
+    tail = non_unknown[4:]
+
+    def fmt_row(label: str, tokens: int, commits: int | None) -> str:
+        pct = (tokens / total_tokens * 100) if total_tokens > 0 else 0.0
+        commits_str = f"{commits:>3d} commits" if commits else "—"
+        return (
+            f"    {label:<18s} {tokens / 1_000_000:>5.1f}M tok "
+            f"({pct:>4.1f}%)  {commits_str}"
+        )
+
+    out: list[str] = ["  By model:"]
+    for b in visible:
+        out.append(
+            fmt_row(
+                b.get("model", "?"),
+                int(b.get("total_tokens") or 0),
+                b.get("git_commits"),
+            )
+        )
+    if tail:
+        tail_tokens = sum(int(b.get("total_tokens") or 0) for b in tail)
+        tail_commits = sum(int(b.get("git_commits") or 0) for b in tail)
+        out.append(
+            fmt_row("other", tail_tokens, tail_commits if tail_commits > 0 else None)
+        )
+    # Unknown always last, as a disclosure row.
+    unknown_bucket = next((b for b in buckets if b.get("model") == "unknown"), None)
+    if unknown_bucket and int(unknown_bucket.get("total_tokens") or 0) > 0:
+        out.append(
+            fmt_row(
+                "unknown",
+                int(unknown_bucket.get("total_tokens") or 0),
+                unknown_bucket.get("git_commits"),
+            )
+        )
+    return out
+
+
 def format_dashboard_text(
     view: DashboardView,
     *,
@@ -685,6 +758,14 @@ def format_dashboard_text(
                     f"    {tl['lane_id']:<18s} {tl['total_tokens']:>10,d} tok"
                     f"  {tpc_str}"
                 )
+
+        # Slice B (v3): by-model sub-section. Suppressed on stores that
+        # contain only session-meta / pre-Slice-B JSONL rows (every
+        # bucket would be ``unknown`` and mislead the operator).
+        by_model = te.get("by_model", {})
+        by_model_lines = _format_dashboard_by_model(by_model)
+        if by_model_lines:
+            lines.extend(by_model_lines)
 
         anti_patterns = te.get("anti_patterns", [])
         if anti_patterns:

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -38,6 +38,7 @@ dashboard_token_economy
 
 from __future__ import annotations
 
+import collections
 import hashlib
 import json
 import logging
@@ -52,8 +53,22 @@ logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Schema version — bump when normalized record format changes
+#
+# History:
+#   v1 — legacy session-meta only.
+#   v2 — added project-jsonl scanner (#1770).
+#   v3 — added per-session observed model + effort dimensions for token
+#        economy Slice B (#2169). Readers tolerate v2 rows via ``.get(...)``
+#        semantics; new fields default to ``None`` / ``{}`` / ``0``.
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
+
+#: Canonical "unknown" bucket label used by Slice B model/effort rollups.
+#:
+#: The null-safety contract (§3.5 of the Slice B shaping plan) makes this a
+#: first-class bucket value, not a placeholder. Legacy session-meta rows and
+#: v2 JSONL rows (no ``model`` field) both surface under this label.
+UNKNOWN_BUCKET = "unknown"
 
 # Default source directories
 DEFAULT_USAGE_DIR = Path.home() / ".claude" / "usage-data"
@@ -144,6 +159,29 @@ class SessionRecord:
     friction_detail: str | None = None
     primary_success: str | None = None
     user_satisfaction_counts: dict[str, int] = field(default_factory=dict)
+
+    # Slice B (v3): per-session observed model + effort (null-safe).
+    #
+    # ``model`` is the majority-by-output-tokens model observed in the
+    # session's assistant messages; ``model_mix`` is populated only when
+    # more than one distinct model contributed to the session and maps
+    # model → output tokens attributed to it. Session-meta rows (legacy
+    # import path) leave both fields at their defaults because the source
+    # format predates per-message model capture.
+    #
+    # ``effort`` is reserved for Slice D/E — at Slice B baseline it
+    # remains ``None`` on every row and surfaces as the ``"unknown"``
+    # bucket in rollups.
+    #
+    # Cache-token fields were tracked in ``_JNLSessionAgg`` pre-Slice-B
+    # but discarded when building records. Persisting them now so
+    # ``ModelBucket`` / ``EffortBucket`` can expose cache breakdown
+    # without a second rescan.
+    model: str | None = None
+    model_mix: dict[str, int] = field(default_factory=dict)
+    effort: str | None = None
+    cache_creation_tokens: int | None = None
+    cache_read_tokens: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +387,11 @@ class _JNLSessionAgg:
     git_branch: str = ""
     git_commits: int = 0
     git_pushes: int = 0
+    # Slice B (v3): per-message model counter, keyed by model string
+    # (e.g. ``"claude-opus-4-7"``, ``"claude-sonnet-4-6"``, ``"synthetic"``).
+    # Values are the output tokens attributed to that model so the
+    # session-level ``model`` can be picked as majority-by-output-tokens.
+    models: collections.Counter[str] = field(default_factory=collections.Counter)
 
 
 def _scan_jsonl_file(path: Path) -> _JNLSessionAgg | None:
@@ -417,16 +460,29 @@ def _scan_jsonl_file(path: Path) -> _JNLSessionAgg | None:
                     msg = obj.get("message")
                     if isinstance(msg, dict):
                         usage = msg.get("usage")
+                        msg_output_tokens = 0
                         if isinstance(usage, dict):
                             has_usage = True
                             agg.input_tokens += _safe_int(usage.get("input_tokens"))
-                            agg.output_tokens += _safe_int(usage.get("output_tokens"))
+                            msg_output_tokens = _safe_int(usage.get("output_tokens"))
+                            agg.output_tokens += msg_output_tokens
                             agg.cache_creation_tokens += _safe_int(
                                 usage.get("cache_creation_input_tokens")
                             )
                             agg.cache_read_tokens += _safe_int(
                                 usage.get("cache_read_input_tokens")
                             )
+
+                        # Slice B (v3): capture the model actually used
+                        # for this assistant message. Attributed by output
+                        # tokens so the session-level ``model`` is the
+                        # majority-of-spend model, not just the first one
+                        # seen. When ``usage`` is absent we still record
+                        # the model with a zero-token vote so single-turn
+                        # sessions without usage never lose their model.
+                        model_name = msg.get("model")
+                        if isinstance(model_name, str) and model_name:
+                            agg.models[model_name] += msg_output_tokens
 
                         # Count git commits/pushes from Bash tool_use blocks
                         content = msg.get("content")
@@ -489,6 +545,23 @@ def _build_record_from_jsonl(
     """Build a SessionRecord from aggregated JSONL data."""
     duration = _compute_duration_minutes(agg.first_timestamp, agg.last_timestamp)
 
+    # Slice B (v3): resolve session-level model as majority-by-output-tokens.
+    #
+    # ``model_mix`` is stored only when >1 distinct model contributed — this
+    # keeps the common single-model case cheap on disk and lets analysts
+    # detect mixed-model sessions just by checking whether the field is
+    # non-empty.
+    model: str | None = None
+    model_mix: dict[str, int] = {}
+    if agg.models:
+        if len(agg.models) == 1:
+            (model,) = agg.models.keys()
+        else:
+            # most_common() breaks ties by first-insertion order, which is
+            # stable for our Counter since we increment once per message.
+            model = agg.models.most_common(1)[0][0]
+            model_mix = dict(agg.models)
+
     rec = SessionRecord(
         session_id=agg.session_id,
         source_path=str(source_path),
@@ -504,6 +577,16 @@ def _build_record_from_jsonl(
         output_tokens=agg.output_tokens,
         git_commits=agg.git_commits if agg.git_commits > 0 else None,
         git_pushes=agg.git_pushes if agg.git_pushes > 0 else None,
+        model=model,
+        model_mix=model_mix,
+        # effort stays None at Slice B baseline — D/E populate it.
+        effort=None,
+        cache_creation_tokens=(
+            agg.cache_creation_tokens if agg.cache_creation_tokens > 0 else None
+        ),
+        cache_read_tokens=(
+            agg.cache_read_tokens if agg.cache_read_tokens > 0 else None
+        ),
     )
 
     # Store lane_id in project_path if we inferred it from slug but
@@ -1522,6 +1605,461 @@ def lane_summary(*, output_dir: Path | None = None) -> list[LaneStats]:
     return sorted(by_lane.values(), key=lambda x: x.total_tokens, reverse=True)
 
 
+# ---------------------------------------------------------------------------
+# Slice B (issue #2169): lane × model × effort rollups
+#
+# These are additive to the existing lane/throughput surfaces. All five
+# summary functions are on-demand — they read the existing store files and
+# do not persist anything new. The null-safety contract (§3.5 of the
+# shaping plan) is enforced by the ``UNKNOWN_BUCKET`` constant: no
+# ``None`` model ever collapses into a default model; it surfaces as its
+# own bucket row so operators can see exactly how much of the store
+# cannot yet be attributed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModelBucket:
+    """Session + token totals grouped by observed model.
+
+    ``git_commits`` is ``None`` when every contributing session had zero
+    commits (e.g. all control-plane / read-only sessions) so downstream
+    renderers can draw an em-dash rather than a misleading ``0``.
+    """
+
+    model: str
+    session_count: int = 0
+    total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    git_commits: int | None = None
+
+
+@dataclass
+class EffortBucket:
+    """Session + token totals grouped by declared effort dimension."""
+
+    effort: str
+    session_count: int = 0
+    total_tokens: int = 0
+    git_commits: int | None = None
+
+
+@dataclass
+class LaneModelRow:
+    """Per-(lane, model) cross-tab row for `usage lanes --by model`."""
+
+    lane_id: str
+    model: str
+    session_count: int = 0
+    total_tokens: int = 0
+    git_commits: int | None = None
+
+
+@dataclass
+class LaneEffortRow:
+    """Per-(lane, effort) cross-tab row for `usage lanes --by effort`."""
+
+    lane_id: str
+    effort: str
+    session_count: int = 0
+    total_tokens: int = 0
+    git_commits: int | None = None
+
+
+@dataclass
+class ModelOutcomeRow:
+    """Directional (lane, day)-granularity join of JSONL model signal
+    with ``task_completed`` event outcomes.
+
+    See §2.5 of the Slice B shaping plan for the directional-not-inferential
+    contract: a lane-day can contain multiple packets and multiple
+    sessions, so per-packet causation cannot be proven at this join
+    granularity.
+    """
+
+    model: str
+    lane_days: int = 0
+    session_count: int = 0
+    total_tokens: int = 0
+    task_completed_count: int = 0
+    shipped_count: int = 0
+    churned_count: int = 0
+
+
+# Outcome disposition conventions (case-insensitive):
+#
+# Shipped-side labels are resolved to ``shipped_count``; abandonment-side
+# labels are resolved to ``churned_count``. Unknown labels increment
+# ``task_completed_count`` only. Keeping this explicit (rather than a
+# global allowlist of "good" labels) lets the report footer disclose
+# which labels it treats as which without the operator having to grep
+# the code.
+_SHIPPED_OUTCOME_LABELS: frozenset[str] = frozenset(
+    {"shipped", "merged", "completed", "success"}
+)
+_CHURNED_OUTCOME_LABELS: frozenset[str] = frozenset(
+    {"abandoned", "reverted", "rolled_back", "failed", "blocked"}
+)
+
+
+def _classify_outcome(shipped_outcome: str | None) -> str | None:
+    """Map a ``shipped_outcome`` event field to ``"shipped"`` / ``"churned"`` / ``None``."""
+    if not shipped_outcome:
+        return None
+    label = shipped_outcome.strip().lower()
+    if not label:
+        return None
+    if label in _SHIPPED_OUTCOME_LABELS:
+        return "shipped"
+    if label in _CHURNED_OUTCOME_LABELS:
+        return "churned"
+    return None
+
+
+def _session_model_label(rec: dict[str, Any]) -> str:
+    """Return the model bucket label for a session record.
+
+    Legacy v2 session-meta rows and pre-Slice-B v2 JSONL rows have no
+    ``model`` field — both surface as the ``"unknown"`` bucket per the
+    null-safety contract. No coercion to a default model is performed.
+    """
+    model = rec.get("model")
+    if isinstance(model, str) and model.strip():
+        return model
+    return UNKNOWN_BUCKET
+
+
+def _session_effort_label(rec: dict[str, Any]) -> str:
+    """Return the effort bucket label for a session record.
+
+    At Slice B baseline every row surfaces as ``"unknown"``. Slices D/E
+    populate the field through the hint → effort promotion pathway.
+    """
+    effort = rec.get("effort")
+    if isinstance(effort, str) and effort.strip():
+        return effort
+    return UNKNOWN_BUCKET
+
+
+def _session_day(rec: dict[str, Any]) -> str | None:
+    """Extract the UTC day (YYYY-MM-DD) from a session's start_time."""
+    start = rec.get("start_time")
+    if not isinstance(start, str) or not start:
+        return None
+    # Tolerate trailing Z and sub-second precision.
+    try:
+        dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.astimezone(timezone.utc).date().isoformat()
+
+
+def _event_day(ts: str | None) -> str | None:
+    """Extract the UTC day (YYYY-MM-DD) from an event timestamp."""
+    if not isinstance(ts, str) or not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.astimezone(timezone.utc).date().isoformat()
+
+
+def _finalize_git_commits(bucket: ModelBucket | EffortBucket) -> None:
+    """Collapse zero-commit buckets to ``None``.
+
+    A ``git_commits`` of ``None`` tells renderers "draw an em-dash" rather
+    than "the bucket really contributed zero commits". We only emit ``None``
+    when every contributing session was a non-committing session (control
+    plane, read-only, session-meta legacy rows without commit capture).
+    """
+    if bucket.git_commits == 0:
+        bucket.git_commits = None
+
+
+def model_summary(*, output_dir: Path | None = None) -> list[ModelBucket]:
+    """Aggregate sessions grouped by observed model.
+
+    Mirrors :func:`lane_summary` in shape: returns a list sorted by
+    ``total_tokens`` descending, with a single ``unknown`` bucket for
+    sessions that never carried a model signal (legacy session-meta,
+    pre-Slice-B JSONL rows).
+
+    Parameters
+    ----------
+    output_dir
+        Path to the token economy store. Defaults to the repo runtime path.
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    sessions = _load_sessions(resolved_output)
+    if not sessions:
+        return []
+
+    by_model: dict[str, ModelBucket] = {}
+    for rec in sessions:
+        label = _session_model_label(rec)
+
+        # When model_mix is present, split input/output tokens across the
+        # contributing models by their output-token share. This matches
+        # the shaping plan §3.1 intent that mixed-model sessions still
+        # split correctly across buckets while counting the session once
+        # under its majority bucket.
+        mix = rec.get("model_mix") or {}
+        if isinstance(mix, dict) and len(mix) > 1 and label != UNKNOWN_BUCKET:
+            total_mix_out = sum(int(v) for v in mix.values() if isinstance(v, int))
+            for sub_model, sub_out in mix.items():
+                if not isinstance(sub_model, str) or not isinstance(sub_out, int):
+                    continue
+                bucket = by_model.setdefault(sub_model, ModelBucket(model=sub_model))
+                share = sub_out / total_mix_out if total_mix_out > 0 else 0.0
+                bucket.input_tokens += int((rec.get("input_tokens") or 0) * share)
+                bucket.output_tokens += sub_out
+                bucket.cache_read_tokens += int(
+                    (rec.get("cache_read_tokens") or 0) * share
+                )
+                bucket.cache_creation_tokens += int(
+                    (rec.get("cache_creation_tokens") or 0) * share
+                )
+                # Session count and git_commits land on the majority row
+                # only (below); sub-rows receive token share only to avoid
+                # double-counting sessions.
+            # Majority row gets the session count + commits.
+            majority = by_model.setdefault(label, ModelBucket(model=label))
+            majority.session_count += 1
+            majority.git_commits = (majority.git_commits or 0) + int(
+                rec.get("git_commits") or 0
+            )
+        else:
+            bucket = by_model.setdefault(label, ModelBucket(model=label))
+            bucket.session_count += 1
+            bucket.input_tokens += int(rec.get("input_tokens") or 0)
+            bucket.output_tokens += int(rec.get("output_tokens") or 0)
+            bucket.cache_read_tokens += int(rec.get("cache_read_tokens") or 0)
+            bucket.cache_creation_tokens += int(rec.get("cache_creation_tokens") or 0)
+            bucket.git_commits = (bucket.git_commits or 0) + int(
+                rec.get("git_commits") or 0
+            )
+
+    for bucket in by_model.values():
+        bucket.total_tokens = bucket.input_tokens + bucket.output_tokens
+        _finalize_git_commits(bucket)
+
+    return sorted(by_model.values(), key=lambda b: b.total_tokens, reverse=True)
+
+
+def effort_summary(*, output_dir: Path | None = None) -> list[EffortBucket]:
+    """Aggregate sessions grouped by declared effort dimension.
+
+    At Slice B baseline this returns a single ``unknown`` bucket covering
+    the full store — no JSONL source currently emits a distinct effort
+    signal. Slices D/E populate the dimension through the TaskPacket
+    ``effort_hint`` → session ``effort`` promotion pathway (not scoped
+    here).
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    sessions = _load_sessions(resolved_output)
+    if not sessions:
+        return []
+
+    by_effort: dict[str, EffortBucket] = {}
+    for rec in sessions:
+        label = _session_effort_label(rec)
+        bucket = by_effort.setdefault(label, EffortBucket(effort=label))
+        bucket.session_count += 1
+        bucket.total_tokens += int(rec.get("input_tokens") or 0) + int(
+            rec.get("output_tokens") or 0
+        )
+        bucket.git_commits = (bucket.git_commits or 0) + int(
+            rec.get("git_commits") or 0
+        )
+
+    for bucket in by_effort.values():
+        _finalize_git_commits(bucket)
+
+    return sorted(by_effort.values(), key=lambda b: b.total_tokens, reverse=True)
+
+
+def _build_session_index(output_dir: Path) -> dict[str, dict[str, Any]]:
+    """Load session_usage.jsonl as a session_id → record map."""
+    index: dict[str, dict[str, Any]] = {}
+    for rec in _load_sessions(output_dir):
+        sid = rec.get("session_id")
+        if isinstance(sid, str) and sid:
+            index[sid] = rec
+    return index
+
+
+def lane_model_summary(*, output_dir: Path | None = None) -> list[LaneModelRow]:
+    """Per-(lane, model) cross-tab for the `usage lanes --by model` surface.
+
+    Joins ``session_attributions.jsonl`` (lane_id) with the full session
+    records (model) via ``session_id``. Sessions that cannot be joined
+    (no attribution record) are omitted — they are already surfaced in
+    :func:`reconcile_totals` as an ``attribution_gap``.
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    attributions = _load_attributions(resolved_output)
+    if not attributions:
+        return []
+
+    session_index = _build_session_index(resolved_output)
+
+    rows: dict[tuple[str, str], LaneModelRow] = {}
+    for attr in attributions:
+        lane_id = attr.get("lane_id") or "unattributed"
+        sid = attr.get("session_id")
+        rec = session_index.get(sid) if isinstance(sid, str) else None
+        model = _session_model_label(rec) if rec else UNKNOWN_BUCKET
+
+        key = (lane_id, model)
+        row = rows.setdefault(key, LaneModelRow(lane_id=lane_id, model=model))
+        row.session_count += 1
+        row.total_tokens += int(attr.get("input_tokens") or 0) + int(
+            attr.get("output_tokens") or 0
+        )
+        row.git_commits = (row.git_commits or 0) + int(attr.get("git_commits") or 0)
+
+    for row in rows.values():
+        if row.git_commits == 0:
+            row.git_commits = None
+
+    return sorted(rows.values(), key=lambda r: (r.lane_id, -r.total_tokens, r.model))
+
+
+def lane_effort_summary(*, output_dir: Path | None = None) -> list[LaneEffortRow]:
+    """Per-(lane, effort) cross-tab.
+
+    Uses the same attributions-join pattern as :func:`lane_model_summary`.
+    At Slice B baseline every row has ``effort="unknown"``.
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    attributions = _load_attributions(resolved_output)
+    if not attributions:
+        return []
+
+    session_index = _build_session_index(resolved_output)
+
+    rows: dict[tuple[str, str], LaneEffortRow] = {}
+    for attr in attributions:
+        lane_id = attr.get("lane_id") or "unattributed"
+        sid = attr.get("session_id")
+        rec = session_index.get(sid) if isinstance(sid, str) else None
+        effort = _session_effort_label(rec) if rec else UNKNOWN_BUCKET
+
+        key = (lane_id, effort)
+        row = rows.setdefault(key, LaneEffortRow(lane_id=lane_id, effort=effort))
+        row.session_count += 1
+        row.total_tokens += int(attr.get("input_tokens") or 0) + int(
+            attr.get("output_tokens") or 0
+        )
+        row.git_commits = (row.git_commits or 0) + int(attr.get("git_commits") or 0)
+
+    for row in rows.values():
+        if row.git_commits == 0:
+            row.git_commits = None
+
+    return sorted(rows.values(), key=lambda r: (r.lane_id, -r.total_tokens, r.effort))
+
+
+def model_outcome_summary(
+    *,
+    output_dir: Path | None = None,
+    events_dir: Path | None = None,
+) -> list[ModelOutcomeRow]:
+    """Directional (lane, day) join of observed model with task_completed events.
+
+    See §2.5 of the shaping plan: we cannot prove per-session causation
+    when a lane-day contains multiple packets. The output is labelled
+    "directional" so consumers surface the caveat in reports.
+
+    Missing or unreadable event logs yield rows with zero outcome counts
+    rather than raising — the join degrades to a pure model × token
+    rollup (still useful for trend watching).
+    """
+    resolved_output = _resolve_output_dir(output_dir)
+    sessions = _load_sessions(resolved_output)
+    if not sessions:
+        return []
+
+    attributions = _load_attributions(resolved_output)
+    attr_by_session: dict[str, dict[str, Any]] = {}
+    for attr in attributions:
+        sid = attr.get("session_id")
+        if isinstance(sid, str) and sid:
+            attr_by_session[sid] = attr
+
+    # Bucket sessions by (lane_id, day, model).
+    lane_day_sessions: dict[tuple[str, str], dict[str, dict[str, int]]] = {}
+    for rec in sessions:
+        sid = rec.get("session_id")
+        if not isinstance(sid, str):
+            continue
+        attr = attr_by_session.get(sid)
+        lane_id = (attr.get("lane_id") if attr else None) or "unattributed"
+        day = _session_day(rec)
+        if day is None:
+            continue
+        model = _session_model_label(rec)
+        slot = lane_day_sessions.setdefault((lane_id, day), {})
+        per_model = slot.setdefault(model, {"sessions": 0, "tokens": 0})
+        per_model["sessions"] += 1
+        per_model["tokens"] += int(rec.get("input_tokens") or 0) + int(
+            rec.get("output_tokens") or 0
+        )
+
+    # Read completion events.
+    effective_events_dir = (
+        events_dir if events_dir is not None else Path(".claude/runtime/events")
+    )
+    events = _read_task_completed_events(effective_events_dir)
+
+    # Bucket events by (lane_id, day) → {"count": N, "shipped": S, "churned": C}.
+    lane_day_events: dict[tuple[str, str], dict[str, int]] = {}
+    for event in events:
+        payload = event.get("payload") or {}
+        lane_id = payload.get("actual_lane") or event.get("lane_id") or "unattributed"
+        day = _event_day(event.get("timestamp"))
+        if day is None:
+            continue
+        slot = lane_day_events.setdefault(
+            (lane_id, day), {"count": 0, "shipped": 0, "churned": 0}
+        )
+        slot["count"] += 1
+        disposition = _classify_outcome(payload.get("shipped_outcome"))
+        if disposition == "shipped":
+            slot["shipped"] += 1
+        elif disposition == "churned":
+            slot["churned"] += 1
+
+    # Fold into per-model rows, attributing outcome counts to every model
+    # that appeared on that lane-day in proportion to session share. This
+    # is the directional-not-inferential approximation — the report must
+    # disclose it.
+    by_model: dict[str, ModelOutcomeRow] = {}
+    for lane_day, per_model_map in lane_day_sessions.items():
+        total_sessions = sum(v["sessions"] for v in per_model_map.values())
+        event_slot = lane_day_events.get(lane_day, {})
+        total_count = event_slot.get("count", 0)
+        total_shipped = event_slot.get("shipped", 0)
+        total_churned = event_slot.get("churned", 0)
+
+        for model, stats in per_model_map.items():
+            row = by_model.setdefault(model, ModelOutcomeRow(model=model))
+            row.lane_days += 1
+            row.session_count += stats["sessions"]
+            row.total_tokens += stats["tokens"]
+            if total_sessions > 0 and total_count > 0:
+                share = stats["sessions"] / total_sessions
+                row.task_completed_count += int(round(total_count * share))
+                row.shipped_count += int(round(total_shipped * share))
+                row.churned_count += int(round(total_churned * share))
+
+    return sorted(by_model.values(), key=lambda r: r.total_tokens, reverse=True)
+
+
 @dataclass
 class ThroughputMetrics:
     """Throughput-normalized token metrics."""
@@ -1996,6 +2534,11 @@ class TotalsReconciliation:
     attribution_gap: int = 0
     token_parity_delta: int = 0
     commit_parity_delta: int = 0
+    # Slice B (v3): parity check between sum-of-by-model and sum-of-lanes.
+    # A non-zero delta here points at a store that was populated by a
+    # pre-Slice-B scanner pass and needs ``usage import --force``.
+    by_model_tokens: int = 0
+    by_model_token_parity_delta: int = 0
     warnings: list[str] = field(default_factory=list)
     ok: bool = True
 
@@ -2039,15 +2582,21 @@ def reconcile_totals(*, output_dir: Path | None = None) -> TotalsReconciliation:
     summary = usage_summary(output_dir=resolved_output)
     lanes = lane_summary(output_dir=resolved_output)
     throughput = throughput_summary(output_dir=resolved_output)
+    by_model = model_summary(output_dir=resolved_output)
 
     lanes_sessions_total = sum(ls.session_count for ls in lanes)
     lanes_tokens_total = sum(ls.total_tokens for ls in lanes)
     lanes_commits_total = sum(ls.git_commits for ls in lanes)
+    by_model_tokens_total = sum(b.total_tokens for b in by_model)
 
     incomplete = max(summary.session_count - throughput.total_sessions, 0)
     attr_gap = summary.session_count - lanes_sessions_total
     token_delta = summary.total_tokens - lanes_tokens_total
     commit_delta = summary.total_git_commits - lanes_commits_total
+    # Model-parity delta compares against summary totals (the whole store)
+    # rather than lanes totals, because model_summary reads session_usage
+    # directly — so the right reference is usage_summary.
+    by_model_delta = summary.total_tokens - by_model_tokens_total
 
     tolerance = _parity_tolerance(summary.total_tokens)
 
@@ -2085,6 +2634,21 @@ def reconcile_totals(*, output_dir: Path | None = None) -> TotalsReconciliation:
             f"sum-of-`usage lanes` ({lanes_commits_total})."
         )
 
+    # Slice B (v3): by-model parity.  model_summary reads session_usage
+    # directly so the expected reference is ``summary.total_tokens``.
+    # Drift here usually means the store was populated by a pre-Slice-B
+    # scanner pass (no ``model`` field) and we fell back to the
+    # ``unknown`` bucket — the fix is a force re-import.
+    if abs(by_model_delta) > tolerance and by_model_tokens_total > 0:
+        warnings.append(
+            f"Model parity delta {by_model_delta:+,} tokens between "
+            f"`usage summary` ({summary.total_tokens:,}) and "
+            f"sum-of-`usage by-model` ({by_model_tokens_total:,}); "
+            f"tolerance ±{tolerance:,}. "
+            f"Hint: run `usage import --force` to rescan JSONL with the "
+            f"model-aware scanner."
+        )
+
     return TotalsReconciliation(
         summary_sessions=summary.session_count,
         summary_tokens=summary.total_tokens,
@@ -2099,6 +2663,8 @@ def reconcile_totals(*, output_dir: Path | None = None) -> TotalsReconciliation:
         attribution_gap=attr_gap,
         token_parity_delta=token_delta,
         commit_parity_delta=commit_delta,
+        by_model_tokens=by_model_tokens_total,
+        by_model_token_parity_delta=by_model_delta,
         warnings=warnings,
         ok=not warnings,
     )
@@ -2306,6 +2872,50 @@ def dashboard_token_economy(
         for f in findings
     ]
 
+    # Slice B (v3): by-model + by-effort roll-ups.  Both are always
+    # included in the JSON surface so scripting consumers get the raw
+    # data even when the text dashboard suppresses the panel (see
+    # format_dashboard_text rendering rules).
+    model_buckets = model_summary(output_dir=resolved_output)
+    model_total = sum(b.total_tokens for b in model_buckets)
+    unknown_tokens = next(
+        (b.total_tokens for b in model_buckets if b.model == UNKNOWN_BUCKET), 0
+    )
+    by_model = {
+        "buckets": [
+            {
+                "model": b.model,
+                "session_count": b.session_count,
+                "total_tokens": b.total_tokens,
+                "input_tokens": b.input_tokens,
+                "output_tokens": b.output_tokens,
+                "cache_read_tokens": b.cache_read_tokens,
+                "cache_creation_tokens": b.cache_creation_tokens,
+                "git_commits": b.git_commits,
+            }
+            for b in model_buckets
+        ],
+        "total_tokens": model_total,
+        "unknown_fraction": (
+            (unknown_tokens / model_total) if model_total > 0 else 0.0
+        ),
+    }
+
+    effort_buckets = effort_summary(output_dir=resolved_output)
+    effort_total = sum(b.total_tokens for b in effort_buckets)
+    by_effort = {
+        "buckets": [
+            {
+                "effort": b.effort,
+                "session_count": b.session_count,
+                "total_tokens": b.total_tokens,
+                "git_commits": b.git_commits,
+            }
+            for b in effort_buckets
+        ],
+        "total_tokens": effort_total,
+    }
+
     return {
         "overview": overview,
         "top_lanes": top_lanes,
@@ -2313,6 +2923,8 @@ def dashboard_token_economy(
         "throughput": throughput,
         "anti_patterns": anti_patterns,
         "store_status": status_dict,
+        "by_model": by_model,
+        "by_effort": by_effort,
     }
 
 

--- a/src/bid_euchre/ops/token_economy.py
+++ b/src/bid_euchre/ops/token_economy.py
@@ -160,23 +160,11 @@ class SessionRecord:
     primary_success: str | None = None
     user_satisfaction_counts: dict[str, int] = field(default_factory=dict)
 
-    # Slice B (v3): per-session observed model + effort (null-safe).
-    #
-    # ``model`` is the majority-by-output-tokens model observed in the
-    # session's assistant messages; ``model_mix`` is populated only when
-    # more than one distinct model contributed to the session and maps
-    # model → output tokens attributed to it. Session-meta rows (legacy
-    # import path) leave both fields at their defaults because the source
-    # format predates per-message model capture.
-    #
-    # ``effort`` is reserved for Slice D/E — at Slice B baseline it
-    # remains ``None`` on every row and surfaces as the ``"unknown"``
-    # bucket in rollups.
-    #
-    # Cache-token fields were tracked in ``_JNLSessionAgg`` pre-Slice-B
-    # but discarded when building records. Persisting them now so
-    # ``ModelBucket`` / ``EffortBucket`` can expose cache breakdown
-    # without a second rescan.
+    # Slice B (v3, null-safe): majority-by-output-tokens model, mix map
+    # (populated only when >1 model observed), effort reserved for
+    # Slice D/E (baseline=None → "unknown" bucket), and cache-token
+    # breakdown carried alongside input/output totals. See module-level
+    # shaping plan at plans/sessions/2026-04-20_token_economy_slice_b.md.
     model: str | None = None
     model_mix: dict[str, int] = field(default_factory=dict)
     effort: str | None = None
@@ -1606,15 +1594,9 @@ def lane_summary(*, output_dir: Path | None = None) -> list[LaneStats]:
 
 
 # ---------------------------------------------------------------------------
-# Slice B (issue #2169): lane × model × effort rollups
-#
-# These are additive to the existing lane/throughput surfaces. All five
-# summary functions are on-demand — they read the existing store files and
-# do not persist anything new. The null-safety contract (§3.5 of the
-# shaping plan) is enforced by the ``UNKNOWN_BUCKET`` constant: no
-# ``None`` model ever collapses into a default model; it surfaces as its
-# own bucket row so operators can see exactly how much of the store
-# cannot yet be attributed.
+# Slice B (issue #2169): additive lane × model × effort rollups. On-demand
+# readers — no new persisted state. Null-safety (§3.5) is enforced by
+# UNKNOWN_BUCKET: None never coerces to a default, it surfaces its own row.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -5720,3 +5720,131 @@ class TestServiceProviderWiring:
         assert d["monitor"] == "MonitorService"
         assert d["task_queue"] == "TaskQueueService"
         assert d["worker_pool"] == "WorkerPoolService"
+
+
+# ---------------------------------------------------------------------------
+# Slice B (issue #2169) — CLI / rollup consistency gate
+# ---------------------------------------------------------------------------
+
+
+class TestUsageByModelCliMatchesLibrary:
+    """Schema-consistency gate between ``usage by-model --json`` and the
+    :func:`model_summary` library surface.
+
+    If the CLI serialization ever drifts from the dataclass contract
+    (renamed field, shape change, sort-order drift), this test flags it
+    so operators' dashboards and the reconcile-parity check cannot
+    silently disagree.
+    """
+
+    def test_by_model_cli_matches_library(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from dataclasses import asdict
+
+        import ops
+
+        from bid_euchre.ops.token_economy import model_summary
+
+        # Write a tiny two-session store.
+        store = tmp_path / "store"
+        store.mkdir()
+        usage = store / "session_usage.jsonl"
+        rows = [
+            {
+                "session_id": "s1",
+                "schema_version": 3,
+                "source_type": "project-jsonl",
+                "input_tokens": 100,
+                "output_tokens": 500,
+                "model": "claude-opus-4-7",
+                "git_commits": 1,
+                "imported_at": "2026-04-20T10:00:00Z",
+                "duration_minutes": 30,
+                "start_time": "2026-04-20T10:00:00Z",
+            },
+            {
+                "session_id": "s2",
+                "schema_version": 3,
+                "source_type": "project-jsonl",
+                "input_tokens": 50,
+                "output_tokens": 200,
+                "model": "synthetic",
+                "git_commits": 0,
+                "imported_at": "2026-04-20T11:00:00Z",
+                "duration_minutes": 15,
+                "start_time": "2026-04-20T11:00:00Z",
+            },
+        ]
+        with usage.open("w", encoding="utf-8") as fh:
+            for r in rows:
+                fh.write(json.dumps(r) + "\n")
+
+        # Direct library call.
+        buckets = model_summary(output_dir=store)
+        lib_payload = [asdict(b) for b in buckets]
+
+        # CLI call — reuse the same ops module; JSON to stdout.
+        # --json is a global flag (must precede the subcommand).
+        rc = ops.main(
+            [
+                "--json",
+                "usage",
+                "by-model",
+                "--output-dir",
+                str(store),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == 0, captured.err
+        cli_payload = json.loads(captured.out)
+
+        # CLI wraps buckets in an object with totals; verify both.
+        assert cli_payload["buckets"] == lib_payload
+        assert cli_payload["total_tokens"] == sum(
+            b["total_tokens"] for b in lib_payload
+        )
+
+    def test_by_effort_cli_smokes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`usage by-effort --json` returns a stable object with buckets + total."""
+        import ops
+
+        store = tmp_path / "store"
+        store.mkdir()
+        usage = store / "session_usage.jsonl"
+        usage.write_text(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "schema_version": 3,
+                    "source_type": "project-jsonl",
+                    "input_tokens": 100,
+                    "output_tokens": 500,
+                    "git_commits": 1,
+                    "imported_at": "2026-04-20T10:00:00Z",
+                    "duration_minutes": 30,
+                    "start_time": "2026-04-20T10:00:00Z",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        rc = ops.main(
+            [
+                "--json",
+                "usage",
+                "by-effort",
+                "--output-dir",
+                str(store),
+            ]
+        )
+        captured = capsys.readouterr()
+        assert rc == 0, captured.err
+        payload = json.loads(captured.out)
+        assert "buckets" in payload
+        assert "total_tokens" in payload
+        # Slice B baseline: every session buckets under 'unknown'.
+        assert payload["buckets"][0]["effort"] == "unknown"

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -1149,3 +1149,147 @@ class TestDashboardWatchFlag:
             assert "summary" in data
         # "Watch stopped." should go to stderr, not stdout
         assert "Watch stopped." not in output
+
+
+# ---------------------------------------------------------------------------
+# Slice B (issue #2169) — by_model panel rendering
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardByModelPanel:
+    """Verify the Slice B ``By model`` sub-section of the dashboard."""
+
+    @staticmethod
+    def _view_with_by_model(by_model: dict) -> DashboardView:
+        now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        return DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            token_economy={
+                "overview": {
+                    "total_tokens": by_model.get("total_tokens", 0),
+                    "session_count": 1,
+                    "total_git_commits": 1,
+                    "tokens_per_hour": 0,
+                    "output_input_ratio": 2.0,
+                    "net_lines": 0,
+                },
+                "top_lanes": [],
+                "by_model": by_model,
+            },
+        )
+
+    def test_dashboard_by_model_rendered_when_non_unknown_present(
+        self,
+    ) -> None:
+        view = self._view_with_by_model(
+            {
+                "buckets": [
+                    {
+                        "model": "claude-opus-4-7",
+                        "total_tokens": 2_000_000,
+                        "session_count": 20,
+                        "git_commits": 10,
+                    },
+                    {
+                        "model": "unknown",
+                        "total_tokens": 500_000,
+                        "session_count": 5,
+                        "git_commits": 0,
+                    },
+                ],
+                "total_tokens": 2_500_000,
+                "unknown_fraction": 0.2,
+            }
+        )
+        now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        text = format_dashboard_text(view, now=now)
+        assert "By model:" in text
+        assert "claude-opus-4-7" in text
+        # Unknown is disclosed as a row when it carries tokens.
+        assert "unknown" in text
+
+    def test_dashboard_by_model_suppressed_when_only_unknown(self) -> None:
+        """Store with only legacy rows → panel is entirely suppressed.
+
+        Renders no "By model:" header so the dashboard stays signal.
+        """
+        view = self._view_with_by_model(
+            {
+                "buckets": [
+                    {
+                        "model": "unknown",
+                        "total_tokens": 1_000_000,
+                        "session_count": 10,
+                        "git_commits": 5,
+                    }
+                ],
+                "total_tokens": 1_000_000,
+                "unknown_fraction": 1.0,
+            }
+        )
+        now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        text = format_dashboard_text(view, now=now)
+        assert "By model:" not in text
+
+    def test_dashboard_by_model_folds_tail_into_other(self) -> None:
+        """>4 non-unknown models collapse the tail into an ``other`` row."""
+        buckets = [
+            {
+                "model": f"model-{i}",
+                "total_tokens": (100 - i) * 100_000,
+                "session_count": 5,
+                "git_commits": 1,
+            }
+            for i in range(6)
+        ]
+        view = self._view_with_by_model(
+            {
+                "buckets": buckets,
+                "total_tokens": sum(b["total_tokens"] for b in buckets),
+                "unknown_fraction": 0.0,
+            }
+        )
+        now = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        text = format_dashboard_text(view, now=now)
+        assert "By model:" in text
+        assert "other" in text
+        # First four rendered verbatim; last two fold into ``other``.
+        assert "model-0" in text
+        assert "model-3" in text
+        # model-4 / model-5 collapsed into the ``other`` fold — they do not
+        # show up as their own rows.
+        # (Sanity check: we can tell by count of explicit model-N label
+        # lines in the text.)
+        explicit_count = sum(1 for i in range(6) if f"model-{i}" in text)
+        # Only the first four are rendered as their own rows.
+        assert explicit_count == 4
+
+    def test_dashboard_json_always_includes_by_model_key(self) -> None:
+        """JSON contract: ``by_model`` key is always present for scripting.
+
+        Whether or not the panel renders in text, the JSON surface must
+        keep a stable shape so downstream consumers can safely key into it.
+        """
+        view = self._view_with_by_model(
+            {
+                "buckets": [
+                    {
+                        "model": "unknown",
+                        "total_tokens": 0,
+                        "session_count": 0,
+                        "git_commits": 0,
+                    }
+                ],
+                "total_tokens": 0,
+                "unknown_fraction": 0.0,
+            }
+        )
+        data = format_dashboard_json(view)
+        # ``format_dashboard_json`` returns a dict; round-trip through
+        # ``json.dumps`` to assert the shape is serializable without loss.
+        round_tripped = json.loads(json.dumps(data))
+        # Token economy section exists and exposes by_model.
+        assert "token_economy" in round_tripped
+        assert "by_model" in round_tripped["token_economy"]

--- a/tests/unit/test_ops_token_economy.py
+++ b/tests/unit/test_ops_token_economy.py
@@ -2036,3 +2036,333 @@ class TestReconcileTotals:
         assert parity.commit_parity_delta == 2
         assert parity.ok is False
         assert any("Commit parity" in w for w in parity.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Slice B (issue #2169) — lane × model × effort rollup tests
+# ---------------------------------------------------------------------------
+
+
+def _make_slice_b_session(
+    session_id: str,
+    *,
+    model: str | None = None,
+    model_mix: dict | None = None,
+    effort: str | None = None,
+    input_tokens: int = 100,
+    output_tokens: int = 500,
+    git_commits: int = 1,
+    start_time: str = "2026-04-20T10:00:00Z",
+    schema_version: int = 3,
+) -> dict:
+    """Build a v3 session record with Slice B fields populated."""
+    rec = _make_session_record(
+        session_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        git_commits=git_commits,
+        start_time=start_time,
+    )
+    rec["schema_version"] = schema_version
+    if model is not None:
+        rec["model"] = model
+    if model_mix is not None:
+        rec["model_mix"] = model_mix
+    if effort is not None:
+        rec["effort"] = effort
+    return rec
+
+
+class TestModelSummary:
+    def test_model_summary_shape(self, output_dir: Path) -> None:
+        """Returns list[ModelBucket]; totals match usage_summary."""
+        from bid_euchre.ops.token_economy import ModelBucket, model_summary
+
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session(
+                    "s1",
+                    model="claude-opus-4-7",
+                    input_tokens=100,
+                    output_tokens=500,
+                ),
+                _make_slice_b_session(
+                    "s2",
+                    model="claude-opus-4-7",
+                    input_tokens=200,
+                    output_tokens=300,
+                ),
+                _make_slice_b_session(
+                    "s3", model="synthetic", input_tokens=50, output_tokens=50
+                ),
+            ],
+        )
+        buckets = model_summary(output_dir=output_dir)
+        assert all(isinstance(b, ModelBucket) for b in buckets)
+        # Sorted by total_tokens descending.
+        labels = [b.model for b in buckets]
+        assert labels == ["claude-opus-4-7", "synthetic"]
+        total = sum(b.total_tokens for b in buckets)
+        summary = usage_summary(output_dir=output_dir)
+        assert total == summary.total_tokens
+
+    def test_model_summary_splits_model_mix_by_output_share(
+        self, output_dir: Path
+    ) -> None:
+        """Mixed-model session splits tokens across buckets proportionally.
+
+        Session count lands on the majority row only (no double-counting).
+        """
+        from bid_euchre.ops.token_economy import model_summary
+
+        _write_sessions(
+            output_dir,
+            [
+                # Single mixed session: 70 opus, 30 synthetic output tokens.
+                _make_slice_b_session(
+                    "mixed-1",
+                    model="claude-opus-4-7",
+                    model_mix={"claude-opus-4-7": 70, "synthetic": 30},
+                    input_tokens=1000,
+                    output_tokens=100,
+                ),
+            ],
+        )
+        buckets = model_summary(output_dir=output_dir)
+        by_label = {b.model: b for b in buckets}
+        assert "claude-opus-4-7" in by_label
+        assert "synthetic" in by_label
+        # Session count on majority row only.
+        assert by_label["claude-opus-4-7"].session_count == 1
+        assert by_label["synthetic"].session_count == 0
+        # Output tokens split in proportion to mix.
+        assert by_label["claude-opus-4-7"].output_tokens == 70
+        assert by_label["synthetic"].output_tokens == 30
+
+
+class TestEffortSummary:
+    def test_effort_summary_all_unknown_at_baseline(self, output_dir: Path) -> None:
+        """With no effort signal, every session buckets as 'unknown'."""
+        from bid_euchre.ops.token_economy import effort_summary
+
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session("s1", model="claude-opus-4-7"),
+                _make_slice_b_session("s2", model="claude-opus-4-7"),
+            ],
+        )
+        buckets = effort_summary(output_dir=output_dir)
+        assert len(buckets) == 1
+        assert buckets[0].effort == "unknown"
+        assert buckets[0].session_count == 2
+
+
+class TestLaneModelSummary:
+    def test_lane_model_summary_respects_attribution(self, output_dir: Path) -> None:
+        """Lane IDs in the cross-tab match lane_summary output."""
+        from bid_euchre.ops.token_economy import (
+            lane_model_summary,
+            lane_summary,
+        )
+
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session(
+                    "s1",
+                    model="claude-opus-4-7",
+                    input_tokens=100,
+                    output_tokens=500,
+                ),
+                _make_slice_b_session(
+                    "s2",
+                    model="synthetic",
+                    input_tokens=50,
+                    output_tokens=100,
+                ),
+            ],
+        )
+        _write_attributions(
+            output_dir,
+            [
+                {
+                    "session_id": "s1",
+                    "lane_id": "author-a",
+                    "worktree_class": "platform",
+                    "input_tokens": 100,
+                    "output_tokens": 500,
+                    "duration_minutes": 30,
+                    "git_commits": 1,
+                    "lines_added": 20,
+                    "lines_removed": 5,
+                },
+                {
+                    "session_id": "s2",
+                    "lane_id": "author-b",
+                    "worktree_class": "platform",
+                    "input_tokens": 50,
+                    "output_tokens": 100,
+                    "duration_minutes": 15,
+                    "git_commits": 1,
+                    "lines_added": 10,
+                    "lines_removed": 0,
+                },
+            ],
+        )
+
+        rows = lane_model_summary(output_dir=output_dir)
+        row_lanes = {r.lane_id for r in rows}
+        summary_lanes = {ls.lane_id for ls in lane_summary(output_dir=output_dir)}
+        assert row_lanes == summary_lanes
+        # One row per (lane, model) pair.
+        assert (("author-a", "claude-opus-4-7")) in {(r.lane_id, r.model) for r in rows}
+        assert (("author-b", "synthetic")) in {(r.lane_id, r.model) for r in rows}
+
+
+class TestModelOutcomeSummary:
+    def test_model_outcome_summary_lane_day_join(self, tmp_path: Path) -> None:
+        """Sessions + task_completed events merge on (lane, day)."""
+        from bid_euchre.ops.token_economy import model_outcome_summary
+
+        output_dir = tmp_path / "store"
+        output_dir.mkdir()
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+
+        # One session on lane author-a, day 2026-04-20, model opus.
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session(
+                    "s1",
+                    model="claude-opus-4-7",
+                    input_tokens=100,
+                    output_tokens=500,
+                    start_time="2026-04-20T10:00:00Z",
+                ),
+            ],
+        )
+        _write_attributions(
+            output_dir,
+            [
+                {
+                    "session_id": "s1",
+                    "lane_id": "author-a",
+                    "worktree_class": "platform",
+                    "input_tokens": 100,
+                    "output_tokens": 500,
+                    "duration_minutes": 30,
+                    "git_commits": 1,
+                    "lines_added": 10,
+                    "lines_removed": 0,
+                },
+            ],
+        )
+
+        # One shipped event on the same (lane, day).
+        event = {
+            "timestamp": "2026-04-20T12:00:00+00:00",
+            "event_type": "task_completed",
+            "source": "ops.test",
+            "lane_id": "author-a",
+            "payload": {
+                "packet_id": "pkt-1",
+                "title": "test",
+                "actual_lane": "author-a",
+                "shipped_outcome": "merged",
+            },
+        }
+        (events_dir / "events.jsonl").write_text(
+            json.dumps(event) + "\n", encoding="utf-8"
+        )
+
+        rows = model_outcome_summary(output_dir=output_dir, events_dir=events_dir)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.model == "claude-opus-4-7"
+        assert row.lane_days == 1
+        assert row.session_count == 1
+        assert row.task_completed_count == 1
+        assert row.shipped_count == 1
+        assert row.churned_count == 0
+
+    def test_model_outcome_summary_missing_events_dir(self, tmp_path: Path) -> None:
+        """Missing events dir returns rows with zero outcome counts."""
+        from bid_euchre.ops.token_economy import model_outcome_summary
+
+        output_dir = tmp_path / "store"
+        output_dir.mkdir()
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session(
+                    "s1",
+                    model="claude-opus-4-7",
+                    start_time="2026-04-20T10:00:00Z",
+                ),
+            ],
+        )
+        _write_attributions(
+            output_dir,
+            [
+                {
+                    "session_id": "s1",
+                    "lane_id": "author-a",
+                    "worktree_class": "platform",
+                    "input_tokens": 100,
+                    "output_tokens": 500,
+                    "duration_minutes": 30,
+                    "git_commits": 1,
+                    "lines_added": 0,
+                    "lines_removed": 0,
+                },
+            ],
+        )
+        # Point events_dir at a non-existent path — should not raise.
+        rows = model_outcome_summary(
+            output_dir=output_dir,
+            events_dir=tmp_path / "does_not_exist",
+        )
+        assert len(rows) == 1
+        assert rows[0].task_completed_count == 0
+        assert rows[0].shipped_count == 0
+
+
+class TestReconcileByModelParity:
+    def test_reconcile_includes_by_model_parity(self, output_dir: Path) -> None:
+        """by_model_tokens is tracked; when all sessions have a model,
+        parity is zero and OK."""
+        _write_sessions(
+            output_dir,
+            [
+                _make_slice_b_session(
+                    "s1",
+                    model="claude-opus-4-7",
+                    input_tokens=100,
+                    output_tokens=500,
+                    git_commits=1,
+                ),
+            ],
+        )
+        _write_attributions(
+            output_dir,
+            [
+                {
+                    "session_id": "s1",
+                    "lane_id": "author-a",
+                    "worktree_class": "platform",
+                    "input_tokens": 100,
+                    "output_tokens": 500,
+                    "duration_minutes": 30,
+                    "git_commits": 1,
+                    "lines_added": 0,
+                    "lines_removed": 0,
+                },
+            ],
+        )
+        parity = reconcile_totals(output_dir=output_dir)
+        assert parity.by_model_tokens == 600
+        # Same-model attribution produces zero parity delta.
+        assert parity.by_model_token_parity_delta == 0

--- a/tests/unit/test_token_economy.py
+++ b/tests/unit/test_token_economy.py
@@ -32,9 +32,16 @@ from bid_euchre.ops.token_economy import (
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_2():
-    """Schema version must be 2 after the JSONL scanner addition."""
-    assert SCHEMA_VERSION == 2
+def test_schema_version_is_3():
+    """Schema version is 3 after the Slice B model/effort/cache fields.
+
+    Version history:
+      v1 — baseline session-meta ingest.
+      v2 — JSONL scanner addition (#1770).
+      v3 — Slice B (issue #2169): model, model_mix, effort,
+           cache_creation_tokens, cache_read_tokens on SessionRecord.
+    """
+    assert SCHEMA_VERSION == 3
 
 
 # ---------------------------------------------------------------------------
@@ -189,9 +196,15 @@ def _make_assistant_msg(
     cache_read: int = 0,
     timestamp: str = "2026-03-25T10:00:00.000Z",
     cwd: str = "/Users/test/Bid-Euchre-steward-author",
+    model: str | None = None,
 ) -> str:
-    """Create a JSONL line for an assistant message with usage data."""
-    obj = {
+    """Create a JSONL line for an assistant message with usage data.
+
+    The ``model`` argument defaults to ``None`` so existing tests see the
+    same output shape (no ``model`` key). Slice B tests pass an explicit
+    model name to exercise the new capture path.
+    """
+    obj: dict = {
         "type": "assistant",
         "sessionId": session_id,
         "timestamp": timestamp,
@@ -209,6 +222,8 @@ def _make_assistant_msg(
             },
         },
     }
+    if model is not None:
+        obj["message"]["model"] = model
     return json.dumps(obj)
 
 
@@ -524,7 +539,7 @@ class TestBuildRecordFromJsonl:
         assert rec.assistant_message_count == 10
         assert rec.duration_minutes == 30
         assert rec.project_path == "/Users/test/Bid-Euchre-steward-author"
-        assert rec.schema_version == 2
+        assert rec.schema_version == 3
 
     def test_missing_cwd_uses_inferred_lane(self, tmp_path: Path):
         agg = _JNLSessionAgg(
@@ -1168,3 +1183,244 @@ class TestJoinOutcomesRecommendedLaneFlow:
         assert len(records) == 1
         assert records[0].recommended_lane is None
         assert records[0].recommendation_match is None
+
+
+# ---------------------------------------------------------------------------
+# Slice B (issue #2169) — model capture + mixed-model handling
+#
+# These tests exercise the scanner's ability to capture the per-message
+# ``model`` string, resolve it to a session-level ``model`` (majority by
+# output tokens), and preserve the raw vote distribution as
+# ``model_mix`` only when more than one distinct model contributed.
+# ---------------------------------------------------------------------------
+
+
+class TestSliceBModelCapture:
+    def test_scan_jsonl_single_model_session(self, tmp_path: Path) -> None:
+        """Single-model session: model captured, model_mix empty."""
+        sid = "sess-sb-01"
+        lines = [
+            _make_assistant_msg(
+                sid,
+                input_tokens=100,
+                output_tokens=50,
+                model="claude-opus-4-7",
+            ),
+            _make_assistant_msg(
+                sid,
+                input_tokens=200,
+                output_tokens=75,
+                model="claude-opus-4-7",
+            ),
+        ]
+        f = tmp_path / f"{sid}.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        # Scanner accumulates votes per model; a single-model session has
+        # exactly one key in the counter.
+        assert list(agg.models.keys()) == ["claude-opus-4-7"]
+        # Value is total output tokens under that model.
+        assert agg.models["claude-opus-4-7"] == 125
+
+    def test_scan_jsonl_mixed_model_session(self, tmp_path: Path) -> None:
+        """Multiple models contribute; counter keeps per-model output totals."""
+        sid = "sess-sb-02"
+        lines = [
+            _make_assistant_msg(
+                sid,
+                input_tokens=100,
+                output_tokens=40,
+                model="claude-opus-4-7",
+            ),
+            _make_assistant_msg(
+                sid,
+                input_tokens=100,
+                output_tokens=10,
+                model="synthetic",
+            ),
+            _make_assistant_msg(
+                sid,
+                input_tokens=100,
+                output_tokens=60,
+                model="claude-opus-4-7",
+            ),
+        ]
+        f = tmp_path / f"{sid}.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert agg.models["claude-opus-4-7"] == 100
+        assert agg.models["synthetic"] == 10
+
+    def test_scan_jsonl_synthetic_only_session(self, tmp_path: Path) -> None:
+        """Synthetic model captured verbatim (not coerced to 'unknown')."""
+        sid = "sess-sb-03"
+        lines = [
+            _make_assistant_msg(
+                sid,
+                input_tokens=50,
+                output_tokens=25,
+                model="synthetic",
+            )
+        ]
+        f = tmp_path / f"{sid}.jsonl"
+        f.write_text("\n".join(lines) + "\n")
+
+        agg = _scan_jsonl_file(f)
+        assert agg is not None
+        assert list(agg.models.keys()) == ["synthetic"]
+
+    def test_build_record_from_jsonl_preserves_model_fields(
+        self, tmp_path: Path
+    ) -> None:
+        """Mixed-model aggregate → majority wins for model, mix is populated."""
+        import collections as _c
+
+        agg = _JNLSessionAgg(
+            session_id="sess-sb-04",
+            input_tokens=300,
+            output_tokens=100,
+            user_message_count=2,
+            assistant_message_count=3,
+            first_timestamp="2026-04-20T10:00:00Z",
+            last_timestamp="2026-04-20T10:10:00Z",
+            cwd="/Users/test/Bid-Euchre-steward-author",
+            models=_c.Counter({"claude-opus-4-7": 70, "synthetic": 30}),
+        )
+        rec = _build_record_from_jsonl(
+            agg,
+            source_path=tmp_path / "sess-sb-04.jsonl",
+            source_hash="deadbeef",
+            now="2026-04-20T11:00:00Z",
+            lane_id="author-b",
+        )
+        # Majority by output tokens.
+        assert rec.model == "claude-opus-4-7"
+        # Mix preserved verbatim for downstream analysis.
+        assert rec.model_mix == {"claude-opus-4-7": 70, "synthetic": 30}
+
+    def test_build_record_from_jsonl_single_model_no_mix(self, tmp_path: Path) -> None:
+        """Single-model session: model set, model_mix empty dict."""
+        import collections as _c
+
+        agg = _JNLSessionAgg(
+            session_id="sess-sb-05",
+            input_tokens=100,
+            output_tokens=50,
+            models=_c.Counter({"claude-opus-4-7": 50}),
+        )
+        rec = _build_record_from_jsonl(
+            agg,
+            source_path=tmp_path / "sess-sb-05.jsonl",
+            source_hash="x",
+            now="2026-04-20T12:00:00Z",
+            lane_id="author-a",
+        )
+        assert rec.model == "claude-opus-4-7"
+        # model_mix is only populated on >1 distinct model.
+        assert rec.model_mix == {}
+
+    def test_session_meta_record_has_no_model(self) -> None:
+        """Legacy SessionRecord (no scanner) has ``model=None``.
+
+        The reader's null-safety contract (§3.2 of shaping plan) requires
+        legacy rows to bucket as ``unknown`` without being coerced to a
+        default model string.
+        """
+        rec = SessionRecord(session_id="legacy-001")
+        assert rec.model is None
+        assert rec.model_mix == {}
+        assert rec.effort is None
+
+    def test_schema_version_bump_read_compat(self, tmp_path: Path) -> None:
+        """Mixed v2/v3 rows in the store load without error.
+
+        The store uses JSONL with per-row ``schema_version``. A v2 row
+        predates the Slice B fields so its on-disk representation lacks
+        ``model`` / ``model_mix`` / ``effort`` — the loader must fall
+        back to ``None`` rather than raising.
+        """
+        from bid_euchre.ops.token_economy import _load_sessions
+
+        usage = tmp_path / "session_usage.jsonl"
+        v2_row = {
+            "session_id": "v2-001",
+            "schema_version": 2,
+            "source_type": "session-meta",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "git_commits": 0,
+            "imported_at": "2026-04-01T10:00:00Z",
+        }
+        v3_row = {
+            "session_id": "v3-001",
+            "schema_version": 3,
+            "source_type": "project-jsonl",
+            "input_tokens": 200,
+            "output_tokens": 75,
+            "model": "claude-opus-4-7",
+            "model_mix": {},
+            "effort": None,
+            "cache_creation_tokens": 10,
+            "cache_read_tokens": 5,
+            "git_commits": 1,
+            "imported_at": "2026-04-20T10:00:00Z",
+        }
+        usage.write_text(
+            json.dumps(v2_row) + "\n" + json.dumps(v3_row) + "\n",
+            encoding="utf-8",
+        )
+        rows = _load_sessions(tmp_path)
+        assert len(rows) == 2
+        # v2 row: missing fields absent (None / defaulted when read).
+        assert rows[0].get("model") is None
+        # v3 row: explicit model preserved.
+        assert rows[1]["model"] == "claude-opus-4-7"
+
+    def test_null_safe_unknown_bucket(self, tmp_path: Path) -> None:
+        """model_summary places legacy rows under the literal ``unknown`` bucket.
+
+        The shaping plan's null-safety contract (§3.2) is that ``unknown``
+        is a first-class bucket name, never coerced to a default model.
+        """
+        from bid_euchre.ops.token_economy import (
+            UNKNOWN_BUCKET,
+            model_summary,
+        )
+
+        usage = tmp_path / "session_usage.jsonl"
+        # One row has no model (legacy), one row has an explicit model.
+        rows = [
+            {
+                "session_id": "legacy-001",
+                "schema_version": 2,
+                "source_type": "session-meta",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "git_commits": 0,
+                "imported_at": "2026-04-01T10:00:00Z",
+            },
+            {
+                "session_id": "v3-001",
+                "schema_version": 3,
+                "source_type": "project-jsonl",
+                "input_tokens": 200,
+                "output_tokens": 75,
+                "model": "claude-opus-4-7",
+                "git_commits": 1,
+                "imported_at": "2026-04-20T10:00:00Z",
+            },
+        ]
+        usage.write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+        )
+        buckets = model_summary(output_dir=tmp_path)
+        labels = [b.model for b in buckets]
+        assert UNKNOWN_BUCKET in labels
+        assert "claude-opus-4-7" in labels
+        # Both rows are represented in the totals.
+        total = sum(b.total_tokens for b in buckets)
+        assert total == (100 + 50) + (200 + 75)


### PR DESCRIPTION
## Summary

Slice B telemetry extension for the token economy (issue #2169, umbrella).
Shaped by #2713. Bumps `SessionRecord` schema v2 → v3 with `model` /
`model_mix` / `effort` / `cache_creation_tokens` / `cache_read_tokens`,
adds five new rollup APIs, three CLI subcommands, and a dashboard
`by_model` panel with null-safety suppression. `unknown` is a first-class,
never-coerced bucket; `by-model` parity against `summary` is locked by a
new reconcile delta.

- **Schema v3** with safe `.get(...)` read-back from v2 rows (decoder
  maps missing model → `unknown`, missing `model_mix` → `{}`, missing
  cache tokens → `0`).
- **Scanner** weights `msg.model` by output tokens per session;
  majority wins the `model` field; `model_mix` populates only when
  >1 model observed. Mixed sessions count once on the majority row;
  tokens fan out proportionally by output-token share.
- **Library:** `model_summary`, `effort_summary`, `lane_model_summary`,
  `lane_effort_summary`, `model_outcome_summary`.
- **CLI:** `usage by-model`, `usage by-effort`, `usage by-model-outcome`
  (both text and `--json`). A one-line `By model:` trailer on
  `usage summary` and a `by-model (Σ)` row + `Model parity delta` on
  `usage reconcile`.
- **Dashboard:** `by_model` panel with suppression when only `unknown`
  is present and `other`-fold when >4 distinct models. JSON shape
  always includes the `by_model` key (empty list when suppressed).
- **Null-safety:** `unknown` is never coerced; disclosure line fires
  on the by-model text output when `unknown >= 10%` of tokens.
- **Parity guard (Slice A §4.0):** existing CLI surfaces are
  byte-exact; all Slice B changes are additive.

## Why

Platform-11 dispatch advisor (Slice E, merged as #2721) needs per-lane
per-model telemetry to drive recommendations. The token economy store
was schema-v2 only — opaque to model splits, effort, and
cache-token breakdown. Slice B is the schema carrier; producers
(effort-hint wiring) landed in Slices D (#2715) and E (#2721).

## Plan

`plans/sessions/2026-04-20_token_economy_slice_b.md`

Baseline report: `plans/sessions/2026-04-20_token_economy_slice_b_report.md`

## Repro / Validation

Tier 1 (targeted):

    uv run python -m pytest tests/unit/test_token_economy.py \
        tests/unit/test_ops_token_economy.py \
        tests/unit/test_ops_dashboard.py \
        tests/unit/test_ops_cli.py

**Result:** 405 passed in 45.83s

Tier 2:

    make check-gated

**Result:** All checks passed (log: `/tmp/make-check-Hpyy6D`)

Operator-facing smoke:

    uv run python scripts/internal/ops.py usage by-model
    uv run python scripts/internal/ops.py usage by-effort
    uv run python scripts/internal/ops.py usage reconcile

Baseline snapshot (post-merge, pre-rescan) captured in
`plans/sessions/2026-04-20_token_economy_slice_b_report.md`.

## Tests

New coverage locking Slice B contracts:

- `tests/unit/test_token_economy.py::TestSliceBModelCapture` — 8 tests
  (single/mixed/synthetic session capture, majority resolution,
  session-meta records, schema-version read-compat, null-safety)
- `tests/unit/test_ops_token_economy.py::TestModelSummary /
  TestEffortSummary / TestLaneModelSummary /
  TestModelOutcomeSummary / TestReconcileByModelParity`
- `tests/unit/test_ops_dashboard.py::TestDashboardByModelPanel` — 4
  tests (render, suppression, tail-fold, JSON shape invariant)
- `tests/unit/test_ops_cli.py::TestUsageByModelCliMatchesLibrary` — 2
  tests (schema-consistency gate: CLI == library; by-effort smoke)

## Worktree proof

    pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
    git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-b
    branch: ops/token-economy-slice-b

## References

- Shaping plan: `plans/sessions/2026-04-20_token_economy_slice_b.md`
  (merged as #2713)
- Baseline report:
  `plans/sessions/2026-04-20_token_economy_slice_b_report.md`
- Slice D (producer, fixed policy controls): #2715
- Slice E (producer, shadow-mode dispatch advisor): #2721

Refs #2169