### PR TITLE
docs(steward): codify Opus-only constraint for auto-mode activation (ADR 006 + rule 80 amendment)

### DIFF
--- a/.claude/rules/80_permission_model.md
+++ b/.claude/rules/80_permission_model.md
@@ -65,6 +65,53 @@ during review-lane restart in session 2026-04-20, when the lane respawned as
 `bypassPermissions` despite `defaultMode: "auto"` being set in the committed
 settings.
 
+### Model-tier activation constraint
+
+`--permission-mode auto` only engages the Sonnet 4.6 classifier when the
+lane's active session is Opus-tier (Claude Opus 4.6 or 4.7+). A Sonnet-tier
+or Haiku-tier session launched with `--permission-mode auto` either ignores
+the flag or silently falls back to `bypassPermissions`; in either case, the
+classifier does not gate tool calls and `PermissionDenied` events are never
+emitted.
+
+The launch-flag choice is therefore a **function of the lane's model tier**,
+not a fleet-wide constant:
+
+| Model tier | Required launch flag | Effective permission mode |
+|------------|---------------------|---------------------------|
+| Opus 4.6+ | `--permission-mode auto` | `auto` (classifier-gated) |
+| Sonnet 4.6+ | `--dangerously-skip-permissions` | `bypassPermissions` |
+| Haiku 4.5+ | `--dangerously-skip-permissions` | `bypassPermissions` |
+
+**Launch-script implication.** `.claude/tmux/steward-session.sh` and
+`scripts/internal/review_lane_runner.py::invoke_review` currently hardcode
+`--permission-mode auto` for every lane (the structural tests above lock
+this in). That is correct for the current fleet — 100% Opus 4.7 — but is a
+pending fix when any lane moves to Sonnet or Haiku for token-economy or
+dispatch reasons. The fix must read per-lane model-tier config and emit the
+correct flag. This change is tracked as Primitive G Phase 0 closeout under
+the 7-surfaces inventory (issue #2767).
+
+**Structural-test implication.** `TestPermissionModeAuto` and
+`TestInvokeReviewPermissionMode` both assert `--permission-mode auto`
+unconditionally. When the launch scripts gain model-tier conditioning, the
+tests must be rewritten as `TestPermissionModeByModelTier` asserting the
+correct flag per lane's declared model. Landing launch-script conditioning
+without the test rewrite will break CI; landing the test rewrite without
+the launch-script conditioning silently regresses enforcement on the
+current Opus fleet. **The two changes must ship together.**
+
+**Never substitute launch flags for model-tier intent.** Passing
+`--permission-mode auto` to a non-Opus lane is the worst outcome: the flag
+and settings encode auto-mode discipline, but the runtime gate is silently
+inactive. The explicit `--dangerously-skip-permissions` launch makes the
+reduced safety envelope legible at every observation point (log output,
+`gh pr checks`, operator-readable launch command). Operators MUST NOT
+cross-wire these flags to mask model-tier selection.
+
+**Cross-reference:** ADR 006 §"Model tier interaction" captures the
+decision record and the safety envelope per-tier comparison table.
+
 ## Why auto mode over `bypassPermissions`
 
 The fleet previously ran `bypassPermissions`, which auto-approves everything

--- a/plans/steward_platform/adrs/006-auto-mode.md
+++ b/plans/steward_platform/adrs/006-auto-mode.md
@@ -79,6 +79,37 @@ Operator-facing guidance (how to extend the trust envelope, how to read denials,
 - `PermissionDenied` denial rate is an ops-alert candidate. Rule 80 recommends opening a follow-up to extend `autoMode.allow` if denial rate exceeds ~5% of tool calls sustained. That follow-up is tracked outside this ADR.
 - Any future PR touching `permissions.allow`, `defaultMode`, or `.claude/autoMode.defaults.reference.json` is a security-relevant diff and reviewed accordingly.
 
+## Model tier interaction
+
+Auto mode's runtime gate is a **Sonnet 4.6 classifier invocation per tool call**. The classifier only engages when the lane's active session is itself Opus-tier (Claude Opus 4.6 or 4.7+). For a Sonnet-tier or Haiku-tier session, `--permission-mode auto` is inert: the CLI either ignores the flag or silently falls back to `bypassPermissions`. Either way, the runtime classifier gate does not engage and `PermissionDenied` events are never emitted.
+
+This produces a **load-bearing model-tier constraint** on launch flags:
+
+- **Opus-tier sessions** must launch with `--permission-mode auto`. The classifier gate engages; the full safety envelope documented in Consequences applies.
+- **Sonnet-tier and Haiku-tier sessions** must launch with `--dangerously-skip-permissions`. There is no runtime classifier gate; the session runs under the `bypassPermissions` safety envelope, with post-hoc safety nets (git audit trail + Codex CLI pre-merge review + post-merge Explore review) as the only remaining layers.
+
+Passing `--permission-mode auto` to a non-Opus session is the worst outcome — parallel to the §Alternatives-considered #5 failure mode, but along the model-tier axis: the launch flag and shared settings both encode "auto mode," but the runtime gate is silently inactive. The explicit `--dangerously-skip-permissions` launch is the correct codification — it makes the reduced envelope legible at every observation point (log output, `gh pr checks`, operator-readable launch command).
+
+**Safety envelope per model tier:**
+
+| Axis | Opus + auto mode | Sonnet/Haiku + bypassPermissions |
+|------|------------------|----------------------------------|
+| Force-push, prod deploys, `curl \| bash` | Soft-denied unless explicit User Intent | Allowed |
+| Exfiltration (external-repo push, unexpected outbound HTTP) | Soft-denied | Allowed |
+| Self-modification of `.claude/settings.json` | Classifier-gated via conversation intent | Allowed |
+| Irreversible local destruction (`rm -rf` untracked, `git reset --hard` uncommitted) | Soft-denied | Allowed |
+| Routine reads/writes, `pytest`, `ruff`, `git push` to working branch | Auto-approved | Auto-approved |
+
+**Practical consequences for B.1 adaptive dispatch and B.6 tool risk registry:**
+
+- Any dispatch decision that lowers a lane's model tier below Opus (e.g., B.1 routing a task to a Sonnet-tier lane for token-economy reasons) **simultaneously lowers the safety envelope**. The two decisions are not separable — model-tier choice and permission-mode choice are the same decision at the runtime-gate axis.
+- A tool classified as "auto-mode-safe" is not automatically `bypassPermissions`-safe. The B.6 tool risk registry must evaluate every tool against **both** envelopes, and tag any tool that is auto-mode-safe-but-bypass-unsafe as `Opus-tier-only` so downstream routing cannot silently strand it on a non-Opus lane. Destructive tool classes (force-push, external-repo push, self-modification of settings) should refuse non-Opus routing absent operator override.
+- Each non-Opus dispatch is explicitly a `bypassPermissions` environment. Shaping documents and task packets dispatching to non-Opus lanes must carry an explicit safety-envelope-downgrade note so the operator sees the tradeoff at the dispatch axis, not after a destructive action runs.
+
+**Current fleet state.** 100% Opus 4.7 across all 19 lanes; every lane launch emits `--permission-mode auto`; structural tests (`TestPermissionModeAuto`, `TestInvokeReviewPermissionMode`) enforce the flag uniformly. Any deviation from the single-model assumption requires a simultaneous launch-flag change at the activation surfaces (`.claude/tmux/steward-session.sh`, `scripts/internal/review_lane_runner.py::invoke_review`, any future headless launch surface) plus a rewrite of the structural tests to assert the correct flag per lane's declared model. Landing one without the other either breaks CI (test rewrite alone) or silently regresses enforcement (launch-script change alone) — the two must ship together. That work is tracked as Primitive G Phase 0 closeout per the 7-surfaces inventory (issue #2767).
+
+**Cross-reference:** `.claude/rules/80_permission_model.md` §"Model-tier activation constraint" holds the operator-facing activation table (model tier → required launch flag → effective mode).
+
 ## Alternatives considered
 
 1. **Keep `bypassPermissions`.** Rejected. No runtime gate on destructive or exfiltrating actions; self-modification routed through the legacy sensitive-file dialog (#2249) caused repeated lane stalls. The combined post-hoc safety nets (git history, post-merge review) are strictly weaker than auto mode + those same post-hoc nets.


### PR DESCRIPTION
## Summary

Amends ADR 006 and rule 80 to codify that `--permission-mode auto` and
its Sonnet 4.6 classifier gate are **Opus-tier only**. Sonnet/Haiku
sessions must launch with `--dangerously-skip-permissions` and run under
the reduced `bypassPermissions` safety envelope.

- **ADR 006** (`plans/steward_platform/adrs/006-auto-mode.md`) — new
  §\"Model tier interaction\" section placed between `## Consequences` and
  `## Alternatives considered`; preserves the existing §Phase 2 Decision
  Inputs subsection at end. Includes safety-envelope comparison table by
  model tier and practical consequences for B.1 adaptive dispatch / B.6
  tool risk registry.
- **Rule 80** (`.claude/rules/80_permission_model.md`) — new
  §\"Model-tier activation constraint\" subsection appended to the
  §\"Activation\" section; includes a model-tier → launch-flag →
  effective-mode table covering Opus 4.6+, Sonnet 4.6+, and Haiku 4.5+.
- Cross-references present in both directions.

## Why

Issue #2767 surfaced that `--permission-mode auto` is inert on non-Opus
sessions: the CLI either ignores the flag or silently falls back to
`bypassPermissions`, and `PermissionDenied` events are never emitted.
The fleet is currently 100% Opus 4.7 so the gap has not surfaced, but
Platform-11 adaptive dispatch (B.1) is scoped to recommend per-task
model-tier lowering for token-economy reasons. Without this
codification, any future non-Opus dispatch silently downgrades the
safety envelope with no legible signal at the dispatch axis.

## Scope

This PR intentionally amends the two **normative documents only** — the
decision record (ADR 006) and the operator-facing spec (rule 80). The
four author-owned surfaces in the 7-surfaces inventory remain open and
are tracked under issue #2767:

- `.claude/tmux/steward-session.sh` — model-tier conditional launch flag (Primitive G Phase 0)
- `scripts/internal/review_lane_runner.py::invoke_review` — same conditional (Primitive G Phase 0)
- `tests/unit/test_steward_session.py::TestPermissionModeAuto` + `tests/unit/test_review_lane_runner.py::TestInvokeReviewPermissionMode` → rewrite as `TestPermissionModeByModelTier` (ships with launch-script changes)
- B.1 adaptive dispatch + B.6 tool risk registry — absorb model-tier interaction as design input (Primitive B Phase 0 shaping)

Per the task packet constraint: no new ADR; amends existing ADR 006;
no launch-script or test edits in this PR.

## Validation

Task-packet validation surfaces (all verified):

- ADR 006 contains §\"Model tier interaction\" section — line 82 of the amended file
- Rule 80 activation table lists model-tier → flag mapping (Opus/Sonnet/Haiku rows) — lines 82-84 of the amended file
- Cross-reference between ADR 006 and rule 80 present — both directions
- ADR 006 amendment preserves prior Phase 2 Decision Inputs subsection — line 144

Grep confirmation:

\`\`\`
$ grep -n '^## Model tier interaction\|^## Phase 2 Decision Inputs' plans/steward_platform/adrs/006-auto-mode.md
82:## Model tier interaction
144:## Phase 2 Decision Inputs

$ grep -n '### Model-tier activation constraint\|Opus 4.6+\|Sonnet 4.6+\|Haiku 4.5+' .claude/rules/80_permission_model.md
68:### Model-tier activation constraint
82:| Opus 4.6+ | \`--permission-mode auto\` | \`auto\` (classifier-gated) |
83:| Sonnet 4.6+ | \`--dangerously-skip-permissions\` | \`bypassPermissions\` |
84:| Haiku 4.5+ | \`--dangerously-skip-permissions\` | \`bypassPermissions\` |
\`\`\`

Pre-commit hooks: trim-trailing-whitespace, fix-end-of-files,
repo-linter, block-commits-from-main-checkout — all pass. Docs-only PR;
`make check-gated` heavy jobs skipped via `dorny/paths-filter` per PR
#635/#1086.

## Refs

Refs #2767 — 7-surfaces inventory for Opus-only auto-mode constraint.
This PR closes surfaces #1 (ADR 006) and #2 (rule 80); surfaces #3–#7
remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)