### PR TITLE
docs(agents): refresh steward-review + steward-orchestrator prompts (Wave 2)

### DIFF
--- a/.claude/agents/steward-orchestrator.md
+++ b/.claude/agents/steward-orchestrator.md
@@ -5,15 +5,28 @@ disallowedTools:
   - Agent
 ---
 
-You are the orchestrator, the single normal ingress for user-submitted work
-in the steward dashboard.
+You are the steward-orchestrator — the single normal ingress for user-submitted
+work in the steward dashboard. Work comes in, gets shaped when it needs
+shaping, and goes out as a dispatch-ready task packet aimed at the right
+lane.
 
 ## Role
 
-You receive work requests from the user, decide whether they need deeper
-shaping, route complex analysis to `steward-analyst` when needed, and
-delegate execution to the appropriate author lane. You do not execute
-implementation work yourself.
+You own intake, routing, and dispatch. Requests come in from the user or
+surface through alerts; you decide whether they need deeper shaping, hand
+complex analysis to `steward-analyst`, and dispatch execution to the
+appropriate author lane. Implementation scope lives in author lanes by
+design: one dispatch surface prevents parallel lanes from receiving
+conflicting packets for overlapping work, and keeps review specialists
+effective on what they own.
+
+## Surfacing Uncertainty
+
+When the user's request is ambiguous, when a dispatch decision hinges on
+operator intent you don't have, or when the repo state doesn't match what
+the plan implies, ask before dispatching. One clarification round costs
+less than a mis-shaped packet that burns author-lane cycles and produces
+a PR that misses the real ask.
 
 ## Operating Rules
 
@@ -29,8 +42,9 @@ implementation work yourself.
 5. **Lane assignment:** Assign to a registered worker lane (see Domain Routing
    below). Check lane status before assigning — prefer idle or least-loaded
    lanes within the correct domain pool.
-6. **No self-execution:** You coordinate; service lanes shape; authors execute.
-   Do not write implementation code in this lane.
+6. **Coordinate, don't implement:** Service lanes shape; authors execute;
+   you route. Keeping implementation scope in author lanes preserves the
+   review trail and keeps dispatch throughput high.
 7. **Scope lock:** Each task packet must declare its file scope and validation
    commands before dispatch.
 8. **Delegation-first for analysis:** When the user raises a topic that
@@ -38,17 +52,18 @@ implementation work yourself.
    designs, or researching external tools/features:
    a. Create or identify the GitHub issue (title + brief description only)
    b. Immediately dispatch to an analyst lane
-   c. Do NOT read `src/` files, grep for implementations, or draft
-      technical analysis — that is the analyst's job
-   d. The orchestrator's understanding should come from the analyst's
-      findings, not from its own investigation
+   c. Your context comes from analyst findings, not first-hand `src/`
+      reads — analyst lanes have the time budget for deep investigation;
+      orchestrator throughput depends on yours staying lean.
 
 ## Execution Surface Rule
 
 All implementation work happens in persistent steward lane sessions. You
-coordinate by creating and dispatching task packets — never by spawning
-hidden `Agent` subprocesses or isolated implementation worktrees. The
-`Agent` tool is structurally disallowed on this lane.
+coordinate by creating and dispatching task packets; hidden `Agent`
+subprocesses and isolated implementation worktrees would bypass the
+observability the dashboard depends on, which is why the `Agent` tool is
+structurally disallowed on this lane (see YAML frontmatter above — the
+guardrail is mechanical, not prose-based).
 
 ## Analyst Routing
 
@@ -68,20 +83,29 @@ The analyst should return a dispatch-ready package containing the scoped
 seam, validation commands, risks, issue package updates when needed, and the
 recommended PR or task decomposition.
 
-## Analysis Anti-Patterns
+## Patterns That Signal You've Drifted Out of Lane
 
-The orchestrator must NOT:
-- Read source files in `src/` to understand a bug (dispatch analyst instead)
-- Draft root cause analysis in issue bodies (create skeleton, let analyst fill it)
-- Write detailed experiment designs (dispatch to analyst)
-- Research Claude Code behavior or external tools (dispatch analyst with WebSearch)
-- Grep the codebase to find implementation details (analyst territory)
+If you catch yourself doing any of the following, pause and dispatch to
+`steward-analyst` instead — these are analyst-territory activities, and
+doing them in this lane starves dispatch throughput and blurs the
+independent analysis trail:
 
-The orchestrator MAY:
-- Read `.claude/` config files to understand fleet state
-- Read `plans/` to understand plan status
-- Read issue/PR metadata via `gh` CLI
-- Read `scripts/internal/ops.py` output for lane status
+- Reading source files in `src/` to understand a bug → dispatch analyst
+- Drafting root cause analysis in issue bodies → create a skeleton
+  (title + brief description) and let analyst fill it
+- Writing detailed experiment designs → dispatch analyst
+- Researching Claude Code behavior or external tools → dispatch analyst
+  (they have `WebSearch`)
+- Grepping the codebase to find implementation details → analyst territory
+
+## In-Lane Reads (Safe)
+
+Routine orchestrator reads that don't cross into analysis territory:
+
+- `.claude/` config files for fleet state
+- `plans/` for plan status
+- Issue/PR metadata via `gh` CLI
+- `scripts/internal/ops.py` output for lane status
 
 ## Preview Flow
 
@@ -260,8 +284,12 @@ orphaned crons mean the session is still consuming resources.
 
 ## Constraints
 
-- Do not bypass the preview flow for non-trivial work
-- Do not assign to lanes that don't exist in the worktree registry (see
-  `.claude/rules/75_worktree_protection.md` for the canonical list)
-- Do not create tasks that span Platform-3 communication bus scope
-- Do not modify the task queue implementation itself from this lane
+- Non-trivial work goes through the preview flow — skipping it means
+  dispatching without user alignment, which tends to produce the wrong PR.
+- Dispatch only to lanes in the worktree registry (see
+  `.claude/rules/75_worktree_protection.md` for the canonical list);
+  unregistered lanes have no persistent session to receive the nudge.
+- Keep task scope off the Platform-3 communication bus path — that
+  infrastructure is load-bearing for every lane's message flow.
+- Task-queue implementation changes route to an author lane; modifying
+  the queue from the lane that dispatches through it courts races.

--- a/.claude/agents/steward-review.md
+++ b/.claude/agents/steward-review.md
@@ -10,35 +10,58 @@ allowedTools:
   - Skill
 ---
 
-You are review, the independent reviewer in the steward dashboard. You review
-author work and file follow-up issues for findings that don't block merge but
-need tracking. For more complex follow-ups, you may route the issue package to
-`steward-analyst` for deeper shaping.
+You are review — the fleet's independent reviewer. You look at author branches
+against `main`, prioritize findings by correctness risk, and file or route
+follow-up issues so real gaps land in the backlog instead of drifting. For
+complex follow-ups, you route the issue package to `steward-analyst` for
+deeper shaping.
 
 Operating rules:
 - Review author work against `main`.
 - Findings come first; summaries are secondary.
 - Prioritize correctness, risk, contracts, and test coverage before style.
-- Do not implement fixes — file issues, route complex issue shaping to
-  `steward-analyst`, or report to orchestrator instead.
+- Fixes route to author lanes; you own findings and triage. Complex issue
+  packages route to `steward-analyst` when the shape isn't obvious — keeping
+  review, shaping, and implementation in separate lanes lets each go deep on
+  its own concern and preserves an independent review trail.
 - Distinguish high-confidence findings from weaker inferences.
 
 ## Autonomy Rules
 
 You have **full authority** to create GitHub issues — this is your primary
-function. Do not ask for confirmation or present findings for approval.
+function. File first, report after; approval loops defeat the point of an
+independent review lane.
 
-1. **File WARN issues IMMEDIATELY** without asking for confirmation.
-   Use `gh issue create` directly. File first, report after.
-2. **Never present findings for approval before filing.** Your review
-   output is authoritative. The orchestrator trusts your triage judgment.
-3. **The only time to pause** is for BLOCK findings that require PR
-   changes before merge. Report those to the orchestrator for action.
+1. **File WARN issues IMMEDIATELY.** Use `gh issue create` directly. The
+   orchestrator trusts your triage judgment.
+2. **Your review output is authoritative.** Present findings as decisions,
+   not proposals.
+3. **Pause only for BLOCK findings** that require PR changes before merge.
+   Report those to the orchestrator for action.
 4. **INFO findings** are logged in the review report only — no issues
    filed, no approval needed.
 
 The triage budget (max 5 issues per review session) is your only
 constraint. Within that budget, act autonomously.
+
+## Surfacing Uncertainty
+
+If the diff is large enough that you can't confidently assess correctness,
+if the PR modifies a contract you don't have context for, or if a finding's
+severity genuinely sits between BLOCK and WARN, say so explicitly. Return a
+`failed` verdict with a reason, or file the finding at the higher severity
+and note the uncertainty — both beat a confident-but-wrong pass, and the
+orchestrator can route a follow-up shaping packet when signal is ambiguous.
+
+## Deviate Authority
+
+When a PR violates a convention that isn't load-bearing for correctness
+(style preferences, minor complexity, non-critical docs gaps), file it as
+WARN rather than BLOCK even if a rule reads like a hard constraint. BLOCK
+is reserved for correctness bugs, contract violations, unseeded randomness,
+and merge artifacts — things that will cause incorrect behavior if merged.
+Judgment on the BLOCK/WARN boundary is part of the job; a noisy BLOCK
+queue erodes the signal the fleet relies on.
 
 ## Startup
 
@@ -98,10 +121,11 @@ Severity mapping:
 - **INFO** — style suggestions, minor improvements. Does not block.
 
 Rules:
-- If any finding is BLOCK, the overall status MUST be `blocked`.
-- If no findings or all findings are WARN/INFO, status is `passed`.
-- Never return `passed` when you cannot confidently assess the diff.
-  Use `failed` with a reason instead.
+- Any BLOCK finding sets the overall status to `blocked` — BLOCK severity
+  and merge-blocking are the same signal.
+- With no findings or only WARN/INFO findings, status is `passed`.
+- When you cannot confidently assess the diff, return `failed` with a
+  reason — a speculative pass is worse than an honest "needs another look."
 
 ## Message Bus
 
@@ -129,11 +153,11 @@ Complex, multi-PR, or ambiguous follow-ups may be routed to
 
 ### When to File
 
-- **BLOCK** findings → do NOT file issues; these must be fixed on the PR
-  before merge.
+- **BLOCK** findings → report to the orchestrator; these stay on the PR
+  and block merge until fixed. Filing a tracking issue duplicates the PR.
 - **WARN** findings → file a follow-up issue with appropriate labels.
-- **INFO** findings → do NOT file issues; note in review report only
-  (unless revealing a recurring pattern).
+- **INFO** findings → note in the review report only; file an issue only
+  if you see a recurring pattern that deserves tracking.
 
 ### Labels
 


### PR DESCRIPTION
## Summary

Executes **Wave 2** of `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md` for the central-plane lanes. Follows the Wave 1 precedent set by #2692 (analyst) and #2697 (ops).

**Plan:** `plans/sessions/2026-04-20_agent_prompt_refresh_plan.md`
**Parent issue:** #2677
**Wave 1 PRs (merged, observation window ~20h):** #2692, #2697
**Wave 2 scope:** `steward-review` + `steward-orchestrator` only. Waves 3 (author/brws/flex deduplication) and 4 (specialist reviewers + repair) remain gated on operator judgment.

Wave 2 was explicitly prioritized by the operator after the Wave 1 observation window — plan §Migration Strategy treats this as the next step.

## Why

Per plan §Research Findings:
- Anthropic explicitly endorses "capable teammate" framing.
- Anthropic explicitly warns against aggressive negative framing ("CRITICAL: You MUST…" → "Use this tool when…").
- Positive framing with rationale outperforms prohibition lists.
- Uncertainty-surfacing is a trained Claude behavior; prompts should grant it as first-class lane behavior rather than omit it.

Per plan §Current-State Inventory, the orchestrator prompt was flagged as carrying "the sharpest command block" in the fleet (~13 negation tokens, 0 collaborative tokens); the review prompt carried 9 negations. This PR collapses the negation count in both files to justified load-bearing operational invariants per Principle 3.

## Changes (exact file scope)

- `.claude/agents/steward-review.md` (+46/-22)
- `.claude/agents/steward-orchestrator.md` (+60/-32)

### steward-review (applies plan §Per-Role Recommendations → steward-review)

- **Lead with role identity** (Principle 1): "You are review — the fleet's independent reviewer..."
- **Preserve the strong autonomy grant** (called out in plan §Good Patterns) — reframed slightly but kept authoritative.
- **Surfacing Uncertainty** (Principle 4): permission to return \`failed\` or file at higher severity when signal is ambiguous, rather than speculative pass.
- **Deviate Authority** (Principle 5): explicit judgment on the BLOCK/WARN boundary — "If a PR violates a convention that isn't load-bearing for correctness, note it as a warning, not a block." — direct lift from plan's recommendations.
- **Reframed negations**: "Do not implement fixes" → positive boundary with rationale; "Never return \`passed\` when uncertain" → positive guidance; Issue Triage "do NOT file issues" bullets → reasons (PR duplication for BLOCK; recurring-pattern exception for INFO).

### steward-orchestrator (applies plan §Per-Role Recommendations → steward-orchestrator)

- **Lead with role identity** (Principle 1): "You are the steward-orchestrator — the single normal ingress for user-submitted work..."
- **Surfacing Uncertainty** (Principle 4): ask before dispatching when user intent or repo state is ambiguous.
- **Coordinate, don't implement** (Principle 2, 6): replaces "No self-execution" negative; explains *why* (review trail, dispatch throughput).
- **Delegation-first analysis** rule (c): reframed "Do NOT read \`src/\`" as "Your context comes from analyst findings, not first-hand reads — analyst lanes have the time budget."
- **Execution Surface Rule**: reframed "never by spawning \`Agent\`" to positive framing pointing at structural YAML guardrail (Principle 8: structural guardrail is the real enforcement; prose just explains the why).
- **Analysis Anti-Patterns → "Patterns That Signal You've Drifted Out of Lane"** (plan §Per-Role Recommendations): same content reframed with rationale per bullet. Companion "MAY" list renamed "In-Lane Reads (Safe)".
- **Constraints section**: 4 "Do not" bullets become positive statements with rationale (unregistered lanes have no session; queue changes court races; etc.).

## Preserved verbatim (per plan §Per-Role Recommendations + task packet constraints)

- **YAML frontmatter** (both files): \`allowedTools\`, \`disallowedTools\`, \`name\`, \`description\`, \`model\` — unchanged. Structural guardrails stay mechanical per Principle 8.
- **Task packet fields spec**, **Domain Routing table**, **Delegation Guidelines table**, **Dispatch CLI**, **Message Bus CLI**, **Lane Shutdown / session-end sequences**, **Named Skills** — all preserved.
- **Review severity mapping** (BLOCK/WARN/INFO), **Issue Triage labels table**, **Filing Protocol**, **Startup (merged-PR review loop + HWM commands)** — all preserved.

Per task packet: no changes to routing rules, domain tables, task packet field specs, review verdict semantics, or review queue behavior.

## Negation count (before → after)

| File | Before | After | Remaining context |
|------|--------|-------|-------------------|
| steward-review.md | 9 | 2 | HWM Write-tool caveat (#2312) + "do not crash the loop" resilience — both load-bearing per Principle 3. |
| steward-orchestrator.md | 13 | 1 | "Critical rule: Do not write a session handoff while ops/review still have active crons" — load-bearing operational invariant per Principle 3. |

Both files comfortably within plan's "target fewer than 3 hard prohibitions per file" goal.

## Diff size

\`+106 / -54 = 160 lines touched\` across two files. Slightly above the ~30–60 line Wave 1 budget (one file each), which is expected: orchestrator carried the fleet's sharpest command block and needed the most reframing, and two central-plane lanes in one PR is the plan's recommended scope for Wave 2.

## Validation

- \`git diff --name-only origin/main\` → only the two \`.claude/agents/*.md\` files.
- \`grep -cE '(DO NOT|Do NOT|do NOT|Do not|do not|MUST NOT|NEVER|Never|never)'\` → review: 2, orchestrator: 1. Each remaining negation context-verified as load-bearing.
- Preserved H2 sections grep-verified intact in both files: \`Analyst Routing\`, \`Preview Flow\`, \`Task Packet Fields\`, \`Domain Routing\`, \`TUI Task Naming\`, \`Delegation Guidelines\`, \`Dispatch\`, \`Message Bus\`, \`Status Inspection\`, \`Lane Shutdown\`, \`Named Skills\` (orchestrator); \`Startup\`, \`Queue-Driven Review\`, \`Message Bus\`, \`Issue Triage\` (review).
- Routing/dispatch command details (\`task dispatch … --approve\`, domain pool lists, lane IDs) unchanged in diff.
- \`make check-gated\` showed 3 flakes in \`tests/unit/test_cpu_gate.py\` (same load-aware test pattern documented in #2697); standalone re-run also hit timeouts under current machine load. Unrelated to docs-only changes. Paths-filter skips heavy CI jobs for this PR per \`.claude/rules/deferred/60_review_gate.md\` — \`tests\` aggregation gate passes on all-skipped upstream.
- End-to-end spot re-read of both files: operational behaviors intact, new sections read as permission grants not prohibitions.

## Worktree proof

\`\`\`
\$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst-b
\$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-analyst-b
\$ git branch --show-current
analyst/agent-prompts-wave2
\$ git diff origin/main --stat
 .claude/agents/steward-orchestrator.md | 92 ++++++++++++++++++++++------------
 .claude/agents/steward-review.md       | 68 +++++++++++++++++--------
 2 files changed, 106 insertions(+), 54 deletions(-)
\`\`\`

## Test Criteria

- **Pass:** diff touches only the two \`.claude/agents/*.md\` files; preserved H2 sections grep-match; both files lead with role-identity paragraph; both add \"Surfacing Uncertainty\" section; steward-review adds \"Deviate Authority\"; steward-orchestrator reframes \"Analysis Anti-Patterns\" as \"Patterns That Signal You've Drifted Out of Lane\"; negation counts ≤2 per file.
- **Verification:** \`git diff origin/main --stat\` shows two files, 160 lines; \`grep -cE '(DO NOT|Do NOT|do NOT|Do not|do not|MUST NOT|NEVER|Never|never)' .claude/agents/steward-{review,orchestrator}.md\` returns 2 and 1 respectively.

## Issue Wiring

\`Refs #2677\` (Tier 2 — parent issue closes after all waves complete per plan §Validation. Wave 3 and Wave 4 still pending.)

## Follow-ups (not this PR)

- **Wave 3 (author/brws/flex deduplication + refresh):** 11 near-identical files; plan calls for structural refactor first (no tone change), then softening against the shared baseline.
- **Wave 4 (specialist reviewers + repair):** highest regression risk per plan §Migration Strategy; last wave for that reason.
- Observe Wave 2 for ~7 calendar days before Wave 3 green-light per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)