### PR TITLE
fix(ops): escape control chars in permission_denied_alert.sh fallback

### DIFF
--- a/scripts/internal/hooks/permission_denied_alert.sh
+++ b/scripts/internal/hooks/permission_denied_alert.sh
@@ -120,9 +120,37 @@ RECORD=$(jq -nc \
   2>/dev/null) || RECORD=""
 
 if [ -z "$RECORD" ]; then
-  # Hand-rolled fallback (escape backslashes + double quotes only)
+  # Hand-rolled fallback. Escapes per RFC 8259 §7:
+  #   - `\` → `\\`, `"` → `\"`
+  #   - named short escapes for \b \t \n \f \r
+  #   - remaining C0 control chars (U+0000–U+001F) → \uXXXX
+  # Uses awk (not sed) because sed cannot process embedded newlines in a
+  # single invocation without non-portable GNU-only extensions, and a single
+  # unescaped newline in the message would corrupt every subsequent line in
+  # the JSONL file (see #2691).
   _esc() {
-    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+    printf '%s' "$1" | LC_ALL=C awk '
+      BEGIN {
+        for (i = 1; i < 256; i++) ord[sprintf("%c", i)] = i
+      }
+      { buf = (NR == 1 ? $0 : buf "\n" $0) }
+      END {
+        n = length(buf)
+        for (i = 1; i <= n; i++) {
+          c = substr(buf, i, 1)
+          v = ord[c] + 0
+          if (c == "\\")            printf "\\\\"
+          else if (c == "\"")       printf "\\\""
+          else if (v == 8)          printf "\\b"
+          else if (v == 9)          printf "\\t"
+          else if (v == 10)         printf "\\n"
+          else if (v == 12)         printf "\\f"
+          else if (v == 13)         printf "\\r"
+          else if (v > 0 && v < 32) printf "\\u%04x", v
+          else                      printf "%s", c
+        }
+      }
+    '
   }
   RECORD=$(printf '{"ts":"%s","lane":"%s","tool":"%s","rule":"%s","message":"%s"}' \
     "$(_esc "$TIMESTAMP")" \

--- a/tests/unit/hooks/test_permission_denied_alert.py
+++ b/tests/unit/hooks/test_permission_denied_alert.py
@@ -48,7 +48,36 @@ def _write_mock_uv(bin_dir: Path, capture_file: Path) -> Path:
     bin_dir.mkdir(parents=True, exist_ok=True)
     shim = bin_dir / "uv"
     shim.write_text(
-        "#!/usr/bin/env bash\n" f'printf "%s\\n" "$@" >> "{capture_file}"\n' "exit 0\n",
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$@" >> "{capture_file}"\nexit 0\n',
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return shim
+
+
+def _write_failing_construct_jq(bin_dir: Path) -> Path:
+    """Shim `jq` that forces the hand-rolled fallback path.
+
+    The hook invokes jq twice:
+      1. To parse stdin fields (`jq -r '.tool_name // ...'`).
+      2. To build the final JSON record (`jq -nc --arg ...`).
+
+    This shim passes (1) through to the real jq but fails (2) by exiting
+    non-zero whenever `-nc` is present in argv. That forces RECORD="" inside
+    the hook, which activates the `_esc`-based hand-rolled fallback that
+    this test suite is exercising.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "jq"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'for arg in "$@"; do\n'
+        '  if [ "$arg" = "-nc" ]; then\n'
+        "    exit 1\n"
+        "  fi\n"
+        "done\n"
+        "# Fall through to the real jq on the system PATH (without bin_dir).\n"
+        'PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" exec jq "$@"\n',
         encoding="utf-8",
     )
     shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
@@ -61,17 +90,25 @@ def _run_hook(
     stdin_payload: str,
     lane_env: str | None = "author-b",
     project_dir: Path | None = None,
+    force_fallback: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
     """Run the hook with a controlled PATH, env, and CLAUDE_PROJECT_DIR.
 
     Returns (completed_process, uv_capture_path, project_dir) so callers can
     assert on the JSONL log contents and the ops.py argv.
+
+    When ``force_fallback`` is True, installs a jq shim that breaks only the
+    JSON-construction call (`jq -nc ...`) so the hook's hand-rolled ``_esc``
+    fallback runs. This is how the control-char escape tests exercise the
+    fallback path that #2691 targets.
     """
     project_dir = project_dir or tmp_path / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
     bin_dir = tmp_path / "bin"
     uv_capture = tmp_path / "uv_argv.log"
     _write_mock_uv(bin_dir, uv_capture)
+    if force_fallback:
+        _write_failing_construct_jq(bin_dir)
 
     # Keep the minimal PATH the hook needs (jq, sed, date, bash builtins, the
     # mock uv). Use /usr/bin + /bin for coreutils and prepend bin_dir so the
@@ -245,6 +282,146 @@ class TestLaneDerivation:
         record = _read_denial_record(project_dir)
         # Must never be empty (would break ops.py --from validation)
         assert record["lane"], record
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fallback JSON escaping (#2691)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackControlCharEscape:
+    """When jq is unavailable for record construction, the hand-rolled
+    fallback must still emit valid JSON even if the classifier message
+    contains control characters (newlines, tabs, CR, other C0 controls).
+
+    Regression for #2691: pre-fix, the fallback only escaped ``\\`` and ``"``,
+    so a single multi-line classifier message would corrupt every subsequent
+    line in the JSONL file, silently breaking jq-based tooling.
+    """
+
+    def test_fallback_with_embedded_newline_produces_valid_jsonl(
+        self, tmp_path: Path
+    ) -> None:
+        payload = json.dumps(
+            {
+                "tool_name": "Bash",
+                "rule_matched": "MultilineRule",
+                "message": "first line\nsecond line\nthird line",
+            }
+        )
+        result, _, project_dir = _run_hook(
+            tmp_path, stdin_payload=payload, force_fallback=True
+        )
+        assert result.returncode == 0, result.stderr
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log = (
+            project_dir
+            / ".claude"
+            / "runtime"
+            / "classifier_denials"
+            / f"{today}.jsonl"
+        )
+        raw = log.read_text(encoding="utf-8")
+        # Each non-empty line in the JSONL file must parse on its own — if
+        # the newline in "message" leaked through, the second line would be
+        # an orphan fragment and json.loads would fail.
+        lines = [ln for ln in raw.splitlines() if ln.strip()]
+        assert (
+            len(lines) == 1
+        ), f"expected exactly one JSONL line, got {len(lines)}: {raw!r}"
+        record = json.loads(lines[0])
+        assert record["message"] == "first line\nsecond line\nthird line"
+        assert record["rule"] == "MultilineRule"
+
+    def test_fallback_escapes_tab_and_carriage_return(self, tmp_path: Path) -> None:
+        payload = json.dumps(
+            {
+                "tool_name": "Edit",
+                "rule_matched": "WhitespaceRule",
+                "message": "col1\tcol2\rwrap",
+            }
+        )
+        result, _, project_dir = _run_hook(
+            tmp_path, stdin_payload=payload, force_fallback=True
+        )
+        assert result.returncode == 0, result.stderr
+        record = _read_denial_record(project_dir)
+        # After json.loads, the original bytes should be restored exactly.
+        assert record["message"] == "col1\tcol2\rwrap"
+
+    def test_fallback_escapes_c0_controls_as_unicode(self, tmp_path: Path) -> None:
+        # U+0001 and U+001F — arbitrary C0 control chars that should be
+        # emitted as \u0001 / \u001f, not passed through raw.
+        payload = json.dumps(
+            {
+                "tool_name": "Bash",
+                "rule_matched": "CtrlRule",
+                "message": "before\u0001mid\u001fafter",
+            }
+        )
+        result, _, project_dir = _run_hook(
+            tmp_path, stdin_payload=payload, force_fallback=True
+        )
+        assert result.returncode == 0, result.stderr
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        log = (
+            project_dir
+            / ".claude"
+            / "runtime"
+            / "classifier_denials"
+            / f"{today}.jsonl"
+        )
+        raw_line = log.read_text(encoding="utf-8").strip()
+        # The raw file content must contain escaped unicode, not the raw bytes
+        assert "\\u0001" in raw_line, raw_line
+        assert "\\u001f" in raw_line, raw_line
+        # And the record must still round-trip through json.loads
+        record = json.loads(raw_line)
+        assert record["message"] == "before\u0001mid\u001fafter"
+
+    def test_fallback_preserves_existing_backslash_and_quote_escapes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression guard: the extended _esc must not break the two original
+        # escape cases (`\` and `"`).
+        payload = json.dumps(
+            {
+                "tool_name": "Write",
+                "rule_matched": "QuoteRule",
+                "message": 'path="C:\\temp" says "hello"',
+            }
+        )
+        result, _, project_dir = _run_hook(
+            tmp_path, stdin_payload=payload, force_fallback=True
+        )
+        assert result.returncode == 0, result.stderr
+        record = _read_denial_record(project_dir)
+        assert record["message"] == 'path="C:\\temp" says "hello"'
+
+    def test_fallback_is_actually_taken(self, tmp_path: Path) -> None:
+        # Sanity check that the shim forces the fallback branch. We can't
+        # directly assert which branch ran, but the construct-jq shim exits
+        # non-zero on `-nc`, which forces RECORD="" and activates _esc. If
+        # the jq-shim ever stopped working, every other test in this class
+        # would silently start covering only the jq-happy-path.
+        import subprocess as sp
+
+        bin_dir = tmp_path / "bin"
+        _write_failing_construct_jq(bin_dir)
+        # The shim must exit 1 for -nc
+        r = sp.run(
+            [str(bin_dir / "jq"), "-nc", "."], capture_output=True, text=True, timeout=5
+        )
+        assert r.returncode != 0, "shim should fail on -nc"
+        # The shim must pass through non-construct calls
+        r2 = sp.run(
+            [str(bin_dir / "jq"), "-r", '.foo // "x"'],
+            input='{"foo":"bar"}',
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert r2.returncode == 0 and r2.stdout.strip() == "bar", r2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend `_esc()` in `scripts/internal/hooks/permission_denied_alert.sh` to emit
  RFC 8259 §7 escapes (named: `\b \t \n \f \r`, plus `\uXXXX` for remaining C0
  controls) on top of the existing backslash/quote handling.
- Uses `awk` (not `sed`) because sed cannot process embedded newlines in a single
  invocation without non-portable GNU-only extensions — a single unescaped
  newline in the classifier message would corrupt every subsequent JSONL line.
- Adds `TestFallbackControlCharEscape` (5 cases) that installs a jq shim to
  fail only on the `jq -nc` record-construction call, forcing the hand-rolled
  fallback, then asserts the resulting JSONL round-trips through `json.loads`.

## Why

From analyst-b triage of #2720 (Category A4) / finding on PR #2676.

The hand-rolled JSON fallback previously escaped only `\\` and `\"`. Control
characters in the classifier message or rule would flow through unescaped,
producing invalid JSON and breaking the JSONL contract documented in the
file's own schema comment (`data contract with future observation tooling —
treat changes as breaking`). A single multi-line classifier denial would
silently corrupt every subsequent line in the daily JSONL file for jq-based
tooling. Per task spec, picked **Option (b) — extend escape function**.

## Repro / Validation

**Targeted test (Tier 1):**
```
uv run python -m pytest tests/unit/hooks/test_permission_denied_alert.py -v
# → 16 passed (including 5 new TestFallbackControlCharEscape cases)
```

**Bash-level smoke test** (fallback forced via jq shim; matches task packet's
validation plan):
```
$ SMOKE_DIR=$(mktemp -d) && mkdir -p "$SMOKE_DIR/bin"
$ cat > "$SMOKE_DIR/bin/jq" <<'SH'
#!/usr/bin/env bash
for arg in "\$@"; do
  if [ "\$arg" = "-nc" ]; then exit 1; fi
done
PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" exec jq "\$@"
SH
$ chmod +x "\$SMOKE_DIR/bin/jq"
$ PATH="\$SMOKE_DIR/bin:…" CLAUDE_PROJECT_DIR="\$SMOKE_DIR" CLAUDE_AGENT_NAME=steward-author-c \
    python3 -c 'import json,sys; sys.stdout.write(json.dumps({"tool_name":"Bash","rule_matched":"MultilineRule","message":"line1\nline2\ttab\u0001ctrl\"q\\back"}))' \
    | bash scripts/internal/hooks/permission_denied_alert.sh
$ jq -c '.' "\$SMOKE_DIR/.claude/runtime/classifier_denials/\$(date -u +%F).jsonl"
{"ts":"…","lane":"author-c","tool":"Bash","rule":"MultilineRule","message":"line1\nline2\ttab\u0001ctrl\"q\\back"}
# OK: JSONL parses cleanly, message round-trips exactly.
```

## Test Criteria (Observable)

1. `pytest tests/unit/hooks/test_permission_denied_alert.py` → 16 passed
   (incl. 5 new control-char cases).
2. With a payload containing `\n`, `\t`, `\r`, and `\u0001` in `message`, the
   written JSONL file contains exactly one line, and `jq -c '.' file.jsonl`
   exits 0 with the round-tripped record.
3. Regression guard: backslash + double-quote escape still works with the
   extended function (`test_fallback_preserves_existing_backslash_and_quote_escapes`).

## Closure

`Refs #2691` — Tier 2 closure. The JSONL schema is a future-tooling contract;
per the issue closure policy, we verify in production with a real denial
that contains a control char, then close with evidence. No auto-close.

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
$ git branch --show-current
fix/permission-denied-alert-control-chars-2691
```

## Tier 2 Note

`make check-gated` on this worktree flaked on three `tests/unit/test_cpu_gate.py`
timing-sensitive cases (`test_passes_through_command_output`,
`test_propagates_exit_code`, `test_proceeds_immediately_when_load_is_low`) when
concurrency load pushed into the gate threshold window. Each passed cleanly in
isolation (`uv run python -m pytest tests/unit/test_cpu_gate.py` → 10/10). The
failures are unrelated to this change — they don't touch the hook script or
its tests. CI will give the authoritative signal.

Refs #2691
Refs #2720 (triage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)