### PR TITLE
fix(tests): skip mobile auction-log tests when helper overshoots auction phase

### DIFF
--- a/tests/browser/test_mobile.py
+++ b/tests/browser/test_mobile.py
@@ -272,6 +272,21 @@ def test_auction_log_all_bidders_visible_mobile(
             pytest.skip("No action-rail element found")
         action_rail.evaluate("el => el.setAttribute('open', '')")
 
+        # The helper must not overshoot the auction phase — if it does,
+        # the layout assertions below are meaningless (#2612).  Skip rather
+        # than hard-fail: overshoot is a helper-race precondition, not a
+        # product bug, so skipping avoids flaky CI red (#2615).
+        #
+        # Check overshoot *before* the item-count assertion so a helper
+        # that races past the 4th bid (rail cleared or items reshuffled as
+        # auction settles) skips cleanly instead of hard-failing (#2615).
+        if mobile_page.locator("#trick-area").count() > 0:
+            pytest.skip(
+                "Helper _advance_to_four_bidders overshot the auction phase — "
+                "game transitioned to trick_play before auction layout could be "
+                "verified (#2612, #2615)."
+            )
+
         # Verify we reached the 4-bidder state before asserting (#2594)
         items = mobile_page.locator(".action-rail__item")
         item_count = items.count()
@@ -279,17 +294,6 @@ def test_auction_log_all_bidders_visible_mobile(
             f"Expected ≥4 auction log items (one per bidder) but found {item_count}. "
             f"The test must reach a four-bidder state before asserting overflow (#2594)."
         )
-
-        # The helper must not overshoot the auction phase — if it does,
-        # the layout assertions below are meaningless (#2612).  Skip rather
-        # than hard-fail: overshoot is a helper-race precondition, not a
-        # product bug, so skipping avoids flaky CI red (#2615).
-        if mobile_page.locator("#trick-area").count() > 0:
-            pytest.skip(
-                "Helper _advance_to_four_bidders overshot the auction phase — "
-                "game transitioned to trick_play before auction layout could be "
-                "verified (#2612, #2615)."
-            )
 
         # The list container should NOT be scrollable during auction
         list_el = mobile_page.locator(".action-rail__list")
@@ -366,23 +370,27 @@ def test_auction_log_all_bidders_visible_mobile_big_text(
             pytest.skip("No action-rail element found")
         action_rail.evaluate("el => el.setAttribute('open', '')")
 
-        # Verify we reached the 4-bidder state (#2594)
-        items = mobile_page.locator(".action-rail__item")
-        item_count = items.count()
-        assert (
-            item_count >= 4
-        ), f"Expected ≥4 auction log items but found {item_count} (#2594)."
-
         # The helper must not overshoot the auction phase — if it does,
         # the layout assertions below are meaningless (#2612).  Skip rather
         # than hard-fail: overshoot is a helper-race precondition, not a
         # product bug, so skipping avoids flaky CI red (#2615).
+        #
+        # Check overshoot *before* the item-count assertion so a helper
+        # that races past the 4th bid (rail cleared or items reshuffled as
+        # auction settles) skips cleanly instead of hard-failing (#2615).
         if mobile_page.locator("#trick-area").count() > 0:
             pytest.skip(
                 "Helper _advance_to_four_bidders overshot the auction phase — "
                 "game transitioned to trick_play before auction layout could be "
                 "verified (#2612, #2615)."
             )
+
+        # Verify we reached the 4-bidder state (#2594)
+        items = mobile_page.locator(".action-rail__item")
+        item_count = items.count()
+        assert (
+            item_count >= 4
+        ), f"Expected ≥4 auction log items but found {item_count} (#2594)."
 
         # Check the list container is NOT scrollable (big text mode)
         list_el = mobile_page.locator(".action-rail__list")


### PR DESCRIPTION
## Summary

- Reorder the `#trick-area` overshoot check ahead of the `item_count >= 4`
  assert in both `test_auction_log_all_bidders_visible_mobile` and its
  big-text sibling. The existing `pytest.skip` branch for overshoot was
  unreachable when the helper raced past the 4th bid — the hard assert
  fired first.
- Test-only change. No product code touched.

## Why

`_advance_to_four_bidders` can transition the game into `trick_play` before
the layout assertions run. When that happens, the auction rail may be
cleared or items reshuffled and `item_count < 4`, so the assert hard-failed
instead of skipping. The overshoot branch was unreachable in that path.

Per triage #2720 Category A3. Tier 1 closure — tests lock behavior.

## Repro / Validation

```bash
uv run python -m pytest tests/browser/test_mobile.py
```

Observed locally: 4 tests collected, all skipped (no playwright runtime in
this environment, as expected for `@pytest.mark.browser` tests). File
parses cleanly and pre-commit ruff / ruff-format pass.

## Tests

- `uv run python -m pytest tests/browser/test_mobile.py` → 4 skipped, 0 errors
- `make check-gated` → All checks passed (logs /tmp/make-check-oml7Pm)

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
$ git worktree list | grep flex-a
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a  fix/2615-mobile-test-helper-race
```

## Test criteria

- Pass: `_advance_to_four_bidders` overshooting into trick_play triggers
  `pytest.skip` instead of an `AssertionError` on `item_count >= 4`. The
  4-bidder assert still fires for the non-overshoot path.
- Fail: A helper overshoot still produces a hard assertion failure in CI.

Fixes #2615