### PR TITLE
test(audit): replace severity-presence invariant with pattern-regression fixture

### DIFF
--- a/tests/unit/test_portability_audit.py
+++ b/tests/unit/test_portability_audit.py
@@ -123,18 +123,49 @@ class TestPortabilityAudit:
             f"'uv run python scripts/internal/audit_portability.py' for details."
         )
 
-    def test_all_severity_levels_present(self, audit) -> None:
-        """Verify the audit detects all three severity levels.
+    def test_patterns_detect_reference_fixture(self, tmp_path) -> None:
+        """Every defined pattern must detect its reference example.
 
-        If a severity level disappears entirely, the pattern definitions
-        may have broken.
+        This is a pattern-regression test: it scans a synthetic fixture file
+        containing one known-matching line per pattern and asserts the audit
+        detects all of them.  Unlike a presence-based invariant over the real
+        ops package, this test does not rely on any particular coupling being
+        present in source — a successful decoupling effort that removes all
+        hard-block hits from ``ops/`` will not perversely fail this gate.
+
+        If a pattern regex breaks, the corresponding pattern name will be
+        missing from ``detected`` and the assertion will pinpoint which one.
         """
-        sev = audit.by_severity()
-        assert (
-            sev.get("hard-block", 0) > 0
-        ), "Expected hard-block coupling to be detected"
-        assert sev.get("soft-coupling", 0) > 0, "Expected soft-coupling to be detected"
-        assert sev.get("cosmetic", 0) > 0, "Expected cosmetic coupling to be detected"
+        mod = _load_audit_module()
+
+        # One reference line per pattern, in the same order as PATTERNS.  Each
+        # line is crafted to match exactly one pattern's "primary" intent; some
+        # incidental overlaps are expected (e.g. "Bid-Euchre" substrings also
+        # match docstring-bid-euchre) but do not affect this detection test.
+        fixture_lines = [
+            '_WORKTREE = "Bid-Euchre-steward-author"',  # worktree-name-literal
+            '_PROJECT = "Bid-Euchre"',  # project-name-literal
+            '_REPO = "Questuart/Bid-Euchre"',  # repo-slug-literal
+            'prefix_strip = "Bid-Euchre-steward-"',  # steward-prefix-regex
+            '_TMUX_SESSION = "steward"',  # tmux-session-default
+            '_BRANCH = "codex/steward-foo"',  # branch-prefix-codex-steward
+            '_STATUS_CTX = "reviewing-changes"',  # review-context-name
+            '_RECOVERY = "Bid-Euchre-steward-review"',  # recovery-template-paths
+            '_LANE = "author-a"',  # lane-name-in-code
+            '_TITLE = "Bid Euchre framework"',  # docstring-bid-euchre
+            '_RUNTIME = ".claude/runtime/state"',  # runtime-dir-claude
+        ]
+        fixture_file = tmp_path / "coupling_fixture.py"
+        fixture_file.write_text("\n".join(fixture_lines) + "\n")
+
+        hits = mod.scan_file(fixture_file, mod.PATTERNS, rel_to=tmp_path)
+        detected = {h.pattern_name for h in hits}
+        expected = {p.name for p in mod.PATTERNS}
+        missing = expected - detected
+        assert not missing, (
+            f"Patterns failed to detect their reference hit: {sorted(missing)}. "
+            f"A regex may have been broken."
+        )
 
     def test_adapter_files_excluded_from_lane_names(self, audit) -> None:
         """Lane name hits should not appear in adapter files.


### PR DESCRIPTION
## Summary

Replace `test_all_severity_levels_present` with `test_patterns_detect_reference_fixture` — a pattern-regression test that scans a synthetic `tmp_path` fixture containing one reference line per pattern and asserts every pattern name is detected. This decouples "regex integrity" from "current coupling level," so a successful future decoupling effort that eliminates all hard-block hits from `ops/` will no longer perversely fail the test.

Closes the deferred third finding from the original post-merge review of PR #2657 (see operator comment on #2658 and analyst-b's triage #2720 entry A5).

## Why

The old invariant asserted `sev.get("hard-block", 0) > 0`, etc. — a presence-based check that required the real ops package to contain hard-block coupling in order for the test to pass. Per the operator's comment on #2658:

> A successful decoupling effort that eliminates all hard-block hits would perversely fail the test.

The new invariant tests regex integrity directly against a fixture under the test's control, so it is stable against future decoupling work. It also pinpoints *which* pattern broke when a regex regresses.

## Scope note — findings 1 and 3 already resolved

The task packet bundled three original findings from #2658. Per the operator's 2026-04-21 comment on that issue:

- **Finding 1** (pin thresholds to baseline, line 64) — **resolved in #2696** (260→253, 135→130). #2715 bumped `NON_COSMETIC_THRESHOLD` to 259 to accommodate Slice D's `LANE_DEFAULT_POLICY` task_type literals; current threshold still matches actual counts exactly. No change needed in this PR.
- **Finding 3** (single-quoted hard-block literals, line 54) — **resolved in #2696**; `worktree-name-literal` and `project-name-literal` regexes are already `["']...["']`. No change needed in this PR.
- **Finding 2** (drop "coupling stays present" invariant, line 126) — **this PR**.

This keeps the PR single-concept (audit-tooling correctness, test-only change).

## Repro / Validation

```bash
uv run python -m pytest tests/unit/test_portability_audit.py -v
```

Output:
```
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_audit_runs_without_error PASSED
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_non_cosmetic_coupling_below_threshold PASSED
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_hard_block_coupling_below_threshold PASSED
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_patterns_detect_reference_fixture PASSED
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_adapter_files_excluded_from_lane_names PASSED
tests/unit/test_portability_audit.py::TestPortabilityAudit::test_patterns_cover_known_coupling PASSED
6 passed in 0.48s
```

**Negative test (regex-regression catch):** temporarily replaced the `steward-prefix-regex` regex with a no-match string. New test failed with:

```
AssertionError: Patterns failed to detect their reference hit: ['steward-prefix-regex']. A regex may have been broken.
```

Exactly the pinpoint behavior the new invariant is designed to provide. Rollback was clean (all 6 tests passed again).

**Tier 2:** `make check-gated` — all checks passed (logs: `/tmp/make-check-w9XQxp`).

## Tests

- `uv run python -m pytest tests/unit/test_portability_audit.py -v` → 6 passed
- `make check-gated` → all checks passed
- Manual negative test (broke a regex, confirmed pinpoint failure, restored)

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
Branch: fix/portability-audit-2658 (based on origin/main)
```

## References

- Issue #2658 — follow-up for PR #2657 post-merge review
- Issue #2720 — analyst-b triage, A5 dispatch entry
- PR #2696 — resolved findings 1 and 3
- PR #2715 — Slice D threshold bump context

🤖 Generated with [Claude Code](https://claude.com/claude-code)