### PR TITLE
feat(ops): cut dashboard + idle_detector over to heartbeat classifier (fixes #2415)

### DIFF
--- a/.claude/skills/lane-status/SKILL.md
+++ b/.claude/skills/lane-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lane-status
-description: Correctly assess the working state of all steward lanes by reading tmux pane content, worktree state, and PR status together. Use before making dispatch or nudge decisions.
+description: Correctly assess the working state of all steward lanes by reading the heartbeat signal, process tree, pane content, worktree state, and PR status together. Use before making dispatch or nudge decisions.
 ---
 
 # /lane-status — Lane State Assessment
@@ -13,7 +13,13 @@ decisions (dispatch, nudge, recovery, or reporting).
 The tmux status bar at the bottom of each pane ALWAYS shows the idle `❯`
 prompt, token count, and model info — even when the session is actively
 working. Reading only the last few lines of a pane capture will
-systematically misclassify active lanes as idle. This skill prevents that.
+systematically misclassify active lanes as idle.
+
+The heartbeat hook (PR #2686) and `lane status` CLI (PR #2695) now give a
+more reliable first read than the pane-capture heuristic. This skill
+documents both the quickest CLI path and the manual multi-signal fallback
+that remains load-bearing for approval-prompt detection and the rare
+edge cases the CLI cannot resolve on its own.
 
 ## Quickest path — heartbeat-aware CLI
 
@@ -36,23 +42,64 @@ uv run python scripts/internal/ops.py lane status --all --no-process-tree
 
 The CLI renders a fixed-width table with columns `LANE`, `PHASE`, `FRESH`,
 `LAST_TOOL`, `SUMMARY`, where `PHASE` ∈ `{active, likely_active, stale,
-blocked, idle, unknown}`. It is powered by Signal 0 (the heartbeat file at
+blocked, idle, unknown}`. It is powered by Signal 1 (the heartbeat file at
 `<worktree>/.claude/runtime/lane_status/<lane>.json` written by the PR
-#2686 PostToolUse hook) plus a process-tree reconciler that upgrades
-`stale`/`idle` to `likely_active` when a live tmux pane or `claude` child
-process is detected.
+#2686 PostToolUse hook) plus a process-tree reconciler (Signal 2) that
+upgrades `stale`/`idle` to `likely_active` when a live tmux pane or
+`claude` child process is detected.
 
-The manual 3-signal procedure below is still correct for edge cases:
+The `ops.py dashboard` surface (PR 3/3 #2415) renders the heartbeat age
+inline for each lane. Use it for a single-screen fleet overview; use
+`lane status` for the authoritative per-lane determination.
+
+The manual multi-signal procedure below is still correct for edge cases:
 classifying approval-blocked lanes, deciding whether a dirty worktree
 represents active work or a stall, or cross-checking when a lane reports
 `stale` but you suspect the pre-#2686 heartbeat blind spot (sessions that
 launched before 2026-04-21).
 
-## Assessment Procedure (manual, 3-signal)
+## Assessment Procedure (manual, 5-signal)
 
-For each lane, gather THREE signals and cross-reference them:
+Gather the signals below in priority order and cross-reference them.
+Signals 1 and 2 are the primary determinants; Signals 3–5 remain
+load-bearing for approval detection, stall disambiguation, and
+completion verification.
 
-### Signal 1: Pane Content (full scan)
+### Signal 1: Heartbeat (PR #2686)
+
+```bash
+# Read the heartbeat file for a lane
+cat <worktree>/.claude/runtime/lane_status/<lane>.json 2>/dev/null
+```
+
+The JSON records `updated_at`, `last_tool`, and `phase`. A heartbeat
+within the freshness threshold (default 120s) is the strongest signal
+that a lane is actively executing tool calls.
+
+| Age | Interpretation |
+|-----|---------------|
+| ≤120s | **WORKING** — PostToolUse hook fired recently |
+| 120s–30m | **STALE** — lane may have crashed or is blocked on a long subprocess |
+| >30m or missing | **LEGACY / IDLE** — no heartbeat signal; fall through to Signals 2–5 |
+
+Missing heartbeat does not imply idle: lanes launched before 2026-04-21
+may not have the hook registered. Always cross-reference with Signal 2.
+
+### Signal 2: Process tree
+
+```bash
+# Check for active validation processes in the lane's worktree
+pgrep -f "pytest|make|ruff" 2>/dev/null
+# Or consult the ops CLI, which does this with proper pane targeting:
+uv run python scripts/internal/ops.py lane status <lane-id>
+```
+
+A live `pytest`, `make`, or `ruff` process under the lane's tmux pane
+shell is definitive evidence the lane is working even when the
+heartbeat is stale (heartbeat cadence is bounded by Claude's tool-call
+loop, which pauses during long subprocess waits).
+
+### Signal 3: Pane content (full scan)
 
 Capture enough of the pane to see the working area, not just the status bar:
 
@@ -61,6 +108,10 @@ tmux capture-pane -t steward:<window>.<pane> -p -S -40 2>/dev/null
 ```
 
 The `-S -40` flag captures the last 40 lines (above the status bar).
+
+Pane scanning remains the **only** reliable signal for approval-blocked
+lanes — permission prompts appear on the pane but do not emit heartbeat
+ticks or process-tree evidence.
 
 **Active-work indicators** (if ANY of these are present, the lane is WORKING):
 - Spinner glyphs: `✶` `✻` `✽` `✢` `⏺` `✳`
@@ -77,13 +128,13 @@ The `-S -40` flag captures the last 40 lines (above the status bar).
 - Or the pane shows a completed summary like `✻ Sautéed for Xm Ys` with
   NO subsequent tool call or spinner
 
-**Approval-blocked indicators:**
+**Approval-blocked indicators** (primary use of Signal 3):
 - `Allow ` followed by a tool name
 - `[A]llow once` / `[Y]es, always` / `[N]o`
 - `Permission required`
 - `Do you want to`
 
-### Signal 2: Worktree State
+### Signal 4: Worktree state
 
 ```bash
 git -C <worktree_path> status --short | wc -l    # dirty file count
@@ -97,7 +148,7 @@ git -C <worktree_path> log --oneline origin/main..HEAD | wc -l  # commits ahead
 | >0 | >0 | Has commits + more uncommitted changes — actively working |
 | 0 | >0 | Committed but not pushed — may be about to push/PR |
 
-### Signal 3: PR Status
+### Signal 5: PR status
 
 ```bash
 # Check if the lane's branch has an open PR
@@ -107,15 +158,20 @@ gh pr list --state open --head <branch_name> --json number,title
 
 ### Cross-Reference Matrix
 
-| Pane | Worktree | PR | True State | Action |
-|------|----------|-----|------------|--------|
-| Active spinner | Any | Any | **WORKING** | Do nothing |
-| Idle | Clean (0/0) | None | **IDLE** — ready for dispatch | Safe to dispatch |
-| Idle | Dirty (>0/0) | None | **STALLED** — finished but didn't commit | Nudge to commit |
-| Idle | Ahead (0/>0) | None | **STALLED** — committed but didn't PR | Nudge to push+PR |
-| Idle | Ahead (0/>0) | Open | **DONE** — PR is open | Complete the packet |
-| Idle | Clean (0/0) | Merged | **DONE** — PR merged | Complete packet, lane is free |
-| Approval prompt | Any | Any | **BLOCKED** — needs user | Alert user immediately |
+Signals are listed in priority order; the leftmost non-empty column
+determines the classification.
+
+| Heartbeat | Process tree | Pane | Worktree | PR | True State | Action |
+|-----------|-------------|------|----------|-----|------------|--------|
+| Fresh (≤120s) | — | — | — | — | **WORKING** | Do nothing |
+| Stale / missing | `pytest\|make\|ruff` match | — | — | — | **VALIDATING** | Do nothing — let validation finish |
+| Stale / missing | — | Active spinner | — | — | **WORKING** | Do nothing |
+| Stale / missing | — | Idle | Clean (0/0) | None | **IDLE** — ready for dispatch | Safe to dispatch |
+| Stale / missing | — | Idle | Dirty (>0/0) | None | **STALLED** — finished but didn't commit | Nudge to commit |
+| Stale / missing | — | Idle | Ahead (0/>0) | None | **STALLED** — committed but didn't PR | Nudge to push+PR |
+| — | — | Idle | Ahead (0/>0) | Open | **DONE** — PR is open | Complete the packet |
+| — | — | Idle | Clean (0/0) | Merged | **DONE** — PR merged | Complete packet, lane is free |
+| — | — | Approval prompt | Any | Any | **BLOCKED** — needs user | Alert user immediately |
 
 ## Pane Map
 
@@ -139,7 +195,14 @@ gh pr list --state open --head <branch_name> --json number,title
 
 ## Quick All-Lanes Check
 
-Run this to get a fast overview of all dispatched lanes:
+The CLI replaces the pane-capture loop for the common case:
+
+```bash
+uv run python scripts/internal/ops.py lane status --all
+```
+
+If you need the legacy pane+worktree dump (e.g., approval-prompt sweep),
+the loop below is still supported:
 
 ```bash
 # For each dispatched lane, check pane + worktree in one pass
@@ -165,7 +228,10 @@ done
 - ❌ Assuming idle prompt = lane is idle (status bar always shows `❯`)
 - ❌ Nudging a lane that's mid-`make check-gated` (interrupts validation)
 - ❌ Treating "Sautéed for Xm" as idle without checking if a new tool call follows
-- ❌ Checking worktree state without checking pane state (dirty could mean mid-work)
+- ❌ Checking worktree state without checking Signals 1–3 (dirty could mean mid-work)
+- ❌ Treating a stale heartbeat as idle without checking the process tree — a long
+  `make check-quiet` run will pause tool calls and let the heartbeat age past the
+  default 120s threshold without the lane actually stalling
 
 ## When to Use
 

--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from bid_euchre.ops.lane_heartbeat import read_heartbeat
 from bid_euchre.ops.status import (
     LaneStatus,
     StatusReport,
@@ -40,6 +41,59 @@ from bid_euchre.ops.status import (
 )
 
 logger = logging.getLogger("ops.dashboard")
+
+
+def _format_age(seconds: int | None) -> str:
+    """Format an age in seconds compactly (``45s``, ``3m12s``, ``1h2m``).
+
+    Mirrors :func:`scripts.internal.ops._format_age` — kept local to avoid
+    reaching into the CLI module from the library.  Keep the two in sync.
+    """
+    if seconds is None:
+        return "\u2014"  # em dash
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        m, s = divmod(seconds, 60)
+        return f"{m}m{s}s"
+    h, rem = divmod(seconds, 3600)
+    m = rem // 60
+    return f"{h}h{m}m"
+
+
+def _heartbeat_age_seconds(lane: LaneStatus, now: datetime) -> int | None:
+    """Return the age of the lane's heartbeat in seconds, or ``None``.
+
+    Reads the heartbeat file at
+    ``<lane.worktree_path>/.claude/runtime/lane_status/<lane.lane_id>.json``.
+    A missing file, malformed JSON, or unparseable timestamp yields
+    ``None`` so the caller can fall back to the legacy render path
+    without raising.
+    """
+    worktree_path = lane.worktree_path
+    if not worktree_path:
+        return None
+    heartbeat_dir = Path(worktree_path) / ".claude" / "runtime" / "lane_status"
+    try:
+        hb = read_heartbeat(lane.lane_id, runtime_dir=heartbeat_dir)
+    except Exception:  # pragma: no cover — defensive
+        return None
+    if hb is None:
+        return None
+    try:
+        updated = datetime.fromisoformat(hb.updated_at.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if updated.tzinfo is None:
+        updated = updated.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    age = (now - updated).total_seconds()
+    if age < 0:
+        return 0
+    return int(age)
+
 
 # ---------------------------------------------------------------------------
 # Default visibility policy
@@ -524,6 +578,9 @@ def _format_lane_line(
     Returns:
         Formatted line string.
     """
+    # Normalize ``now`` so helpers receive a concrete datetime.
+    effective_now = now if now is not None else datetime.now(timezone.utc)
+
     # State badge
     if lane.attention_needed:
         state_badge = f"[{lane.state}!]"
@@ -539,8 +596,16 @@ def _format_lane_line(
         task_info = lane.session_task
     elif lane.state == "likely_active" and lane.liveness_source:
         task_info = f"likely active (via {lane.liveness_source})"
+        if lane.liveness_source == "heartbeat":
+            age_s = _heartbeat_age_seconds(lane, effective_now)
+            if age_s is not None:
+                task_info = f"likely active (via heartbeat, {_format_age(age_s)} ago)"
     elif lane.state == "stale" and lane.liveness_source:
         task_info = f"stale (via {lane.liveness_source})"
+        if lane.liveness_source == "heartbeat":
+            age_s = _heartbeat_age_seconds(lane, effective_now)
+            if age_s is not None:
+                task_info = f"stale (via heartbeat, {_format_age(age_s)} ago)"
     elif lane.session_task:
         task_info = f"idle, last: {lane.session_task}"
     else:

--- a/src/bid_euchre/ops/idle_detector.py
+++ b/src/bid_euchre/ops/idle_detector.py
@@ -27,6 +27,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from bid_euchre.ops.events import append_event, read_events
+from bid_euchre.ops.lane_heartbeat import (
+    DEFAULT_FRESHNESS_SECONDS,
+    is_fresh,
+    read_heartbeat,
+)
 
 logger = logging.getLogger("ops.idle_detector")
 
@@ -111,14 +116,58 @@ def _find_last_meaningful_event(
     return None
 
 
+def _resolve_heartbeat_dir_for_lane(
+    worktree_path: str | None,
+    runtime_dir: Path | None,
+) -> Path | None:
+    """Resolve the ``lane_status`` directory for a registered lane.
+
+    Mirrors :func:`bid_euchre.ops.status._resolve_heartbeat_dir` precedence
+    so the idle detector reads heartbeats from exactly the location PR
+    #2686's hook writes them.  See that function's docstring for the full
+    contract; this local copy exists to avoid importing the heavy status
+    module from the lightweight idle detector.
+
+    Precedence:
+
+    1. ``<worktree_path>/.claude/runtime/lane_status`` — cross-worktree
+       reads when the registry records a lane's worktree root.
+    2. ``<runtime_dir>/lane_status`` — self-read / test fallback.
+    3. ``None`` — let :func:`read_heartbeat` use its own CWD default.
+    """
+    if worktree_path:
+        return Path(worktree_path) / ".claude" / "runtime" / "lane_status"
+    if runtime_dir is not None:
+        return runtime_dir / "lane_status"
+    return None
+
+
 def _get_active_lane_ids(
     runtime_dir: Path | None = None,
+    *,
+    now: datetime | None = None,
+    threshold_seconds: int = DEFAULT_FRESHNESS_SECONDS,
 ) -> list[str]:
     """Return lane IDs that are currently active.
 
-    Uses a lightweight check: reads the worktree registry for lanes with
-    an active session_id.  This avoids importing the full status module's
-    heavy aggregation machinery.
+    A lane counts as active when **either** of the following holds and the
+    lane is not on the :data:`CONTROL_PLANE_LANES` exclusion list:
+
+    - The worktree registry records a non-empty ``session_id`` for the
+      lane (legacy behavior).
+    - The lane has a fresh heartbeat file at
+      ``<worktree_path>/.claude/runtime/lane_status/<lane_id>.json``
+      written within ``threshold_seconds`` (issue #2415 failure-mode F1:
+      ``make check-quiet`` runs drop ``session_id`` to null for the
+      duration, but the PostToolUse hook keeps the heartbeat fresh).
+
+    Control-plane lanes (``orchestrator``, ``ops``, ``review``) are
+    excluded from both signals — a fresh orchestrator heartbeat does not
+    keep the fleet from auto-shutoff.
+
+    Heartbeat reads are bounded O(lanes); no subprocesses are spawned.
+    A missing or malformed heartbeat falls back to the legacy
+    ``session_id``-only semantics.
     """
     if runtime_dir is None:
         runtime_dir = Path(".claude/runtime")
@@ -136,8 +185,27 @@ def _get_active_lane_ids(
         except (OSError, ValueError):
             continue
         lane_id = data.get("lane_id", "")
+        if not lane_id or lane_id in CONTROL_PLANE_LANES:
+            continue
+
         session_id = data.get("session_id")
-        if session_id and lane_id and lane_id not in CONTROL_PLANE_LANES:
+        if session_id:
+            active.append(lane_id)
+            continue
+
+        # Session is cleared (either never set or dropped during a
+        # subprocess run) — consult the heartbeat before declaring the
+        # lane idle.  Registry ``worktree_path`` points the reader at the
+        # lane's own ``.claude/runtime/lane_status/`` directory.
+        worktree_path = data.get("worktree_path")
+        heartbeat_dir = _resolve_heartbeat_dir_for_lane(worktree_path, runtime_dir)
+        if heartbeat_dir is None:
+            continue
+        try:
+            hb = read_heartbeat(lane_id, runtime_dir=heartbeat_dir)
+        except Exception:  # pragma: no cover — defensive
+            continue
+        if is_fresh(hb, threshold_seconds=threshold_seconds, now=now):
             active.append(lane_id)
 
     return active
@@ -173,8 +241,11 @@ def is_fleet_idle(
     # 1. Find the last meaningful event
     last_event_ts = _find_last_meaningful_event(events_dir)
 
-    # 2. Check for currently active lanes
-    active_lanes = _get_active_lane_ids(runtime_dir)
+    # 2. Check for currently active lanes.  ``now`` is threaded through
+    #    so heartbeat freshness is evaluated against the same clock the
+    #    caller supplied (critical for deterministic tests and for
+    #    consistent "idle_minutes" accounting).
+    active_lanes = _get_active_lane_ids(runtime_dir, now=now)
 
     # If any lane is actively running, the fleet is not idle
     if active_lanes:

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -1293,3 +1293,128 @@ class TestDashboardByModelPanel:
         # Token economy section exists and exposes by_model.
         assert "token_economy" in round_tripped
         assert "by_model" in round_tripped["token_economy"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _format_lane_line heartbeat-age rendering (issue #2415 PR 3/3)
+# ---------------------------------------------------------------------------
+
+
+from bid_euchre.ops.dashboard import _format_lane_line  # noqa: E402
+
+
+def _make_heartbeat_lane(
+    lane_id: str,
+    *,
+    worktree_path: Path,
+    state: str,
+    liveness_source: str | None,
+) -> LaneStatus:
+    """Build a LaneStatus whose worktree_path points at a real directory."""
+    return LaneStatus(
+        lane_id=lane_id,
+        lane_class="author",
+        worktree_path=str(worktree_path),
+        branch="feat/demo",
+        lifecycle_class="persistent",
+        has_active_session=False,
+        state=state,
+        liveness_source=liveness_source,
+    )
+
+
+def _write_hb(
+    worktree_path: Path,
+    lane_id: str,
+    *,
+    updated_at: datetime,
+) -> None:
+    heartbeat_dir = worktree_path / ".claude" / "runtime" / "lane_status"
+    heartbeat_dir.mkdir(parents=True, exist_ok=True)
+    ts = updated_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {
+        "schema_version": 1,
+        "lane_id": lane_id,
+        "pid": 4242,
+        "session_id": None,
+        "updated_at": ts,
+        "last_tool": "Bash",
+        "phase": None,
+        "extras": {},
+    }
+    (heartbeat_dir / f"{lane_id}.json").write_text(json.dumps(payload, sort_keys=True))
+
+
+class TestFormatLaneLineHeartbeat:
+    """Heartbeat-age rendering in ``_format_lane_line`` (issue #2415 PR 3/3)."""
+
+    def test_no_heartbeat_events_source_unchanged(self, tmp_path: Path) -> None:
+        """Parity: non-heartbeat liveness sources render the legacy string."""
+        lane = _make_heartbeat_lane(
+            "author-a",
+            worktree_path=tmp_path,
+            state="likely_active",
+            liveness_source="events",
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        line = _format_lane_line(lane, now=now)
+        assert "likely active (via events)" in line
+        assert "heartbeat" not in line
+
+    def test_heartbeat_likely_active_includes_age(self, tmp_path: Path) -> None:
+        """Fresh heartbeat: render ``likely active (via heartbeat, 15s ago)``."""
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_hb(tmp_path, "author-a", updated_at=now - timedelta(seconds=15))
+        lane = _make_heartbeat_lane(
+            "author-a",
+            worktree_path=tmp_path,
+            state="likely_active",
+            liveness_source="heartbeat",
+        )
+        line = _format_lane_line(lane, now=now)
+        assert "likely active (via heartbeat, 15s ago)" in line
+
+    def test_heartbeat_stale_includes_age(self, tmp_path: Path) -> None:
+        """Stale-state heartbeat still renders the age, not just the source."""
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_hb(tmp_path, "author-a", updated_at=now - timedelta(minutes=5))
+        lane = _make_heartbeat_lane(
+            "author-a",
+            worktree_path=tmp_path,
+            state="stale",
+            liveness_source="heartbeat",
+        )
+        line = _format_lane_line(lane, now=now)
+        # 5m = 300s → "5m0s ago"
+        assert "stale (via heartbeat, 5m0s ago)" in line
+
+    def test_heartbeat_missing_falls_back_gracefully(self, tmp_path: Path) -> None:
+        """Missing heartbeat file: no traceback; fall back to ``via heartbeat``."""
+        # No heartbeat written — directory exists but no JSON file.
+        lane = _make_heartbeat_lane(
+            "author-a",
+            worktree_path=tmp_path,
+            state="likely_active",
+            liveness_source="heartbeat",
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        line = _format_lane_line(lane, now=now)
+        assert "likely active (via heartbeat)" in line
+        # Must not include an age token.
+        assert "ago" not in line
+
+    def test_heartbeat_malformed_falls_back_gracefully(self, tmp_path: Path) -> None:
+        """Corrupt heartbeat file: render without raising."""
+        heartbeat_dir = tmp_path / ".claude" / "runtime" / "lane_status"
+        heartbeat_dir.mkdir(parents=True, exist_ok=True)
+        (heartbeat_dir / "author-a.json").write_text("{not json")
+        lane = _make_heartbeat_lane(
+            "author-a",
+            worktree_path=tmp_path,
+            state="likely_active",
+            liveness_source="heartbeat",
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        line = _format_lane_line(lane, now=now)
+        assert "likely active (via heartbeat)" in line
+        assert "ago" not in line

--- a/tests/unit/test_ops_idle_detector.py
+++ b/tests/unit/test_ops_idle_detector.py
@@ -744,3 +744,223 @@ class TestExecuteShutoff:
         assert result.executed is True
         assert result.event_logged is True
         assert result.idle_status.idle is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: heartbeat-aware _get_active_lane_ids (issue #2415 PR 3/3)
+# ---------------------------------------------------------------------------
+
+
+def _write_heartbeat_file(
+    runtime_dir: Path,
+    lane_id: str,
+    *,
+    updated_at: datetime,
+    last_tool: str | None = "Bash",
+    worktree_path: Path | None = None,
+) -> Path:
+    """Write a heartbeat JSON file at the location the lane hook would use.
+
+    When ``worktree_path`` is provided, writes under
+    ``<worktree_path>/.claude/runtime/lane_status/`` (the cross-worktree
+    read path).  Otherwise writes under ``<runtime_dir>/lane_status/``.
+    """
+    if worktree_path is not None:
+        heartbeat_dir = worktree_path / ".claude" / "runtime" / "lane_status"
+    else:
+        heartbeat_dir = runtime_dir / "lane_status"
+    heartbeat_dir.mkdir(parents=True, exist_ok=True)
+    path = heartbeat_dir / f"{lane_id}.json"
+    ts = updated_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {
+        "schema_version": 1,
+        "lane_id": lane_id,
+        "pid": 12345,
+        "session_id": None,
+        "updated_at": ts,
+        "last_tool": last_tool,
+        "phase": None,
+        "extras": {},
+    }
+    path.write_text(json.dumps(payload, sort_keys=True))
+    return path
+
+
+def _register_lane_with_worktree(
+    runtime_dir: Path,
+    lane_id: str,
+    *,
+    session_id: str | None,
+    worktree_path: Path | None,
+) -> None:
+    """Write a worktree registry entry recording an optional worktree path."""
+    registry = runtime_dir / "worktree_registry"
+    entry: dict[str, object] = {"lane_id": lane_id, "session_id": session_id}
+    if worktree_path is not None:
+        entry["worktree_path"] = str(worktree_path)
+    (registry / f"{lane_id}.json").write_text(json.dumps(entry))
+
+
+class TestGetActiveLaneIdsHeartbeat:
+    """Heartbeat-aware coverage for the PR 3/3 gate (issue #2415 F1)."""
+
+    def test_no_heartbeat_session_id_only_unchanged(self, runtime_dir: Path) -> None:
+        """Parity: lanes with session_id and no heartbeat still count as active."""
+        _register_lane(runtime_dir, "author-a", session_id="sess-001")
+        assert _get_active_lane_ids(runtime_dir) == ["author-a"]
+
+    def test_no_heartbeat_no_session_id_inactive(self, runtime_dir: Path) -> None:
+        """Parity: lanes without session_id or heartbeat remain inactive."""
+        _register_lane(runtime_dir, "author-a", session_id=None)
+        assert _get_active_lane_ids(runtime_dir) == []
+
+    def test_fresh_heartbeat_no_session_id_is_active(
+        self, tmp_path: Path, runtime_dir: Path
+    ) -> None:
+        """F1 regression: fresh heartbeat keeps the lane active despite null session_id."""
+        worktree = tmp_path / "wt_author_a"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "author-a",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_heartbeat_file(
+            runtime_dir,
+            "author-a",
+            updated_at=now - timedelta(seconds=15),
+            worktree_path=worktree,
+        )
+        result = _get_active_lane_ids(runtime_dir, now=now)
+        assert result == ["author-a"]
+
+    def test_stale_heartbeat_no_session_id_is_inactive(
+        self, tmp_path: Path, runtime_dir: Path
+    ) -> None:
+        """A heartbeat aged past the freshness threshold does not count."""
+        worktree = tmp_path / "wt_author_a"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "author-a",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_heartbeat_file(
+            runtime_dir,
+            "author-a",
+            updated_at=now - timedelta(minutes=30),
+            worktree_path=worktree,
+        )
+        # Default lane_heartbeat threshold is 600s (10m) — 30m is well past it.
+        result = _get_active_lane_ids(runtime_dir, now=now)
+        assert result == []
+
+    def test_heartbeat_control_plane_excluded(
+        self, tmp_path: Path, runtime_dir: Path
+    ) -> None:
+        """A fresh heartbeat for a control-plane lane does not count toward active."""
+        worktree = tmp_path / "wt_orch"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "orchestrator",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_heartbeat_file(
+            runtime_dir,
+            "orchestrator",
+            updated_at=now - timedelta(seconds=10),
+            worktree_path=worktree,
+        )
+        assert _get_active_lane_ids(runtime_dir, now=now) == []
+
+    def test_heartbeat_cross_worktree_resolution(
+        self, tmp_path: Path, runtime_dir: Path
+    ) -> None:
+        """Reader resolves the heartbeat at the registry-recorded worktree path."""
+        # The heartbeat file lives under the lane's OWN worktree, not the
+        # caller's runtime_dir. This mirrors the orchestrator reading a
+        # remote lane's hook output.
+        worktree = tmp_path / "some_other_worktree"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "author-b",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_heartbeat_file(
+            runtime_dir,
+            "author-b",
+            updated_at=now - timedelta(seconds=30),
+            worktree_path=worktree,
+        )
+        # A heartbeat placed under runtime_dir/lane_status must NOT satisfy
+        # the lookup when the registry records a different worktree_path.
+        # Use a very stale fallback so even if the resolver mistakenly
+        # consults it, freshness still fails.
+        _write_heartbeat_file(
+            runtime_dir,
+            "author-b",
+            updated_at=now - timedelta(minutes=60),
+            worktree_path=None,  # writes under runtime_dir/lane_status
+        )
+        result = _get_active_lane_ids(runtime_dir, now=now)
+        assert result == ["author-b"]
+
+    def test_fleet_idle_returns_not_idle_on_fresh_heartbeat_only(
+        self, tmp_path: Path, events_dir: Path, runtime_dir: Path
+    ) -> None:
+        """is_fleet_idle integration: fresh heartbeat with null session → idle=False."""
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "author-a",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc)
+        _write_heartbeat_file(
+            runtime_dir,
+            "author-a",
+            updated_at=now - timedelta(seconds=20),
+            worktree_path=worktree,
+        )
+        # Also seed a stale meaningful event so idle_minutes has something
+        # to report.
+        _write_event(
+            events_dir, "task_completed", now - timedelta(minutes=200), "author-a"
+        )
+        result = is_fleet_idle(
+            threshold_minutes=90,
+            events_dir=events_dir,
+            runtime_dir=runtime_dir,
+            now=now,
+        )
+        assert result.idle is False
+        assert "author-a" in result.active_lanes
+
+    def test_malformed_heartbeat_falls_back_to_session_id(
+        self, tmp_path: Path, runtime_dir: Path
+    ) -> None:
+        """A malformed heartbeat file must not mask or disturb session_id gating."""
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        _register_lane_with_worktree(
+            runtime_dir,
+            "author-a",
+            session_id=None,
+            worktree_path=worktree,
+        )
+        heartbeat_dir = worktree / ".claude" / "runtime" / "lane_status"
+        heartbeat_dir.mkdir(parents=True, exist_ok=True)
+        (heartbeat_dir / "author-a.json").write_text("{not valid json")
+        assert _get_active_lane_ids(runtime_dir) == []


### PR DESCRIPTION
## Summary

PR 3/3 of the #2415 heartbeat-classifier series. Completes the consumer chain so the remaining F1 symptom sites pick up the heartbeat signal (the session-id-is-null-during-make-check pattern).

- **`idle_detector._get_active_lane_ids`** — lane counts as active when either `session_id` is non-null **or** a fresh heartbeat exists under the lane's registry-recorded worktree. Control-plane exclusion (`orchestrator`/`ops`/`review`) unchanged.
- **`dashboard._format_lane_line`** — when `liveness_source == "heartbeat"`, the render now appends the heartbeat age: e.g. `"likely active (via heartbeat, 15s ago)"`, `"stale (via heartbeat, 5m0s ago)"`. Missing/malformed heartbeat falls back to the legacy `"via heartbeat"` string without raising.
- **`.claude/skills/lane-status/SKILL.md`** — manual procedure reordered to `heartbeat → process tree → pane → worktree → PR`; new **VALIDATING** matrix row covers the "stale heartbeat + live `pytest`/`make`/`ruff` process" case. Pane procedure retained (still load-bearing for approval-prompt detection).

## Why

Issue #2415 failure mode F1: a lane running `make check-quiet` emits heartbeats via the PR #2686 PostToolUse hook but its registry `session_id` is momentarily cleared. Before this PR, `idle_detector` Gate 1 ignored the heartbeat and could trigger auto-shutoff on an actively working fleet; the dashboard rendered `"likely active (via heartbeat)"` without age, forcing the operator to shell out to `lane status` to confirm freshness. PRs 1/3 (#2686 writer) and 2/3 (#2695 `status.py` Signal 0 + `lane status` CLI) fixed the other consumers. This is the last consumer site.

## Repro / Validation

```bash
# Tier 1 — targeted
uv run python -m pytest tests/unit/test_ops_dashboard.py tests/unit/test_ops_idle_detector.py -v
# 111 passed

# Parity guards
uv run python -m pytest tests/unit/test_ops_status_heartbeat.py tests/unit/test_ops_cli_lane_status.py -q
# 34 passed

# Tier 2
git fetch origin main && git rebase origin/main
make check-gated
# ✓ All checks passed
```

## Tests

**New tests (13 total):**

`tests/unit/test_ops_idle_detector.py::TestGetActiveLaneIdsHeartbeat` (8):
- `test_no_heartbeat_session_id_only_unchanged` — parity
- `test_no_heartbeat_no_session_id_inactive` — parity
- `test_fresh_heartbeat_no_session_id_is_active` — F1 regression guard
- `test_stale_heartbeat_no_session_id_is_inactive` — 30m stale → not active
- `test_heartbeat_control_plane_excluded` — fresh orchestrator heartbeat does not count
- `test_heartbeat_cross_worktree_resolution` — honors registry `worktree_path`
- `test_fleet_idle_returns_not_idle_on_fresh_heartbeat_only` — `is_fleet_idle` integration
- `test_malformed_heartbeat_falls_back_to_session_id` — graceful degradation

`tests/unit/test_ops_dashboard.py::TestFormatLaneLineHeartbeat` (5):
- `test_no_heartbeat_events_source_unchanged` — parity (liveness_source != heartbeat)
- `test_heartbeat_likely_active_includes_age` — `"likely active (via heartbeat, 15s ago)"`
- `test_heartbeat_stale_includes_age` — `"stale (via heartbeat, 5m0s ago)"`
- `test_heartbeat_missing_falls_back_gracefully` — no traceback, no age token
- `test_heartbeat_malformed_falls_back_gracefully` — corrupt JSON doesn't raise

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author
$ git worktree list | head -5
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author  c3710f34 [feat/dashboard-heartbeat-cutover-2415]
```

## Scope

Scope matches the dispatch packet (`cee62e01da5e`):
- `src/bid_euchre/ops/dashboard.py`
- `src/bid_euchre/ops/idle_detector.py`
- `.claude/skills/lane-status/SKILL.md`
- `tests/unit/test_ops_dashboard.py`
- `tests/unit/test_ops_idle_detector.py`

No schema changes. No CLI flag changes. `LaneStatus`, `DashboardView`, `IdleStatus`, `Heartbeat` all unchanged.

## Backward-compat

- Pre-#2686 sessions (no heartbeat): both consumers fall through to the legacy `session_id`-only path. No regression.
- Heartbeat file race (read during writer's atomic rename): `read_heartbeat` returns `None` on missing/partial file; both consumers handle `None`.
- `schema_version != 1`: `read_heartbeat` returns `None`; treated as missing.
- Control-plane lanes: fresh heartbeat for `orchestrator`/`ops`/`review` does not count toward active-lane set.

Refs #2415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)