### PR TITLE
refactor(hooks): consolidate lane-id resolver into shared library (#2690)

### DIFF
--- a/.claude/hooks/lane-heartbeat-post-tool.sh
+++ b/.claude/hooks/lane-heartbeat-post-tool.sh
@@ -56,34 +56,21 @@ if command -v jq >/dev/null 2>&1; then
     TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
 fi
 
-# Resolve lane_id (mirrors post-merge-notify.sh).
+# Resolve lane_id via the canonical shared helper (#2690). Pure bash,
+# no `uv run` cold start — preserves the 2s budget above. Locate the
+# lib relative to this script (works when CLAUDE_PROJECT_DIR is unset,
+# e.g. in test harnesses); fall back to CLAUDE_PROJECT_DIR second.
 LANE_ID=""
-if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
-    LANE_ID=$(printf '%s' "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
-fi
-if [ -z "$LANE_ID" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
-    case "$DIR_NAME" in
-        *steward-author-scratch) LANE_ID="author-scratch" ;;
-        *steward-author-b)       LANE_ID="author-b" ;;
-        *steward-author-c)       LANE_ID="author-c" ;;
-        *steward-author-d)       LANE_ID="author-d" ;;
-        *steward-author)         LANE_ID="author-a" ;;
-        *steward-brws-author-a)  LANE_ID="brws-author-a" ;;
-        *steward-brws-author-b)  LANE_ID="brws-author-b" ;;
-        *steward-brws-author-c)  LANE_ID="brws-author-c" ;;
-        *steward-brws-author-d)  LANE_ID="brws-author-d" ;;
-        *steward-analyst-b)      LANE_ID="analyst-b" ;;
-        *steward-analyst-c)      LANE_ID="analyst-c" ;;
-        *steward-analyst-d)      LANE_ID="analyst-d" ;;
-        *steward-analyst)        LANE_ID="analyst-a" ;;
-        *steward-flex-a)         LANE_ID="flex-a" ;;
-        *steward-flex-b)         LANE_ID="flex-b" ;;
-        *steward-flex-c)         LANE_ID="flex-c" ;;
-        *steward-flex-d)         LANE_ID="flex-d" ;;
-        *steward-review)         LANE_ID="review" ;;
-        *steward-ops)            LANE_ID="ops" ;;
-    esac
+_hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _hook_dir=""
+if [ -n "$_hook_dir" ] && [ -r "$_hook_dir/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$_hook_dir/lib/resolve-lane-id.sh"
+    LANE_ID=$(resolve_lane_id)
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+     [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    LANE_ID=$(resolve_lane_id)
 fi
 
 # Without a lane_id there is no meaningful heartbeat to write.  Exit 0 so

--- a/.claude/hooks/lib/resolve-lane-id.sh
+++ b/.claude/hooks/lib/resolve-lane-id.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# resolve-lane-id.sh — canonical lane-id resolver for steward hooks.
+#
+# This library centralizes the 19-case lane-id resolution logic that had
+# been duplicated — and had drifted — across seven hook scripts. Before
+# this file, analyst-*, flex-d, brws-author-d, and ops/review lanes were
+# intermittently resolved as "unknown" depending on which hook fired,
+# producing live attribution gaps in the event stream, orchestrator
+# task-completion messages, scope-drift enforcement, and the #2701
+# dispatched-packet PR write-back.
+#
+# Usage (from any hook):
+#     # shellcheck disable=SC1091
+#     . "${CLAUDE_PROJECT_DIR:?}/.claude/hooks/lib/resolve-lane-id.sh"
+#     LANE_ID=$(resolve_lane_id)
+#     [ -z "$LANE_ID" ] && LANE_ID="<caller-specific fallback if any>"
+#
+# Contract:
+#   - Reads $CLAUDE_AGENT_NAME and $CLAUDE_PROJECT_DIR (both optional).
+#   - Prints canonical lane_id to stdout; empty string if the context
+#     cannot be classified.
+#   - No side effects. Safe under `set -euo pipefail`.
+#   - Does NOT apply caller-specific fallbacks (hostname, Bid-Euchre → main,
+#     wildcard sed). Each caller owns its own fallback policy — see
+#     permission-denied-log.sh and permission_denied_alert.sh for the
+#     two known fallback patterns.
+#
+# Performance note:
+#   Pure bash with a sourced function — no `uv run` cold start. This is
+#   deliberate: the lane-heartbeat hook holds a 2s wall-clock budget
+#   (.claude/hooks/lane-heartbeat-post-tool.sh:12-14) that a Python
+#   spawn per tool call would blow.
+#
+# Ordering note:
+#   `*steward-author-scratch)` MUST precede `*steward-author)` because
+#   `*steward-author` glob would otherwise match the scratch suffix.
+#   tests/unit/test_resolve_lane_id.py locks this invariant.
+#
+# Ref: issue #2690
+
+resolve_lane_id() {
+    local lane=""
+    if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
+        lane=$(printf '%s' "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
+    fi
+    if [ -z "$lane" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+        local dir_name
+        dir_name=$(basename "$CLAUDE_PROJECT_DIR" 2>/dev/null || true)
+        case "$dir_name" in
+            *steward-author-scratch) lane="author-scratch" ;;
+            *steward-author-b)       lane="author-b" ;;
+            *steward-author-c)       lane="author-c" ;;
+            *steward-author-d)       lane="author-d" ;;
+            *steward-author)         lane="author-a" ;;
+            *steward-brws-author-a)  lane="brws-author-a" ;;
+            *steward-brws-author-b)  lane="brws-author-b" ;;
+            *steward-brws-author-c)  lane="brws-author-c" ;;
+            *steward-brws-author-d)  lane="brws-author-d" ;;
+            *steward-analyst-b)      lane="analyst-b" ;;
+            *steward-analyst-c)      lane="analyst-c" ;;
+            *steward-analyst-d)      lane="analyst-d" ;;
+            *steward-analyst)        lane="analyst-a" ;;
+            *steward-flex-a)         lane="flex-a" ;;
+            *steward-flex-b)         lane="flex-b" ;;
+            *steward-flex-c)         lane="flex-c" ;;
+            *steward-flex-d)         lane="flex-d" ;;
+            *steward-review)         lane="review" ;;
+            *steward-ops)            lane="ops" ;;
+        esac
+    fi
+    printf '%s' "$lane"
+}

--- a/.claude/hooks/permission-denied-log.sh
+++ b/.claude/hooks/permission-denied-log.sh
@@ -29,36 +29,24 @@ REASON=$(echo "$INPUT" | jq -r '.reason // "no reason provided"' 2>/dev/null || 
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null || echo '{}')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")
 
-# Derive lane name — prefer CLAUDE_AGENT_NAME, fall back to project dir parsing.
-# Use canonical lane IDs (e.g. "author-a" not "author") matching post-merge-notify.sh.
+# Derive lane name via the canonical helper (#2690), then apply the
+# hook-specific "Bid-Euchre → main" / wildcard fallback. The unknown
+# default preserves the old behavior when the project dir is missing.
 LANE="unknown"
-if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
-    LANE=$(echo "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
-elif [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
-    case "$DIR_NAME" in
-        *steward-author-scratch) LANE="author-scratch" ;;
-        *steward-author-b)       LANE="author-b" ;;
-        *steward-author-c)       LANE="author-c" ;;
-        *steward-author-d)       LANE="author-d" ;;
-        *steward-author)         LANE="author-a" ;;
-        *steward-brws-author-a)  LANE="brws-author-a" ;;
-        *steward-brws-author-b)  LANE="brws-author-b" ;;
-        *steward-brws-author-c)  LANE="brws-author-c" ;;
-        *steward-brws-author-d)  LANE="brws-author-d" ;;
-        *steward-analyst-b)      LANE="analyst-b" ;;
-        *steward-analyst-c)      LANE="analyst-c" ;;
-        *steward-analyst-d)      LANE="analyst-d" ;;
-        *steward-analyst)        LANE="analyst-a" ;;
-        *steward-flex-a)         LANE="flex-a" ;;
-        *steward-flex-b)         LANE="flex-b" ;;
-        *steward-flex-c)         LANE="flex-c" ;;
-        *steward-flex-d)         LANE="flex-d" ;;
-        *steward-review)         LANE="review" ;;
-        *steward-ops)            LANE="ops" ;;
-        Bid-Euchre)              LANE="main" ;;
-        *)                       LANE=$(echo "$DIR_NAME" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/') ;;
-    esac
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    RESOLVED=$(resolve_lane_id)
+    if [ -n "$RESOLVED" ]; then
+        LANE="$RESOLVED"
+    elif [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+        DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
+        case "$DIR_NAME" in
+            Bid-Euchre) LANE="main" ;;
+            *)          LANE=$(echo "$DIR_NAME" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/') ;;
+        esac
+    fi
 fi
 
 # Ensure runtime directory exists

--- a/.claude/hooks/post-merge-notify.sh
+++ b/.claude/hooks/post-merge-notify.sh
@@ -68,33 +68,14 @@ if [ -n "$PR_NUM" ]; then
     # Gap C: sentinel is created AFTER successful execution (see below)
 fi
 
-# Resolve lane_id (fallback for Gap B)
+# Resolve lane_id (fallback for Gap B). Sourced helper centralizes the
+# 19-case fleet table — see .claude/hooks/lib/resolve-lane-id.sh (#2690).
 LANE_ID=""
-
-# Try CLAUDE_AGENT_NAME first (e.g., "steward-author-c" -> "author-c")
-if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
-    LANE_ID=$(echo "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
-fi
-
-# Fall back to CLAUDE_PROJECT_DIR directory name parsing
-if [ -z "$LANE_ID" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
-    case "$DIR_NAME" in
-        *steward-author-scratch) LANE_ID="author-scratch" ;;
-        *steward-author-b)       LANE_ID="author-b" ;;
-        *steward-author-c)       LANE_ID="author-c" ;;
-        *steward-author-d)       LANE_ID="author-d" ;;
-        *steward-author)         LANE_ID="author-a" ;;
-        *steward-brws-author-a)  LANE_ID="brws-author-a" ;;
-        *steward-brws-author-b)  LANE_ID="brws-author-b" ;;
-        *steward-brws-author-c)  LANE_ID="brws-author-c" ;;
-        *steward-brws-author-d)  LANE_ID="brws-author-d" ;;
-        *steward-flex-a)         LANE_ID="flex-a" ;;
-        *steward-flex-b)         LANE_ID="flex-b" ;;
-        *steward-flex-c)         LANE_ID="flex-c" ;;
-        *steward-review)         LANE_ID="review" ;;
-        *steward-ops)            LANE_ID="ops" ;;
-    esac
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    LANE_ID=$(resolve_lane_id)
 fi
 
 # ---------------------------------------------------------------------------

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -58,29 +58,14 @@ write_request(req, emit_event=True)
   # Resolve the calling lane the same way post-merge-notify.sh does so
   # the two hooks agree on ownership. Best-effort — a failure here never
   # blocks PR creation.
+  # Canonical resolver — previously missing analyst-* which broke the
+  # #2701 PR write-back for analyst-lane PRs on the auto-merge path.
   LANE_ID=""
-  if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
-    LANE_ID=$(echo "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
-  fi
-  if [ -z "$LANE_ID" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
-    case "$DIR_NAME" in
-      *steward-author-scratch) LANE_ID="author-scratch" ;;
-      *steward-author-b)       LANE_ID="author-b" ;;
-      *steward-author-c)       LANE_ID="author-c" ;;
-      *steward-author-d)       LANE_ID="author-d" ;;
-      *steward-author)         LANE_ID="author-a" ;;
-      *steward-brws-author-a)  LANE_ID="brws-author-a" ;;
-      *steward-brws-author-b)  LANE_ID="brws-author-b" ;;
-      *steward-brws-author-c)  LANE_ID="brws-author-c" ;;
-      *steward-brws-author-d)  LANE_ID="brws-author-d" ;;
-      *steward-flex-a)         LANE_ID="flex-a" ;;
-      *steward-flex-b)         LANE_ID="flex-b" ;;
-      *steward-flex-c)         LANE_ID="flex-c" ;;
-      *steward-flex-d)         LANE_ID="flex-d" ;;
-      *steward-review)         LANE_ID="review" ;;
-      *steward-ops)            LANE_ID="ops" ;;
-    esac
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+     [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    LANE_ID=$(resolve_lane_id)
   fi
 
   if [ -n "$LANE_ID" ]; then

--- a/.claude/hooks/post-task-event.sh
+++ b/.claude/hooks/post-task-event.sh
@@ -21,20 +21,17 @@ if [ "$EXIT_CODE" != "0" ]; then
     exit 0
 fi
 
-# Resolve lane_id from worktree directory name
-# e.g., Bid-Euchre-steward-author-c → author-c
+# Resolve lane_id via the canonical helper (#2690). Previously this hook
+# only handled author-a/b/c/d + review + ops, emitting task_completed
+# events with lane_id="unknown" for every analyst/flex/brws merge —
+# the event stream was structurally blind to >10 fleet lanes.
 LANE_ID="unknown"
-if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR")
-    case "$DIR_NAME" in
-        *steward-author-scratch) LANE_ID="author-scratch" ;;
-        *steward-author-b)       LANE_ID="author-b" ;;
-        *steward-author-c)       LANE_ID="author-c" ;;
-        *steward-author-d)       LANE_ID="author-d" ;;
-        *steward-author)         LANE_ID="author-a" ;;
-        *steward-review)         LANE_ID="review" ;;
-        *steward-ops)            LANE_ID="ops" ;;
-    esac
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    RESOLVED=$(resolve_lane_id)
+    [ -n "$RESOLVED" ] && LANE_ID="$RESOLVED"
 fi
 
 # Check for task-relevant patterns in the command

--- a/.claude/hooks/scope-drift-guard.sh
+++ b/.claude/hooks/scope-drift-guard.sh
@@ -27,27 +27,15 @@ if [[ "$TRIMMED" != "git commit"* ]]; then
   exit 0
 fi
 
-# Determine lane identity
-LANE_ID="${CLAUDE_AGENT_NAME:-}"
-if [ -z "$LANE_ID" ]; then
-  # Fallback: parse from project directory name
-  PROJ_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-  DIR_NAME=$(basename "$PROJ_DIR")
-  case "$DIR_NAME" in
-    *steward-author)    LANE_ID="author-a" ;;
-    *steward-author-b)  LANE_ID="author-b" ;;
-    *steward-author-c)  LANE_ID="author-c" ;;
-    *steward-author-d)  LANE_ID="author-d" ;;
-    *steward-author-scratch) LANE_ID="author-scratch" ;;
-    *brws-author-a)     LANE_ID="brws-author-a" ;;
-    *brws-author-b)     LANE_ID="brws-author-b" ;;
-    *brws-author-c)     LANE_ID="brws-author-c" ;;
-    *brws-author-d)     LANE_ID="brws-author-d" ;;
-    *steward-flex-a)    LANE_ID="flex-a" ;;
-    *steward-flex-b)    LANE_ID="flex-b" ;;
-    *steward-flex-c)    LANE_ID="flex-c" ;;
-    *)                  LANE_ID="" ;;
-  esac
+# Determine lane identity via the canonical helper (#2690). Before this,
+# analyst-*, flex-d, brws-b/c, review, and ops lanes all silently
+# skipped scope enforcement because the case statement fell through.
+LANE_ID=""
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+  # shellcheck disable=SC1091
+  . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+  LANE_ID=$(resolve_lane_id)
 fi
 
 if [ -z "$LANE_ID" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ eggs/
 .eggs/
 lib/
 lib64/
+# Exception: .claude/hooks/lib/ is the steward hook shared-library dir
+# (see .claude/hooks/lib/resolve-lane-id.sh). It is not a Python venv.
+!.claude/hooks/lib/
+!.claude/hooks/lib/**
 parts/
 sdist/
 var/

--- a/scripts/internal/hooks/permission_denied_alert.sh
+++ b/scripts/internal/hooks/permission_denied_alert.sh
@@ -64,33 +64,24 @@ fi
 # ---------------------------------------------------------------------------
 # Step 2 — derive lane id
 # ---------------------------------------------------------------------------
+# Resolve via the canonical helper (#2690) and then apply the
+# caller-specific fallbacks that this hook is responsible for:
+# Bid-Euchre → "main", wildcard sed, and finally hostname. None of
+# those belong in the shared helper because they would silently widen
+# other callers (e.g., lane-heartbeat would start writing to a
+# phantom "main" lane).
 LANE=""
-if [ -n "${CLAUDE_AGENT_NAME:-}" ]; then
-  LANE=$(printf '%s' "$CLAUDE_AGENT_NAME" | sed 's/^steward-//')
-elif [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+  # shellcheck disable=SC1091
+  . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+  LANE=$(resolve_lane_id)
+fi
+if [ -z "$LANE" ] && [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
   DIR_NAME=$(basename "$CLAUDE_PROJECT_DIR" 2>/dev/null || echo "")
   case "$DIR_NAME" in
-    *steward-author-scratch) LANE="author-scratch" ;;
-    *steward-author-b)       LANE="author-b" ;;
-    *steward-author-c)       LANE="author-c" ;;
-    *steward-author-d)       LANE="author-d" ;;
-    *steward-author)         LANE="author-a" ;;
-    *steward-brws-author-a)  LANE="brws-author-a" ;;
-    *steward-brws-author-b)  LANE="brws-author-b" ;;
-    *steward-brws-author-c)  LANE="brws-author-c" ;;
-    *steward-brws-author-d)  LANE="brws-author-d" ;;
-    *steward-analyst-b)      LANE="analyst-b" ;;
-    *steward-analyst-c)      LANE="analyst-c" ;;
-    *steward-analyst-d)      LANE="analyst-d" ;;
-    *steward-analyst)        LANE="analyst-a" ;;
-    *steward-flex-a)         LANE="flex-a" ;;
-    *steward-flex-b)         LANE="flex-b" ;;
-    *steward-flex-c)         LANE="flex-c" ;;
-    *steward-flex-d)         LANE="flex-d" ;;
-    *steward-review)         LANE="review" ;;
-    *steward-ops)            LANE="ops" ;;
-    Bid-Euchre)              LANE="main" ;;
-    *)                       LANE=$(printf '%s' "$DIR_NAME" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/') ;;
+    Bid-Euchre) LANE="main" ;;
+    *)          LANE=$(printf '%s' "$DIR_NAME" | sed 's/^Bid-Euchre-steward-//' | sed 's/^Bid-Euchre/main/') ;;
   esac
 fi
 # Final fallback: hostname. Never let LANE be empty.

--- a/tests/unit/hooks/test_permission_denied_alert.py
+++ b/tests/unit/hooks/test_permission_denied_alert.py
@@ -31,6 +31,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[3]
 HOOK_SH = REPO_ROOT / "scripts" / "internal" / "hooks" / "permission_denied_alert.sh"
 FIXTURE = REPO_ROOT / "tests" / "fixtures" / "classifier_denial_sample.json"
+RESOLVE_LANE_LIB = REPO_ROOT / ".claude" / "hooks" / "lib" / "resolve-lane-id.sh"
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +105,12 @@ def _run_hook(
     """
     project_dir = project_dir or tmp_path / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
+    # Stage the canonical lane-id resolver library under the tmp project
+    # dir so the hook can source it the same way it does in production
+    # (#2690 — resolver previously lived inline in each hook).
+    lib_dst = project_dir / ".claude" / "hooks" / "lib" / "resolve-lane-id.sh"
+    lib_dst.parent.mkdir(parents=True, exist_ok=True)
+    lib_dst.write_text(RESOLVE_LANE_LIB.read_text(encoding="utf-8"), encoding="utf-8")
     bin_dir = tmp_path / "bin"
     uv_capture = tmp_path / "uv_argv.log"
     _write_mock_uv(bin_dir, uv_capture)

--- a/tests/unit/hooks/test_resolve_lane_id.py
+++ b/tests/unit/hooks/test_resolve_lane_id.py
@@ -1,0 +1,275 @@
+"""Unit tests for .claude/hooks/lib/resolve-lane-id.sh.
+
+The resolver is a pure-bash sourced function that centralizes the
+19-case fleet lane-id table previously duplicated across seven hook
+scripts (#2690). These tests exercise every canonical fleet lane,
+the CLAUDE_AGENT_NAME precedence rule, the case-pattern ordering
+invariant (author-scratch before author), and the empty/unknown
+fallback contract.
+
+The tests invoke bash directly — no `uv run` — to match the hook
+execution environment, where the heartbeat hook's 2s budget forbids
+Python cold starts.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB_SH = REPO_ROOT / ".claude" / "hooks" / "lib" / "resolve-lane-id.sh"
+
+
+# ---------------------------------------------------------------------------
+# Helper — run the sourced function in a clean bash subprocess
+# ---------------------------------------------------------------------------
+
+
+def _resolve(
+    *,
+    agent_name: str | None = None,
+    project_dir: str | None = None,
+    strict: bool = True,
+) -> str:
+    """Source the library in a fresh bash shell and call resolve_lane_id.
+
+    `strict=True` matches the six hooks that run with `set -euo pipefail`
+    so we prove the helper is strict-mode safe.
+    """
+    env: dict[str, str] = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    if agent_name is not None:
+        env["CLAUDE_AGENT_NAME"] = agent_name
+    if project_dir is not None:
+        env["CLAUDE_PROJECT_DIR"] = project_dir
+
+    strict_prefix = "set -euo pipefail\n" if strict else ""
+    script = f"{strict_prefix}. {LIB_SH}\nresolve_lane_id\n"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert (
+        result.returncode == 0
+    ), f"resolve_lane_id exited {result.returncode}: stderr={result.stderr!r}"
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the library file exists and is syntactically valid
+# ---------------------------------------------------------------------------
+
+
+def test_lib_file_exists() -> None:
+    assert LIB_SH.is_file(), f"Missing library: {LIB_SH}"
+
+
+def test_lib_passes_bash_syntax_check() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(LIB_SH)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_AGENT_NAME path — simple prefix strip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "agent_name,expected",
+    [
+        ("steward-author-a", "author-a"),
+        ("steward-author-b", "author-b"),
+        ("steward-author-c", "author-c"),
+        ("steward-author-d", "author-d"),
+        ("steward-analyst-c", "analyst-c"),
+        ("steward-flex-d", "flex-d"),
+        ("steward-brws-author-d", "brws-author-d"),
+        ("steward-review", "review"),
+        ("steward-ops", "ops"),
+        # No steward- prefix → passthrough (unusual, but the contract
+        # is "strip the prefix if present", not "validate the value").
+        ("orchestrator", "orchestrator"),
+    ],
+)
+def test_agent_name_strip(agent_name: str, expected: str) -> None:
+    assert _resolve(agent_name=agent_name) == expected
+
+
+def test_agent_name_takes_precedence_over_project_dir() -> None:
+    """When both env vars are set, AGENT_NAME wins."""
+    out = _resolve(
+        agent_name="steward-flex-a",
+        project_dir="/x/y/Bid-Euchre-steward-author-d",
+    )
+    assert out == "flex-a"
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_PROJECT_DIR fallback — full fleet coverage
+# ---------------------------------------------------------------------------
+
+
+CANONICAL_LANES = [
+    # (worktree dir basename, expected lane_id)
+    ("Bid-Euchre-steward-author", "author-a"),
+    ("Bid-Euchre-steward-author-b", "author-b"),
+    ("Bid-Euchre-steward-author-c", "author-c"),
+    ("Bid-Euchre-steward-author-d", "author-d"),
+    ("Bid-Euchre-steward-author-scratch", "author-scratch"),
+    ("Bid-Euchre-steward-brws-author-a", "brws-author-a"),
+    ("Bid-Euchre-steward-brws-author-b", "brws-author-b"),
+    ("Bid-Euchre-steward-brws-author-c", "brws-author-c"),
+    ("Bid-Euchre-steward-brws-author-d", "brws-author-d"),
+    ("Bid-Euchre-steward-analyst", "analyst-a"),
+    ("Bid-Euchre-steward-analyst-b", "analyst-b"),
+    ("Bid-Euchre-steward-analyst-c", "analyst-c"),
+    ("Bid-Euchre-steward-analyst-d", "analyst-d"),
+    ("Bid-Euchre-steward-flex-a", "flex-a"),
+    ("Bid-Euchre-steward-flex-b", "flex-b"),
+    ("Bid-Euchre-steward-flex-c", "flex-c"),
+    ("Bid-Euchre-steward-flex-d", "flex-d"),
+    ("Bid-Euchre-steward-review", "review"),
+    ("Bid-Euchre-steward-ops", "ops"),
+]
+
+
+@pytest.mark.parametrize("basename,expected", CANONICAL_LANES)
+def test_project_dir_all_canonical_lanes(
+    tmp_path: Path, basename: str, expected: str
+) -> None:
+    project = tmp_path / basename
+    project.mkdir()
+    assert _resolve(project_dir=str(project)) == expected
+
+
+def test_project_dir_works_with_absolute_path_prefix(tmp_path: Path) -> None:
+    """Patterns use `*steward-...)` glob so any path prefix matches."""
+    deep = tmp_path / "Projects" / "Meta" / "Bid-Euchre-steward-analyst-c"
+    deep.mkdir(parents=True)
+    assert _resolve(project_dir=str(deep)) == "analyst-c"
+
+
+def test_project_dir_when_basename_alone_matches() -> None:
+    """Even a bare basename (no leading dirs) must match."""
+    # Use a real path for basename() to work — /tmp is safe.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = Path(tmp) / "Bid-Euchre-steward-ops"
+        proj.mkdir()
+        assert _resolve(project_dir=str(proj)) == "ops"
+
+
+def test_author_scratch_ordering_does_not_collide_with_author() -> None:
+    """`*steward-author-scratch)` must precede `*steward-author)`.
+
+    Without correct ordering, `Bid-Euchre-steward-author-scratch` would
+    match `*steward-author)` first (since both globs apply) and resolve
+    to "author-a". This test locks the invariant documented in the
+    library preamble.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = Path(tmp) / "Bid-Euchre-steward-author-scratch"
+        proj.mkdir()
+        assert _resolve(project_dir=str(proj)) == "author-scratch"
+
+
+# ---------------------------------------------------------------------------
+# Unknown / empty contract
+# ---------------------------------------------------------------------------
+
+
+def test_neither_env_var_set_returns_empty() -> None:
+    """Contract: unresolved context returns empty string, not 'unknown'.
+
+    Each caller owns its own fallback policy (hostname, "unknown",
+    "main", etc.). This keeps the helper unopinionated.
+    """
+    assert _resolve() == ""
+
+
+def test_unknown_dir_returns_empty(tmp_path: Path) -> None:
+    """Dir names that don't match the fleet table return empty."""
+    proj = tmp_path / "Bid-Euchre"
+    proj.mkdir()
+    assert _resolve(project_dir=str(proj)) == ""
+
+    proj2 = tmp_path / "Bid-Euchre-foo"
+    proj2.mkdir()
+    assert _resolve(project_dir=str(proj2)) == ""
+
+    proj3 = tmp_path / "some-other-repo"
+    proj3.mkdir()
+    assert _resolve(project_dir=str(proj3)) == ""
+
+
+def test_empty_agent_name_falls_through_to_project_dir(tmp_path: Path) -> None:
+    """AGENT_NAME="" must not short-circuit — project_dir should still resolve."""
+    proj = tmp_path / "Bid-Euchre-steward-flex-b"
+    proj.mkdir()
+    assert _resolve(agent_name="", project_dir=str(proj)) == "flex-b"
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode safety — six of seven callers run with set -euo pipefail
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_safe_under_strict_mode(tmp_path: Path) -> None:
+    """Caller hooks use `set -euo pipefail`; helper must not trip it."""
+    proj = tmp_path / "Bid-Euchre-steward-review"
+    proj.mkdir()
+    # Already strict=True by default, but be explicit to document intent.
+    assert _resolve(project_dir=str(proj), strict=True) == "review"
+
+
+def test_resolver_strict_mode_with_no_env() -> None:
+    """Empty resolution path must also be strict-mode safe."""
+    assert _resolve(strict=True) == ""
+
+
+# ---------------------------------------------------------------------------
+# Single-source-of-truth invariant
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicate_steward_case_statement_in_callers() -> None:
+    """After consolidation, no hook in the caller set should carry a
+    duplicate `*steward-author-d)` case pattern.
+
+    This guards against someone re-introducing a drifted copy. The
+    canonical pattern appears exactly once: in resolve-lane-id.sh.
+    """
+    callers = [
+        REPO_ROOT / ".claude" / "hooks" / "post-merge-notify.sh",
+        REPO_ROOT / ".claude" / "hooks" / "lane-heartbeat-post-tool.sh",
+        REPO_ROOT / ".claude" / "hooks" / "post-pr-review.sh",
+        REPO_ROOT / ".claude" / "hooks" / "permission-denied-log.sh",
+        REPO_ROOT / ".claude" / "hooks" / "scope-drift-guard.sh",
+        REPO_ROOT / ".claude" / "hooks" / "post-task-event.sh",
+        REPO_ROOT / "scripts" / "internal" / "hooks" / "permission_denied_alert.sh",
+    ]
+    for caller in callers:
+        assert caller.is_file(), f"Missing caller: {caller}"
+        text = caller.read_text(encoding="utf-8")
+        # The signature pattern that appeared in every duplicate block.
+        # After migration, this pattern lives only in the library.
+        assert "*steward-author-d)" not in text, (
+            f"{caller.name} still carries a duplicate lane-id case "
+            f"statement — source lib/resolve-lane-id.sh instead."
+        )


### PR DESCRIPTION
## Summary

Extract the 19-case fleet lane-id resolver into
`.claude/hooks/lib/resolve-lane-id.sh` (pure-bash, sourced). Seven hook
scripts carried drifted copies of the same case statement, producing
silent attribution gaps for analyst/flex/brws/review/ops lanes.

## Why

`analyst-c`'s shaping on #2690 showed that triage's 3-duplicate count
under-counted: seven hooks had the case statement, and their drift
was breaking live correctness (not just style):

| Hook | Was missing |
|------|-------------|
| `post-merge-notify.sh` | analyst-*, flex-d, brws-author-d — merges came through as `from_lane='unknown'` |
| `post-pr-review.sh` | analyst-* — #2701 PR write-back never fired for analyst lanes on auto-merge |
| `post-task-event.sh` | all of analyst-*, flex-*, brws-* — event stream structurally blind to 10+ lanes |
| `scope-drift-guard.sh` | analyst-*, flex-d, brws-b/c/d, review, ops — scope enforcement silently skipped |
| `lane-heartbeat-post-tool.sh` | wildcard fallback (already covered by #2686) |
| `permission-denied-log.sh` | consolidated with existing fallbacks preserved |
| `scripts/internal/hooks/permission_denied_alert.sh` | already complete; keeps its `Bid-Euchre → main` + hostname fallbacks inline |

Adding a new lane now edits one file.

## Design

- **Pure bash, sourced function** — the `lane-heartbeat-post-tool.sh`
  hook holds a 2s wall-clock budget; a `uv run` per hook invocation
  would blow it.
- **Strict exact match only** — `Bid-Euchre → main`, hostname
  fallback, and wildcard sed remain inline at callers that need them.
  Pulling them into the shared helper would silently widen behavior
  for the other five callers.
- **Contract** — returns canonical lane_id or empty string; caller
  owns its own fallback policy (`unknown`, hostname, `main`).
- **Single source path via `$CLAUDE_PROJECT_DIR`** — works for both
  `.claude/hooks/**` and `scripts/internal/hooks/**` call sites.
- **Case-ordering invariant** — `*steward-author-scratch)` precedes
  `*steward-author)`. Locked by test.

## Behavior changes (all corrections)

Four hooks now resolve lanes they previously silently ignored:

1. `post-merge-notify.sh` — analyst merges now carry `from_lane` →
   completion messages route correctly.
2. `post-pr-review.sh` — #2701 PR write-back now fires for analyst
   lanes on auto-merge.
3. `post-task-event.sh` — `task_completed` events now carry real
   lane_ids for analyst/flex/brws lanes (was `"unknown"`).
4. `scope-drift-guard.sh` — scope enforcement now fires for
   analyst-*, flex-d, brws-b/c/d, review, ops (was exit-0 skip).

Downstream consumers (message bus, reconcile_dispatched_packets,
events stream, scope enforcement) already accept any fleet lane.
A grep for `lane_id == "unknown"` turned up no consumer filters.

## .gitignore

The global `lib/` rule (Python venvs) was masking the new hook
library directory. Added explicit negation so `.claude/hooks/lib/`
is tracked without broadening the venv ignore.

## Test plan

- [x] `uv run python -m pytest tests/unit/hooks/test_resolve_lane_id.py -v` → 41 tests, all green
- [x] `uv run python -m pytest tests/unit/hooks/` → 52 tests, all green (includes updated permission_denied_alert fixture that stages the lib under tmp project dir)
- [x] `bash -n` on every modified hook passes syntax
- [x] Smoke: `CLAUDE_PROJECT_DIR=/tmp/Bid-Euchre-steward-analyst-c bash -c '. .claude/hooks/lib/resolve-lane-id.sh && resolve_lane_id'` → `analyst-c`
- [x] `make check-gated` passes
- [x] Test locks single-source-of-truth: no caller can re-introduce `*steward-author-d)` without failing `test_no_duplicate_steward_case_statement_in_callers`

## Worktree proof

```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/2690-consolidate-lane-id-resolver
lane: author-d
```

## Closure

Fixes #2690 (Tier 1 — bounded refactor, fully locked by CI)

## Coordination

No other PR touches `.claude/hooks/**` or `scripts/internal/hooks/**`.
#2689 (lane-heartbeat pure-shell rewrite) is still open but has not
landed on main; on re-check the referenced coordination overlap with
`lane-heartbeat-post-tool.sh` is on different logic (JSON build vs.
the lane-id case statement). This PR's single-file lib sourcing is
orthogonal to the heartbeat rewrite and should rebase cleanly if
#2689 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)