### PR TITLE
fix(web): unify counterfactual export schema as OPTIONAL_FIELDS (#2645)

### DIFF
--- a/tests/unit/hosted_play/test_export.py
+++ b/tests/unit/hosted_play/test_export.py
@@ -1144,3 +1144,67 @@ class TestGluttonCounterfactualExport:
 
         result = decision_to_jsonl(decision, match, hand)
         assert "glutton_action" not in result
+
+
+# ---------------------------------------------------------------------------
+# GBT bid counterfactual export tests (#2645)
+# ---------------------------------------------------------------------------
+
+
+class TestBidCounterfactualExport:
+    """Verify ``counterfactual`` is optional: present only when non-null.
+
+    Schema unification (#2645): both counterfactual fields share the
+    omit-when-null pattern.  ``counterfactual`` lives in OPTIONAL_FIELDS,
+    not REQUIRED_FIELDS.
+    """
+
+    def test_counterfactual_is_optional_not_required(self):
+        """Schema constant: ``counterfactual`` must be an OPTIONAL field."""
+        from web.export import OPTIONAL_FIELDS, REQUIRED_FIELDS
+
+        assert "counterfactual" in OPTIONAL_FIELDS
+        assert "counterfactual" not in REQUIRED_FIELDS
+
+    def test_counterfactual_included_when_present(self, db_session):
+        """counterfactual field appears in export for decisions that have it."""
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+        hand = create_test_hand(db_session, match)
+        cf_payload = {"n": 3, "contract": "H"}
+        decision = create_test_decision(
+            db_session,
+            match,
+            hand,
+            phase="bid",
+            actor_type="human",
+            decision_source="human",
+            counterfactual_json=json.dumps(cf_payload),
+        )
+
+        result = decision_to_jsonl(decision, match, hand)
+        assert "counterfactual" in result
+        assert result["counterfactual"] == cf_payload
+
+    def test_counterfactual_absent_when_null(self, db_session):
+        """counterfactual field is omitted for decisions without it.
+
+        This is the key behaviour change from #2645: previously the field was
+        always emitted as ``null`` on non-human rows, wasting bytes.  Now it
+        is omitted entirely, matching the glutton_action precedent (PR #2616).
+        """
+        player = create_test_player(db_session)
+        match = create_test_match(db_session, player_id=player.id)
+        hand = create_test_hand(db_session, match)
+        # AI bid row — no counterfactual_json set.
+        decision = create_test_decision(
+            db_session,
+            match,
+            hand,
+            phase="bid",
+            actor_type="ai",
+            decision_source="heuristic",
+        )
+
+        result = decision_to_jsonl(decision, match, hand)
+        assert "counterfactual" not in result

--- a/web/export.py
+++ b/web/export.py
@@ -50,16 +50,18 @@ REQUIRED_FIELDS: frozenset[str] = frozenset(
         "legal_actions",
         "chosen_action",
         "game_state",
-        "counterfactual",
         "decision_time_ms",
         "timestamp",
     }
 )
 
-# Fields that appear only on certain decision types (e.g. glutton_action
-# on human play decisions).  Tests should accept these as valid extras.
+# Fields that appear only on certain decision types and are omitted when null,
+# saving bytes on non-human rows.  Both counterfactual fields share this
+# omit-when-null pattern (see #2645 and the glutton_action precedent in
+# PR #2616).  Tests should accept these as valid extras.
 OPTIONAL_FIELDS: frozenset[str] = frozenset(
     {
+        "counterfactual",
         "glutton_action",
     }
 )
@@ -126,16 +128,17 @@ def decision_to_jsonl(
         "legal_actions": legal_actions,
         "chosen_action": chosen_action,
         "game_state": game_state,
-        "counterfactual": (
-            json.loads(decision_row.counterfactual_json)
-            if decision_row.counterfactual_json
-            else None
-        ),
         "decision_time_ms": decision_row.decision_time_ms,
         "timestamp": timestamp,
     }
 
-    # Include glutton counterfactual when present (human play decisions).
+    # Include GBT bid counterfactual when present (human bid decisions).
+    # Omit when null to save bytes on non-human rows (#2645), matching the
+    # glutton_action pattern below.
+    if decision_row.counterfactual_json is not None:
+        result["counterfactual"] = json.loads(decision_row.counterfactual_json)
+
+    # Include glutton play counterfactual when present (human play decisions).
     if decision_row.glutton_action_json is not None:
         result["glutton_action"] = json.loads(decision_row.glutton_action_json)
 


### PR DESCRIPTION
## Summary

- Move `counterfactual` from `REQUIRED_FIELDS` to `OPTIONAL_FIELDS` in
  `web/export.py` so both counterfactual fields (GBT bid counterfactual and
  glutton play counterfactual) share the omit-when-null pattern.
- Update `decision_to_jsonl` to include `counterfactual` in the output dict
  only when `decision_row.counterfactual_json is not None`. Previously the
  key was always emitted with `null` on non-human rows, wasting bytes on
  every AI decision exported.
- Add `TestBidCounterfactualExport` class locking the new contract (schema
  constants, present-when-set, absent-when-null).

## Why

Per issue #2645 (Option A, analyst-b triage in #2720): the schema was
inconsistent — `glutton_action` was OPTIONAL (omit-when-null, PR #2616) but
`counterfactual` was REQUIRED (always emit `null` for AI rows). The two
counterfactual fields should share the same pattern. Unification saves
bytes on non-human rows and simplifies the schema contract.

## Repro / Validation

```bash
uv run python -m pytest tests/unit/hosted_play/test_export.py
# → 41 passed in 0.28s

make check-gated
# → ✓ All checks passed
```

## Tests

New tests lock the contract:

- `TestBidCounterfactualExport::test_counterfactual_is_optional_not_required`
  — schema constants
- `TestBidCounterfactualExport::test_counterfactual_included_when_present`
  — present-when-set
- `TestBidCounterfactualExport::test_counterfactual_absent_when_null`
  — omit-when-null (the behaviour change)

Existing `TestSchemaCompliance::test_no_extra_fields` continues to pass
because `counterfactual` now lives in `OPTIONAL_FIELDS` and the assertion
subtracts both REQUIRED and OPTIONAL from the output keys.

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b`
- `git rev-parse --show-toplevel`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b`
- Branch: `fix/2645-counterfactual-optional-fields`

## Closure

Fixes #2645 — Tier 1 (schema unification; tests lock new contract).

## References

- Issue #2645 — schema inconsistency
- Triage #2720 Category A6
- Precedent PR #2616 — `glutton_action` OPTIONAL_FIELDS pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)