### PR TITLE
fix(strategy): skip sitting-out seats in glutton void-backed checks (#2654)

### DIFF
--- a/src/bid_euchre/strategy/glutton.py
+++ b/src/bid_euchre/strategy/glutton.py
@@ -21,7 +21,7 @@ from .base import Strategy, card_value_for_dump
 # GluttonStrategy or GluttonIsolatedStrategy. See
 # docs/02_agent/STRATEGY_VERSIONING.md for the semver rules and PR
 # changelog template.
-GLUTTON_STRATEGY_VERSION = "0.11.0"
+GLUTTON_STRATEGY_VERSION = "0.11.1"
 """Changelog:
 
 - 0.7.0 — Initial versioned baseline (PR #2529)
@@ -44,6 +44,15 @@ GLUTTON_STRATEGY_VERSION = "0.11.0"
   trick-completion detection for 3-player loner/moon tricks.
   Gated behind ``cash_winners_on_lead`` for high/low.
   Category: MINOR.
+- 0.11.1 — Void-backed check skips sitting-out seats (#2654).
+  In loner hands the sitting-out partner never plays a card, so
+  ``_void_suits_by_seat[sit_out]`` stays empty forever. The prior
+  ``all(opp void)`` check spuriously returned False whenever the
+  sitting-out seat fell into a defender's ``opp_seats`` tuple,
+  blocking defenders from ever firing the void-backed lead against
+  a loner caller. The fix tracks ``_seats_played`` from
+  ``observe_play`` and filters ``opp_seats`` to active seats once
+  plays have been observed. Category: PATCH.
 """
 
 
@@ -173,6 +182,13 @@ class GluttonStrategy(Strategy):
             2: set(),
             3: set(),
         }
+        # Seats that have played at least one card in the current hand.
+        # Used by ``_opponents_void_in_suit`` to skip sitting-out seats in
+        # loner/moon hands — a seat that never plays can never demonstrate
+        # a void, so it would otherwise block void-backed checks for
+        # defenders whose ``opp_seats`` tuple includes the sitting-out
+        # partner (#2654).
+        self._seats_played: Set[int] = set()
         # Contract context (set by on_hand_start)
         self._contract_type: str = "high"
         self._trump_suit: Optional[str] = None
@@ -208,6 +224,7 @@ class GluttonStrategy(Strategy):
         """Reset per-hand state at the start of each hand."""
         self._seen_counts = {}
         self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
+        self._seats_played = set()
         self._contract_type = contract_type
         self._trump_suit = trump_suit
         self._player_index = player_index
@@ -227,6 +244,11 @@ class GluttonStrategy(Strategy):
         """Track played cards and infer voids from play patterns."""
         # Increment seen count (clamp at 2 for double deck)
         self._seen_counts[card] = min(2, self._seen_counts.get(card, 0) + 1)
+
+        # Track that this seat has played at least one card this hand.
+        # Used to distinguish active seats from the sitting-out partner
+        # in loner/moon hands (#2654).
+        self._seats_played.add(player_index)
 
         # Infer voids: if a player didn't follow suit, they're void in led suit
         if len(trick_plays) >= 1:
@@ -257,20 +279,40 @@ class GluttonStrategy(Strategy):
                 self._last_won_lead_seat = None
 
     def _opponents_void_in_suit(self, suit: str, player_index: int) -> bool:
-        """Return True if both logical opponents are void in the given suit.
+        """Return True if every *active* logical opponent is void in the suit.
 
-        When both opponents have demonstrated a void (via failed follow-suit
-        in ``observe_play``), any card in that suit is a guaranteed winner
-        regardless of rank — opponents cannot follow suit and therefore
-        cannot beat the lead (#2627).
+        When every active opponent has demonstrated a void (via failed
+        follow-suit in ``observe_play``), any card in that suit is a
+        guaranteed winner regardless of rank — opponents cannot follow suit
+        and therefore cannot beat the lead (#2627).
 
-        Works correctly for both loner (only 2 active opponents) and regular
-        hands (partner winning = team wins, so leading into a voided suit
-        is safe).
+        Loner/moon handling (#2654): the sitting-out partner never plays
+        a card, so ``_void_suits_by_seat[sit_out]`` stays empty for the
+        whole hand. If a defender's ``opp_seats`` tuple includes the
+        sitting-out seat, the plain ``all(opp void)`` check would return
+        False forever, blocking the void-backed lead even when the single
+        active opponent has clearly voided the suit. To fix this, we
+        filter ``opp_seats`` down to seats that have actually played a
+        card this hand (``_seats_played``). In normal 4-player hands all
+        opponents eventually appear in ``_seats_played`` after trick 1,
+        so filtering is a no-op. In loner hands it correctly reduces the
+        check to the single active opponent.
+
+        Before any plays are observed (``_seats_played`` empty, e.g. the
+        caller leading trick 1), we leave ``opp_seats`` unfiltered; no
+        voids are known yet anyway, so the result is ``False`` either way.
         """
         opp_seats = ((player_index + 1) % 4, (player_index + 3) % 4)
+        if self._seats_played:
+            active_opp_seats = tuple(
+                opp for opp in opp_seats if opp in self._seats_played
+            )
+        else:
+            active_opp_seats = opp_seats
+        if not active_opp_seats:
+            return False
         return all(
-            suit in self._void_suits_by_seat.get(opp, set()) for opp in opp_seats
+            suit in self._void_suits_by_seat.get(opp, set()) for opp in active_opp_seats
         )
 
     def _threat_copies_remaining(
@@ -980,6 +1022,9 @@ class GluttonIsolatedStrategy(Strategy):
             2: set(),
             3: set(),
         }
+        # Seats that have played at least one card in the current hand.
+        # Mirror of :attr:`GluttonStrategy._seats_played` (#2654).
+        self._seats_played: Set[int] = set()
         # Contract context (set by on_hand_start)
         self._contract_type: str = "high"
         self._trump_suit: Optional[str] = None
@@ -1019,6 +1064,7 @@ class GluttonIsolatedStrategy(Strategy):
         """Reset per-hand state at the start of each hand."""
         self._seen_counts = {}
         self._void_suits_by_seat = {0: set(), 1: set(), 2: set(), 3: set()}
+        self._seats_played = set()
         self._contract_type = contract_type
         self._trump_suit = trump_suit
         self._player_index = player_index
@@ -1038,6 +1084,9 @@ class GluttonIsolatedStrategy(Strategy):
         """Track played cards and infer voids from play patterns."""
         # Increment seen count (clamp at 2 for double deck)
         self._seen_counts[card] = min(2, self._seen_counts.get(card, 0) + 1)
+
+        # Track seats that have played at least one card this hand (#2654).
+        self._seats_played.add(player_index)
 
         # Infer voids: if a player didn't follow suit, they're void in led suit
         if len(trick_plays) >= 1:
@@ -1108,13 +1157,22 @@ class GluttonIsolatedStrategy(Strategy):
         return True
 
     def _opponents_void_in_suit(self, suit: str, player_index: int) -> bool:
-        """Return True if both logical opponents are void in the given suit.
+        """Return True if every *active* logical opponent is void in the suit.
 
-        Mirror of :meth:`GluttonStrategy._opponents_void_in_suit` (#2627).
+        Mirror of :meth:`GluttonStrategy._opponents_void_in_suit` (#2627,
+        #2654 sitting-out filter).
         """
         opp_seats = ((player_index + 1) % 4, (player_index + 3) % 4)
+        if self._seats_played:
+            active_opp_seats = tuple(
+                opp for opp in opp_seats if opp in self._seats_played
+            )
+        else:
+            active_opp_seats = opp_seats
+        if not active_opp_seats:
+            return False
         return all(
-            suit in self._void_suits_by_seat.get(opp, set()) for opp in opp_seats
+            suit in self._void_suits_by_seat.get(opp, set()) for opp in active_opp_seats
         )
 
     def _count_effective_suit(self, hand: List[Card], suit: str) -> int:

--- a/tests/unit/test_greedy.py
+++ b/tests/unit/test_greedy.py
@@ -386,13 +386,14 @@ class TestCashWinnersOnLead:
             f"must lead A♥ (gating suppresses Cash-A) — got {hand[choice]}"
         )
 
-    def test_version_bumped_to_0_11_0(self):
-        """Void-backed winner leads (#2627) bumps version to 0.11.0."""
+    def test_version_bumped_to_0_11_1(self):
+        """Void-backed winner leads (#2627 → 0.11.0) plus sitting-out seat
+        skip (#2654 → 0.11.1 PATCH)."""
         from bid_euchre.strategy.glutton import GLUTTON_STRATEGY_VERSION
 
-        assert GLUTTON_STRATEGY_VERSION == "0.11.0"
-        assert GluttonStrategy.VERSION == "0.11.0"
-        assert GluttonIsolatedStrategy.VERSION == "0.11.0"
+        assert GLUTTON_STRATEGY_VERSION == "0.11.1"
+        assert GluttonStrategy.VERSION == "0.11.1"
+        assert GluttonIsolatedStrategy.VERSION == "0.11.1"
 
     # ---- Contract-type gating tests (Cash-A.1 → 0.9.0 update) ----
 
@@ -810,3 +811,200 @@ class TestObservePlayLonerTricks:
             strat.observe_play(seat, card, trick_plays, "low", None)
 
         assert strat._last_won_lead_suit is None
+
+
+class TestVoidBackedSkipsSittingOutSeats:
+    """Void-backed check skips sitting-out seats (#2654).
+
+    In loner/moon hands the sitting-out partner never plays a card, so their
+    ``_void_suits_by_seat`` entry stays empty forever. If a defender's
+    ``opp_seats`` tuple includes that sitting-out seat, the plain
+    ``all(opp void)`` check in the original implementation (#2627) would
+    return False forever, blocking the void-backed winner lead even when
+    the single active opponent had clearly voided the suit.
+
+    These tests lock the #2654 fix: ``_opponents_void_in_suit`` filters
+    ``opp_seats`` down to seats that have actually played a card this hand.
+    """
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_loner_defender_sees_void_backed_with_sitting_out_opponent(
+        self, cls, kwargs
+    ):
+        """Loner called by team 0,2; defender at seat 1 is leading.
+
+        Seat 2 sits out (caller's partner). Seat 1's ``opp_seats`` = (2, 0),
+        which includes the sitting-out seat 2. If seat 0 (the caller) has
+        demonstrated a void in spades via prior play, seat 1 should
+        recognize ♠J as a void-backed winner even though seat 2 has an
+        empty void set (never plays).
+        """
+        strat = cls(**kwargs)
+        hand = [
+            Card("S", "J"),  # void-backed candidate
+            Card("C", "K"),
+            Card("C", "Q"),
+            Card("C", "T"),
+        ]
+        strat.on_hand_start(hand, "low", None, player_index=1)
+
+        # Simulate a completed 3-player trick where seat 0 (the caller)
+        # voided on a heart lead by seat 1 — this populates both
+        # ``_seats_played`` and ``_void_suits_by_seat[0]``.
+        trick_plays = [
+            (1, Card("H", "T")),  # seat 1 leads hearts
+            (3, Card("H", "J")),  # seat 3 follows
+            (0, Card("C", "Q")),  # seat 0 (caller) voids on hearts
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+        # Seat 0 is void in hearts from this trick. Now mark seat 0 also
+        # void in spades (the suit we want to check).
+        strat._void_suits_by_seat[0].add("S")
+
+        assert strat._opponents_void_in_suit("S", player_index=1) is True, (
+            f"{cls.__name__}: with seat 2 sitting out, void-backed should "
+            "fire based on seat 0's void alone"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_loner_defender_still_requires_active_opponent_void(self, cls, kwargs):
+        """If the sole active opponent is *not* void, void-backed must NOT
+        fire — filtering the sitting-out seat cannot lower the bar below the
+        remaining active opponent.
+        """
+        strat = cls(**kwargs)
+        hand = [Card("S", "J"), Card("C", "K")]
+        strat.on_hand_start(hand, "low", None, player_index=1)
+
+        # Only seats 0, 1, 3 play (seat 2 sits out). Seat 0 has NOT shown
+        # a void in spades.
+        trick_plays = [
+            (1, Card("S", "T")),
+            (3, Card("S", "J")),
+            (0, Card("S", "A")),  # seat 0 follows spades
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._opponents_void_in_suit("S", player_index=1) is False, (
+            f"{cls.__name__}: active opponent (seat 0) not void → void-backed "
+            "must stay False even with seat 2 sitting out"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_normal_4player_hand_still_requires_both_opponents_void(self, cls, kwargs):
+        """In a normal 4-player hand all seats play, so
+        ``_seats_played`` grows to {0,1,2,3} after trick 1 and filtering is
+        a no-op. Confirm the original invariant (both opponents void) is
+        preserved.
+        """
+        strat = cls(**kwargs)
+        hand = [Card("S", "J"), Card("C", "K")]
+        strat.on_hand_start(hand, "low", None, player_index=0)
+
+        # 4-player trick: all seats play. Only seat 1 voids on the hearts
+        # lead; seat 3 follows suit.
+        trick_plays = [
+            (0, Card("H", "T")),
+            (1, Card("C", "K")),  # seat 1 voids hearts
+            (2, Card("H", "J")),
+            (3, Card("H", "Q")),  # seat 3 follows
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+        # Only seat 1 in the opponent pair (1, 3) is void in spades.
+        strat._void_suits_by_seat[1].add("S")
+
+        assert strat._opponents_void_in_suit("S", player_index=0) is False, (
+            f"{cls.__name__}: with both opponents active, void-backed still "
+            "requires both to be void in the suit"
+        )
+
+    @pytest.mark.parametrize(
+        "cls,kwargs",
+        [
+            (GluttonStrategy, {"cash_winners_on_lead": True}),
+            (
+                GluttonIsolatedStrategy,
+                {"smart_leads": True, "cash_winners_on_lead": True},
+            ),
+        ],
+        ids=["Glutton", "GluttonIsolated"],
+    )
+    def test_no_plays_observed_yet_returns_false(self, cls, kwargs):
+        """Before any ``observe_play`` call (e.g., caller leading trick 1 in
+        a normal hand), ``_seats_played`` is empty. The filter is skipped
+        and the check falls through to the unfiltered opp_seats. With no
+        voids known yet, the result is ``False`` either way — this test
+        guards that behavior to prevent the filter from inadvertently
+        returning True on an empty-knowledge state.
+        """
+        strat = cls(**kwargs)
+        hand = [Card("S", "J"), Card("C", "K")]
+        strat.on_hand_start(hand, "low", None, player_index=0)
+
+        assert strat._opponents_void_in_suit("S", player_index=0) is False, (
+            f"{cls.__name__}: with no plays observed yet, void-backed must "
+            "be False (no evidence of any opponent being void)"
+        )
+
+    def test_seats_played_tracks_observe_play(self):
+        """Smoke test: ``_seats_played`` is populated as observe_play fires."""
+        strat = GluttonStrategy(cash_winners_on_lead=True)
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+        assert strat._seats_played == set()
+
+        trick_plays = [
+            (0, Card("S", "T")),
+            (1, Card("S", "J")),
+            (3, Card("S", "Q")),
+        ]
+        for seat, card in trick_plays:
+            strat.observe_play(seat, card, trick_plays, "low", None)
+
+        assert strat._seats_played == {0, 1, 3}, (
+            "After a 3-player loner trick, _seats_played should contain "
+            "exactly the 3 active seats"
+        )
+
+    def test_seats_played_reset_on_hand_start(self):
+        """``_seats_played`` resets between hands."""
+        strat = GluttonStrategy(cash_winners_on_lead=True)
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+        strat.observe_play(1, Card("S", "T"), [(1, Card("S", "T"))], "low", None)
+        assert strat._seats_played == {1}
+
+        # New hand — _seats_played must reset.
+        strat.on_hand_start([Card("S", "A")] * 10, "low", None, player_index=0)
+        assert strat._seats_played == set()


### PR DESCRIPTION
## Summary

- `GluttonStrategy._opponents_void_in_suit` and its `GluttonIsolatedStrategy` mirror now filter `opp_seats` down to seats that have actually played a card in the current hand (`_seats_played`).
- `observe_play` populates `_seats_played`; `on_hand_start` resets it.
- Version bump `0.11.0` → `0.11.1` (PATCH — behavior change without config surface, per `docs/02_agent/STRATEGY_VERSIONING.md`).

## Why

In loner/moon hands the sitting-out partner never plays a card, so `_void_suits_by_seat[sit_out]` stays empty for the whole hand. When a defender's `opp_seats = ((player_index + 1) % 4, (player_index + 3) % 4)` included the sitting-out seat, the plain `all(opp void)` check from #2627 spuriously returned `False` forever, blocking defenders from ever firing the void-backed winner lead against a loner caller — even when the single active opponent had clearly voided the suit.

Scenario: seat 0 bids loner; seat 2 sits out. Defender at seat 1 holds `♠J` and leads. `opp_seats = (2, 0)`. Seat 0 has demonstrated void in spades via prior play, but seat 2 has never played so `_void_suits_by_seat[2] = set()` → `all()` → `False`. Void-backed path does not fire, AI leads into a non-voided suit, loses the trick.

After the fix: `_seats_played = {0, 1, 3}` once trick 1 has been observed; filtered `active_opp_seats = (0,)`; `all(seat 0 void)` → `True`; ♠J is recognized as a void-backed winner. In normal 4-player hands, all four seats appear in `_seats_played` after trick 1, so filtering is a no-op — existing `all(both void)` semantics are preserved.

Fixes #2654 (analyst-b triage #2720 Category A1).

## Repro / Validation

```bash
# Tier 1: targeted tests (113 tests: 52 in test_greedy.py + 61 in test_glutton.py)
uv run python -m pytest tests/unit/test_greedy.py tests/unit/test_glutton.py -v

# Tier 2: full validation
make check-gated
```

## Tests

New `TestVoidBackedSkipsSittingOutSeats` in `tests/unit/test_greedy.py` (parametrized across `GluttonStrategy` + `GluttonIsolatedStrategy`):

- `test_loner_defender_sees_void_backed_with_sitting_out_opponent` — positive: loner defender with sitting-out seat in `opp_seats` fires the void-backed check based on the single active opponent's void.
- `test_loner_defender_still_requires_active_opponent_void` — negative: if the sole active opponent is not void, the check stays `False` (filter doesn't lower the bar).
- `test_normal_4player_hand_still_requires_both_opponents_void` — regression guard: in normal 4-player hands, filtering is a no-op and both opponents must still be void.
- `test_no_plays_observed_yet_returns_false` — edge case: before any `observe_play` call, `_seats_played` empty, check returns `False` (no voids known).
- `test_seats_played_tracks_observe_play` — smoke: `_seats_played` populated correctly from `observe_play`.
- `test_seats_played_reset_on_hand_start` — smoke: `_seats_played` resets across hands.

Existing `test_version_bumped_to_0_11_0` renamed to `test_version_bumped_to_0_11_1` and updated for the PATCH bump.

## Validation Performed

- `uv run python -m pytest tests/unit/test_greedy.py tests/unit/test_glutton.py` → **113 passed**
- `make check-gated` → **All checks passed** (logs: `/tmp/make-check-Mh4a4n`)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
worktree: Bid-Euchre-steward-author-c (author-c lane)
branch: fix/glutton-skip-sitting-out-2654 (based on origin/main)
```

## References

- Issue: #2654 (follow-up from PR #2652 Codex review warning at `glutton.py:271`)
- Triage: #2720 (analyst-b) Category A1
- Related: #2627 (void-backed winner leads, the feature this fix hardens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)