### PR TITLE
docs(plans): add ADR seeds 005/007/010/B8 from analyst-a plugin source evaluation

### DIFF
--- a/plans/steward_platform/adrs/005-review-plugin-evaluation.md
+++ b/plans/steward_platform/adrs/005-review-plugin-evaluation.md
@@ -1,0 +1,64 @@
+# ADR 005 — Review Plugin Evaluation
+
+**Status:** SEEDED (draft 8); filing at Phase 0 kickoff
+**Primitive:** C (KB / ADR discipline), E (messaging/triage overlap)
+**Supersedes:** none
+**Seed source:** `plans/steward_platform/plugin_source_evaluation.md` §2 + §6.1 (analyst-a, 2026-04-23)
+
+---
+
+## Context
+
+Anthropic's official `anthropics/claude-code/plugins/code-review` plugin overlaps steward's `scripts/internal/review_driver.py`. Draft 8 B.8 / ADR 005 commits to an ADR-level evaluation. Source read (2026-04-23 by analyst-a) shows the plugin is a 4-parallel-reviewer + Nx-validator-subagent orchestration in ~109 lines of command prompt at `plugins/code-review/commands/code-review.md`, not the "5 specialized reviewers with 0-100 confidence scoring" marketing framing the README implies.
+
+Key source-derived observations:
+
+- **4 parallel reviewers, not 5:** two redundant Sonnet CLAUDE.md-compliance reviewers + two Opus bug-detection agents. No "git history analyzer" reviewer in source despite README claim.
+- **No 0-100 confidence scoring in source.** The README's "threshold 80 default" framing is post-hoc documentation. The actual noise-suppression mechanism is a two-pass flag→validate filter implemented via Nx parallel validator subagents.
+- **Plugin has no SHA-bound verdict, no merge-guard, no scope-lock, no auto-fix commit loop, no status-context publication** — steward's `review_driver.py` carries all six.
+
+See analyst-a's §2 for full source snippets.
+
+## Decision
+
+**Retain `review_driver.py` as the sole review orchestrator.** Cherry-pick two patterns into it as Phase-1+ improvements (not Phase-0 blockers):
+
+1. **Parallel-reviewer fan-out** with Codex CLI + N Opus subagent reviewers on different foci (e.g., "scan diff for bugs", "verify scope lock", "audit CLAUDE.md compliance"). Feature-flagged; rollback via flag flip (Pattern 7 reversibility).
+2. **Validator-subagent pass for false-positive suppression** before writing findings to the review report. Addresses the 50-106 precheck false-positive pattern recent plan PRs keep hitting.
+
+**Do not install the plugin.**
+
+Draft 8 language around "0-100 confidence scoring" (if any survives) should be amended to "validator-subagent filter pass" since the former is post-hoc documentation, not source behavior.
+
+## Consequences
+
+- `review_driver.py` gains an optional multi-reviewer mode (feature-flagged; single-Codex-CLI remains Phase 0 baseline).
+- Phase 1+ experimentation can land the parallel-reviewer + validator-subagent pattern without blocking Phase 0 kickoff.
+- SHA-bound verdict, merge-guard, scope-lock, auto-fix loop, and status-context publication — all steward-specific — are preserved.
+- Cloud `/autofix-pr` remains evaluate-only (separate consideration; operator-dependent since it moves PR fix loop to cloud and changes operator-presence model).
+
+## Alternatives considered
+
+1. **Install the plugin + delete `review_driver.py`.** Rejected. Plugin does not carry SHA-bound verdicts, merge-guard integration, auto-fix commit loop, scope-lock enforcement, or `reviewing-changes` status-context publication. Retrofitting all six is more work than the status quo.
+2. **Leave `review_driver.py` unchanged.** Rejected. The validator-subagent pass is a clean noise-reduction win worth implementing given the recurring precheck false-positive pattern.
+3. **Cloud `/autofix-pr` as replacement for local review_driver.** Deferred to operator; out of scope for this ADR.
+
+## Open questions
+
+1. Should the validator-subagent cherry-pick ship during Phase 0 or strictly Phase 1+? Analyst-a's recommendation: defer to operator; not a Phase 0 blocker and neutral against kill criteria.
+
+## Source evidence
+
+- Plugin repo: `https://github.com/anthropics/claude-code/tree/main/plugins/code-review`
+- Command file read: `plugins/code-review/commands/code-review.md` (109 lines)
+- Plugin manifest: `.claude-plugin/plugin.json` (v1.0.0, author Boris Cherny, MIT license via `anthropics/claude-code` repo license)
+- Evaluation artifact: `plans/steward_platform/plugin_source_evaluation.md` §2 (analyst-a, 2026-04-23)
+
+## Phase 2 Decision Inputs
+
+**Portability readiness:** Improved (rejecting wholesale adoption keeps the review pipeline seam thin).
+**Meta-layer need:** no change.
+**Kill signal for primitive(s) named:** no.
+**Re-evaluation needed in Phase 3:** no (Phase 1+ cherry-pick is an enhancement, not a re-evaluation).
+**Surprise finding:** README 0-100 scoring / 5-specialized-reviewers framing exceeds actual source behavior — reinforces ADR discipline requiring source-snippet citations for Tier S adoption decisions.
+**Disposition:** open (pending Phase 0 kickoff filing)

--- a/plans/steward_platform/adrs/007-observability-plugin-evaluation.md
+++ b/plans/steward_platform/adrs/007-observability-plugin-evaluation.md
@@ -1,0 +1,75 @@
+# ADR 007 — Observability Plugin Evaluation
+
+**Status:** SEEDED (draft 8); filing at Phase 0 kickoff
+**Primitive:** A (trace/observability)
+**Supersedes:** none
+**Seed source:** `plans/steward_platform/plugin_source_evaluation.md` §4 + §6.3 (analyst-a, 2026-04-23)
+
+---
+
+## Context
+
+`melodic-software/claude-code-observability` (MIT, v1.0.0, schema v1.9.0, actively maintained) implements a single-Python-dispatcher + 14-event JSONL logger with verbosity tiers, rotation, seq/pid/turn_id correlation fields, and `extra_fields` extensibility.
+
+Source read (2026-04-23 by analyst-a) shows 80% of Primitive A's event-class coverage but only 40% of §9.7 first-class-ID coverage. Specifically:
+
+- **Present:** `session_id`, `schema_version` pattern.
+- **Absent as first-class:** `project_id`, `cell_id`, `task_id` (cross-event), `lane_id`, `trace_id`, `incident_fingerprint`, `prompt_policy_version`.
+
+Absent IDs would have to live in `extra_fields: Dict[str, Any]`, defeating §9.7's "first-class IDs carried in every event" framing — non-queryable except via full-scan.
+
+However, the plugin's dispatcher design is well-considered: never-block async, pathlib-portable, stdlib-only, 14-event registry with correlation fields. These are exactly the patterns Primitive A needs.
+
+## Decision
+
+**Implement steward's `ops/events.py` per Primitive A §4.2 Work using the plugin's dispatcher pattern as the reference implementation, with §9.7 IDs native to the top-level schema (not `extra_fields`).** Do not install, fork, or depend on the plugin package.
+
+**Adopt (as patterns in bespoke code):**
+
+1. Single-dispatcher architecture.
+2. JSONL daily files with rotation.
+3. Correlation fields (`seq`, `pid`, `timestamp_ns`, `turn_id`) at top-level.
+4. Verbosity tiers (`minimal` / `summary` / `full`) for per-event detail control.
+5. Registry-driven known-field contract with `extra_fields` future-proofing — but steward's `extra_fields` is a bug marker (Pattern 8 observable-by-default: every known emitter routes to a top-level field).
+6. Cross-platform file locking.
+7. `_categorize_error` taxonomy for standardized error classification.
+8. `_build_status_message` pattern for event-to-human-readable summaries.
+
+**Reject:**
+
+- Plugin installation / dependency.
+- Fork maintenance.
+- `extra_fields` as the default landing zone for §9.7 IDs.
+
+## Consequences
+
+- Primitive A's Phase 0 Readiness ("Event schema finalized; committed") is implemented via a known, proven pattern rather than derived from scratch.
+- `ops/events.py` becomes a natural candidate for cross-fleet extraction (extensibility Pattern 1 adapter contract; portability gain).
+- Steward owns its own `schema_version` bump policy per §4.2 ("v1.N and remain replay-compatible").
+- `extra_fields` is treated as a bug marker per Pattern 8: every known emitter routes to a top-level field; `extra_fields` appearing for a known emitter is a lint violation (enforced by `agent_readability_lint.py` Pattern 9 extension).
+- Dispatcher, rotation, and correlation-field patterns reduce the risk that steward re-derives a weaker version of proven design.
+
+## Alternatives considered
+
+1. **Install the plugin and inject `extra_fields` for §9.7 IDs.** Rejected. §9.7 IDs as non-first-class break queryability ("grep-verifiable downstream use" Phase 1 Validation criterion depends on first-class IDs). Forking the plugin to add IDs as top-level would incur upstream-drift maintenance.
+2. **Write from scratch without pattern reference.** Rejected. Plugin's dispatcher design is well-considered; re-deriving is wasteful and would produce a weaker result.
+3. **Adopt plugin as supplemental (dual-emitter).** Rejected. Creates two event streams with different schemas; defeats unified-schema discipline.
+
+## Open questions
+
+1. Under ADR 007, is `extra_fields` tolerated in steward's schema for Phase 1, or must all unknown-field routing be resolved before Phase 1 ships? Analyst-a's recommendation: operator-call. Stricter stance ("every known emitter must route to top-level") aligns with Pattern 8 observable-by-default.
+
+## Source evidence
+
+- Plugin repo: per claudepluginhub.com listing (public GitHub of `melodic-software/claude-code-observability-plugins` or equivalent; exact path captured in evaluation artifact)
+- Source read: single-Python-dispatcher module + 14-event registry + JSONL writer + correlation-field structure
+- Evaluation artifact: `plans/steward_platform/plugin_source_evaluation.md` §4 (analyst-a, 2026-04-23)
+
+## Phase 2 Decision Inputs
+
+**Portability readiness:** Improved. Bespoke implementation using plugin's dispatcher pattern keeps the portability seam thin (pattern, not dependency).
+**Meta-layer need:** no change.
+**Kill signal for primitive(s) named:** no. This ADR sharpens Primitive A implementation rather than killing it.
+**Re-evaluation needed in Phase 3:** low-priority trigger if plugin's upstream schema adds features steward wants (e.g., a standardized `task_id` field at top-level). Not a mandatory re-evaluation.
+**Surprise finding:** The plugin's documentation and README understate the schema-ID coverage question. Marketing claims "14 events" but doesn't disclose which §9.7-equivalent fields are top-level vs. `extra_fields`. Another Tier S candidate where source reading revealed a material gap from marketing framing.
+**Disposition:** open (pending Phase 0 kickoff filing)

--- a/plans/steward_platform/adrs/010-mcp-memory-service-evaluation.md
+++ b/plans/steward_platform/adrs/010-mcp-memory-service-evaluation.md
@@ -1,0 +1,64 @@
+# ADR 010 — mcp-memory-service Evaluation
+
+**Status:** SEEDED (draft 8); filing at Phase 0 kickoff
+**Primitive:** C (durable memory + KB), D (archivist inflow/outflow)
+**Supersedes:** none
+**Seed source:** `plans/steward_platform/plugin_source_evaluation.md` §5 + §6.4 (analyst-a, 2026-04-23)
+
+---
+
+## Context
+
+`doobidoo/mcp-memory-service` (Apache-2.0, v10.13.0, 1717 stars at time of evaluation) provides MCP tools for semantic memory (`store_memory` / `retrieve_memory` / `search_by_tag` / `delete_memory` / `list_memories` / `recall_memory` / etc.), plus autonomous "dream-inspired" consolidation (exponential decay scoring, creative association discovery, semantic compression, controlled forgetting) and pluggable storage backends (SQLite-vec / Cloudflare KV+Vectorize / Milvus / Hybrid local+cloud).
+
+Source read (2026-04-23 by analyst-a) exposes multiple impedance mismatches with steward's Primitive C/D discipline:
+
+- **All §9.7 first-class IDs absent** from the memory schema. Would have to live inside `metadata: Optional[Dict[str, Any]]`, making them non-queryable except via full-scan. Impedance is deeper than ID mapping: the plugin models memory as "content + tags + semantic embedding"; steward models knowledge as "curated artifact classes (NOTES / PLAYBOOKS / anti_patterns / incidents / ADRs / harness_assumptions / INDEX)" with explicit operator-gated promotion.
+- **Storage lives outside git.** Per-machine SQLite, Cloudflare KV, Milvus — none write to git-committed markdown. Conflicts with `.claude/rules/deferred/30_data_contract.md` commit policy ("only promoted artifacts committed") and with draft 8's KB structure (committed markdown under `knowledge/`).
+- **Autonomous consolidation silently mutates memory state.** `ControlledForgettingEngine` deletes low-importance memories after a configurable window; `SemanticCompressionEngine` compresses clusters into summary entries; `DreamInspiredConsolidator` orchestrates both. Conflicts with draft 8's explicit-promotion + operator-review-gate discipline (Primitive D archivist inflow is operator-reviewed; GC outflow is operator-accepted; there is no "silently mutate state" path).
+- **Heavy dependency footprint.** ChromaDB / SQLite-vec / Cloudflare — introduces infrastructure not justified by a current steward workflow.
+
+The plugin's value is the semantic retrieval layer. Steward does not currently have a semantic-retrieval workflow; grep over curated markdown satisfies the current use case.
+
+## Decision
+
+**Do not adopt.** Keep `ops/memory.py` + `knowledge/` curated markdown + MEMORY.md + archivist operator-gated promotion as the Primitive C/D mechanism.
+
+**Reference the plugin's MCP tool signatures only** — if steward later exposes an MCP interface over the committed KB corpus (unlikely until Phase 2+), reuse the shape (`store_memory` / `retrieve_memory` / `search_by_tag` / `list_memories` / `delete_memory` + `destructiveHint` / `readOnlyHint` MCP tool annotations).
+
+## Consequences
+
+- Steward's commit discipline (only promoted artifacts committed; operator review before promotion) remains intact.
+- No vector-DB dependency introduced.
+- KB stays git-auditable and portable.
+- Archivist flow stays operator-gated — no autonomous state mutation.
+- **Phase 3 soft re-evaluation trigger:** revisit if either fires during Phase 1/2:
+  - (a) `knowledge/NOTES.md` exceeds a size where grep-based recall breaks agent-readability — soft threshold: ~20 KB or ~500 entries, whichever first.
+  - (b) Archivist inflow volume exceeds operator-review capacity — ≥10 candidate lessons per nightly run sustained for ≥1 week.
+- Recommended evaluation window: 6 months post Phase 2 close.
+
+## Alternatives considered
+
+1. **Wholesale adoption as replacement for `ops/memory.py`.** Rejected. Autonomous consolidation conflicts with commit discipline; heavy dependency footprint; lock-in via content-hash + embedding storage; §9.7 IDs not first-class.
+2. **Adopt as supplemental inflow-only layer.** Deferred. No current workflow requires semantic retrieval; re-evaluate at Phase 3 trigger.
+3. **Stand up a thin `sentence-transformers + SQLite-vec` wrapper over the committed markdown corpus.** Deferred. Cheaper than adopting the plugin, but only if a semantic-retrieval need emerges; no current need.
+
+## Open questions
+
+1. Phase 3 soft re-evaluation trigger thresholds (~20 KB / 500 entries / 10 candidate lessons per nightly / 1 week sustained) are first-cut. Operator can calibrate against actual KB growth observed during Phase 0. Alternative: "grep produces >50 hits on a common query" as an operator-readable threshold.
+
+## Source evidence
+
+- Plugin repo: `https://github.com/doobidoo/mcp-memory-service`
+- License: Apache-2.0; v10.13.0
+- Source-read modules: `storage/sqlite_vec.py` (192 KB), `server_impl.py` (152 KB), `consolidation/__init__.py` + associated modules (`decay.py`, `associations.py`, `clustering.py`, `compression.py`, `forgetting.py`, `consolidator.py`, `scheduler.py`, `health.py`), `storage/graph.py` + `consolidation/relationship_inference.py` (27 KB each).
+- Evaluation artifact: `plans/steward_platform/plugin_source_evaluation.md` §5 (analyst-a, 2026-04-23)
+
+## Phase 2 Decision Inputs
+
+**Portability readiness:** Improved. Rejection keeps `ops/memory.py` + `knowledge/` markdown as the portable pattern.
+**Meta-layer need:** no change.
+**Kill signal for primitive(s) named:** no. Primitive C (durable memory + KB) + Primitive D (archivist) remain live; ADR 010 closes a named evaluation without reshaping scope.
+**Re-evaluation needed in Phase 3:** **Yes, soft trigger.** Revisit if thresholds in §Consequences fire during Phase 1/2.
+**Surprise finding:** Plugin storage layer is larger than the rest of the plugin combined (192 KB `sqlite_vec.py` vs. 27 KB `graph.py` + 152 KB `server_impl.py`). Most of the cost is in backend + embeddings, not the MCP interface. If steward ever did need semantic retrieval, a thin `sentence-transformers + SQLite-vec` wrapper over committed markdown would be cheaper than adopting this plugin.
+**Disposition:** open (pending Phase 0 kickoff filing)

--- a/plans/steward_platform/adrs/B8-native-task-system-evaluation.md
+++ b/plans/steward_platform/adrs/B8-native-task-system-evaluation.md
@@ -1,0 +1,66 @@
+# ADR B8 — Native Task/Dependency System Evaluation
+
+**Status:** SEEDED (draft 8); filing at Phase 0 kickoff
+**Primitive:** B (dispatch/skill/prompt-policy) sub-deliverable B.8
+**Supersedes:** none
+**Seed source:** `plans/steward_platform/plugin_source_evaluation.md` §3 + §6.2 (analyst-a, 2026-04-23)
+
+---
+
+## Context
+
+Claude Code's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (enabled via settings.json or environment flag) provides a team-lead + teammates + shared task list + mailbox architecture. Draft 8 B.8 commits to an ADR evaluating which parts of steward's `ops/task_queue.py` + `ops/worker_pool.py` + `ops/scheduler.py` contract are subsumed by native substrate.
+
+Key source-derived observations from analyst-a (reading docs at `code.claude.com/docs/en/agent-teams` and Task-tool / TeammateTool APIs):
+
+- **Native tasks are session-ephemeral.** Teammates die with the lead session; no restart/resumption per the experimental limitations.
+- **No `scope_declared` field.** Native tasks carry subject / description / optional activeForm / metadata dict. No equivalent of steward's scope-lock (declared file patterns that must not be exceeded).
+- **No domain routing.** No platform vs. browser-game pool concept.
+- **No lane affinity.** No equivalent of "author-a stays author-a across sessions" — teammates are allocated ad-hoc from a pool.
+- **No routing metadata.** No `task_type` / `complexity_estimate` / `model_hint` / `effort_hint` on native task objects (which drive steward's adaptive dispatch advisor).
+- **TeammateTool + SendMessage/broadcast** provide intra-session mailbox semantics; they do not carry durable cross-restart guarantees.
+
+Lifecycle hooks (`TeammateIdle`, `TaskCreated`, `TaskCompleted`) are already in draft 8 Tier S Primitive A scope independent of this ADR.
+
+## Decision
+
+**Keep `ops/task_queue.py`, `ops/worker_pool.py`, `ops/scheduler.py`, and the orchestrator → author-lane nudge protocol bespoke.** Native Agent Teams substrate does not subsume steward's durable packet semantics.
+
+**Adopt the following from Agent Teams as supplemental (not replacement):**
+
+1. **Lifecycle hooks** (`TeammateIdle`, `TaskCreated`, `TaskCompleted`) emitted into `ops/events.py` schema — already covered by Tier S absorption in Primitive A.
+2. **`SendMessage` + `broadcast`** as a supplemental intra-session channel for orchestrator ↔ lane coordination pings. Steward's message bus (`ops/message_bus.py`) remains authoritative for durable / cross-restart semantics.
+
+**Do not enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` on steward lanes by default.** Retainable operator decision: per-lane experimentation is tolerated; it does not compete with the bus.
+
+## Consequences
+
+- Steward's task contract (scope-locked packets + domain routing + lane affinity + routing metadata) survives unchanged as the canonical dispatch model.
+- Scope-lock discipline remains orthogonal to any native task primitive, preserving its value independent of substrate evolution.
+- §9.7 first-class IDs remain expressible on steward packets; `agent_id` / `agent_type` from Agent Teams hooks can be correlated via a lookup table if per-lane experimentation happens.
+- Phase 3 re-evaluation trigger: if `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` graduates from experimental AND native tasks gain scope/metadata/durability fields, revisit this ADR.
+
+## Alternatives considered
+
+1. **Adopt Agent Teams as packet-dispatch substrate.** Rejected. Would require building 6 extensions atop native substrate — scope field, domain routing, lane affinity, durable cross-restart state, routing metadata (4 fields), message-bus bridge. More work than keeping bespoke.
+2. **Replace message bus with `SendMessage`.** Rejected. Session-ephemeral; loses cross-restart durability that steward's orchestrator → author-lane protocol depends on.
+3. **Pilot on a single flex lane for observation.** Deferred to operator per analyst-a's open question. Source-level evaluation is sufficient to close B.8 without empirical data.
+
+## Open questions
+
+1. Pilot `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` on one flex lane to observe empirical behavior (sharpens the "graduates from experimental" Phase 3 re-evaluation trigger)?
+
+## Source evidence
+
+- Docs read: `https://code.claude.com/docs/en/agent-teams`
+- Task tool / TeammateTool API references (accessible via Claude Code docs + `claude --help` subcommand inspection)
+- Evaluation artifact: `plans/steward_platform/plugin_source_evaluation.md` §3 (analyst-a, 2026-04-23)
+
+## Phase 2 Decision Inputs
+
+**Portability readiness:** no change (steward's dispatch model remains the portable seam).
+**Meta-layer need:** no change.
+**Kill signal for primitive(s) named:** no.
+**Re-evaluation needed in Phase 3:** yes, soft trigger if Agent Teams graduates from experimental AND native task schema gains scope/metadata/durability fields. Recommended evaluation window: 6 months post Phase 2 close or when upstream change lands, whichever sooner.
+**Surprise finding:** Agent Teams' "persistent task system" framing is misleading — native tasks are session-ephemeral with no restart. Reinforces the ADR discipline requiring source-level verification (Pattern 9 load-bearing-ownership lint extended to Tier S candidates).
+**Disposition:** open (pending Phase 0 kickoff filing)

--- a/plans/steward_platform/adrs/README.md
+++ b/plans/steward_platform/adrs/README.md
@@ -1,0 +1,26 @@
+# Steward Platform ADRs
+
+**Purpose:** Architecture Decision Records for the steward platform governing plan. Filed at Phase 0 kickoff per draft 8 §14 Open Items #11–#17 and updated as decisions evolve across phases.
+
+**Naming convention:** `NNN-<slug>.md` for numbered ADRs; `BN-<slug>.md` for B-sub-deliverable ADRs (matches draft 8 §5-B sub-deliverables table).
+
+**Seed source:** Plugin ADRs (005, B8, 007, 010) are seeded from analyst-a's source evaluation at `plans/steward_platform/plugin_source_evaluation.md` §6. Analyst-a source-read the actual plugins, found material marketing-vs-source discrepancies for three of four candidates, and produced source-grounded adoption decisions. The seeds below are the promotable ADR forms of those decisions.
+
+**Lifecycle:** ADRs are immutable once filed. If a decision changes, a new ADR supersedes the old one with an explicit reference.
+
+## Index
+
+| ID | Title | Status | Primitive |
+|---|---|---|---|
+| 001 | Platform-11/13 dismissal evidence + agent-readability scorecard floor | Pending (Phase 0 kickoff) | C |
+| 002 | Review-cycle-as-evidence (drafts 1–8 lineage) | Pending (Phase 0 close per analyst-d Q5) | C |
+| 003 | Token-economy native vs. bespoke boundary | Pending (Phase 0 close) | F |
+| 004 | Hook migration boundary | Pending (Phase 0 close) | E |
+| **005** | **Review plugin evaluation** | **Seeded (draft 8)** | **C/E** |
+| 006 | Auto mode codification | Pending (Phase 0 kickoff) | G |
+| **007** | **Observability plugin evaluation** | **Seeded (draft 8)** | **A** |
+| **010** | **mcp-memory-service evaluation** | **Seeded (draft 8)** | **C/D** |
+| **B8** | **Native task/dependency system evaluation** | **Seeded (draft 8)** | **B** |
+| G10 | `.claude/system_prompts/` vs. `.claude/agents/` relationship | Pending (Phase 0 kickoff; options: replacement/supplement/orthogonal) | G |
+
+**Seeded** = draft 8 contains ADR seed text; the ADR file below is promotion-ready pending Phase 0 kickoff finalization (operator signoff + filing date).


### PR DESCRIPTION
## Summary

Folds analyst-a's plugin_source_evaluation.md findings (PR #2754 merged earlier today) into promotion-ready ADR files at `plans/steward_platform/adrs/`. Each ADR carries the corresponding §6.N seed from the analyst artifact with light editing.

## ADR decisions

| ADR | Target | Decision |
|---|---|---|
| **005** | Official code-review plugin | RETAIN `review_driver.py`; CHERRY-PICK parallel-reviewer fan-out + validator-subagent filter pass as Phase-1+ improvement |
| **B8** | Agent Teams + TeammateTool + Task system | KEEP `task_queue.py`/`worker_pool.py` bespoke; adopt lifecycle hooks (already Tier S) + SendMessage as supplemental channel; do NOT enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` |
| **007** | `melodic-software/claude-code-observability` | ADOPT dispatcher pattern + JSONL schema conventions in bespoke `ops/events.py` with §9.7 IDs as first-class; do NOT install/fork |
| **010** | `doobidoo/mcp-memory-service` | REJECT wholesale adoption; reference MCP tool signatures only; Phase 3 soft re-evaluation trigger if NOTES.md > 20KB/500 entries or archivist inflow > operator-review capacity sustained ≥1 week |

## Source-reading beats marketing

Analyst-a found marketing-vs-source discrepancies for three of four candidates:
- code-review plugin's "0-100 scoring" is actually a two-pass flag→validate filter
- Agent Teams' "persistent task system" is session-ephemeral with no restart
- mcp-memory-service's "dream-inspired consolidation" is autonomous state mutation (conflicts with commit discipline)

All four ADRs cite source snippets and derive adoption decisions from actual behavior, not marketing framing.

## Status

All four ADRs **SEEDED** (draft 8). Promotion-ready; filing at Phase 0 kickoff with operator signoff + filing date per draft 8 §14 Open Items #11-#17.

Docs-only; no code, test, or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)