### PR TITLE
fix(web): narrow play_strategy_version migration except to duplicate-column

### DIFF
--- a/tests/unit/hosted_play/test_app.py
+++ b/tests/unit/hosted_play/test_app.py
@@ -728,3 +728,45 @@ class TestMigrationDuplicateColumnRobustness:
             engine = app.state.engine
             cols = [c["name"] for c in sa_inspect(engine).get_columns("matches")]
             assert cols.count("play_strategy_version") == 1
+
+    def test_matches_migration_reraises_non_duplicate_operational_error(
+        self, tmp_path, monkeypatch
+    ):
+        """Non-duplicate OperationalError during the play_strategy_version
+        migration must propagate instead of being silently swallowed (#2653).
+
+        Prior to the fix, the ``except (OperationalError, ProgrammingError)``
+        at ``web/app.py`` line 152 swallowed every such error — including
+        connection drops, permission failures, and disk-full conditions —
+        and logged a misleading "column already present" message.  The
+        narrowed handler only swallows duplicate-column errors; anything
+        else now surfaces at startup as intended.
+        """
+        import pytest
+        from sqlalchemy.exc import OperationalError
+
+        import web.app as app_module
+
+        db_path = tmp_path / "legacy.db"
+        db_url = _create_legacy_db(db_path)
+
+        real_text = app_module.text
+
+        def text_with_injection(sql):
+            # Redirect only the play_strategy_version migration statement to
+            # a bogus table so it raises OperationalError("no such table: …"),
+            # which is NOT a duplicate-column error and must propagate.
+            if "ADD COLUMN play_strategy_version" in sql:
+                return real_text(
+                    "ALTER TABLE nonexistent_matches_table "
+                    "ADD COLUMN play_strategy_version TEXT"
+                )
+            return real_text(sql)
+
+        monkeypatch.setattr(app_module, "text", text_with_injection)
+
+        config = make_hosted_play_test_config(tmp_path, database_url=db_url)
+        app = create_app(config=config)
+        with pytest.raises(OperationalError, match="no such table"):
+            with TestClient(app):
+                pass

--- a/web/app.py
+++ b/web/app.py
@@ -149,9 +149,15 @@ async def lifespan(app: FastAPI):
                     text("ALTER TABLE matches ADD COLUMN play_strategy_version TEXT")
                 )
             logger.info("Migration: added play_strategy_version column to matches")
-        except (OperationalError, ProgrammingError):
+        except (OperationalError, ProgrammingError) as exc:
             # SQLite raises OperationalError, PostgreSQL raises ProgrammingError
-            # for duplicate-column errors (#2532, #2632).
+            # for duplicate-column errors (#2532, #2632).  Only swallow those —
+            # re-raise anything else (connection errors, permission issues,
+            # disk-full, bogus schema) so startup fails loudly instead of
+            # silently claiming the column is present (#2653).
+            msg = str(exc).lower()
+            if "duplicate column" not in msg and "already exists" not in msg:
+                raise
             logger.info(
                 "Migration: play_strategy_version column already present (concurrent)"
             )


### PR DESCRIPTION
## Summary

- Narrows the `except (OperationalError, ProgrammingError)` at `web/app.py`
  line 152 to only swallow duplicate-column errors; re-raises anything
  else (connection drops, permission issues, disk-full, bogus schema) so
  lifespan startup fails loudly instead of silently logging "already
  present."
- Adds `test_matches_migration_reraises_non_duplicate_operational_error`
  to lock the behavior — injects a "no such table" `OperationalError` at
  the ALTER TABLE call and asserts it propagates through `TestClient`
  startup.

## Why

Per analyst-b triage #2720 (Category A2 — dispatch-ready quick-win). Prior
to this fix, any non-duplicate `OperationalError` or `ProgrammingError` at
that migration point was swallowed and logged as "column already present",
hiding real startup failures. Discovered by the review coordinator on PR
#2650; filed as follow-up #2653.

## Scope

Only the `play_strategy_version` handler at `web/app.py:152`. The sibling
handlers at lines 170 (`counterfactual_json`) and 189 (`glutton_action_json`)
share the identical anti-pattern and are out of the declared packet scope
— a follow-up issue will cover them.

## Repro / Validation

Tier 1 (targeted):

    uv run python -m pytest tests/unit/hosted_play/test_app.py -v -k Migration
    # → 20 passed (incl. the new regression test)

Tier 2:

    make check-gated
    # → 11900 passed, 1 unrelated flake
    #   (tests/unit/test_cpu_gate.py::TestCpuGateLoadAwareness::
    #   test_proceeds_immediately_when_load_is_low — cpu_gate.sh
    #   subprocess TimeoutExpired at 30s under loaded-machine conditions)
    uv run python -m pytest tests/unit/test_cpu_gate.py::TestCpuGateLoadAwareness::test_proceeds_immediately_when_load_is_low -v
    # → 1 passed in 0.12s  (confirms load-induced flake, not regression)

Test criteria (pass/fail):
- `test_matches_migration_reraises_non_duplicate_operational_error` MUST
  pass — injected "no such table" OperationalError propagates as
  `pytest.raises(OperationalError, match="no such table")` through the
  TestClient lifespan.
- Existing `test_concurrent_add_column_on_matches` MUST still pass —
  duplicate-column error is still swallowed as before (`msg` contains
  "duplicate column").

## Worktree proof

    $ pwd
    /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
    $ git rev-parse --show-toplevel
    /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
    $ git worktree list | grep author-d
    .../Bid-Euchre-steward-author-d        661f2468 [fix/2653-narrow-migration-except]

Fixes #2653

🤖 Generated with [Claude Code](https://claude.com/claude-code)