### PR TITLE
fix(review): exclude path-existence precheck on plans/**/*.md-only PRs (Refs #2761)

### DIFF
--- a/scripts/internal/deterministic_prechecks.py
+++ b/scripts/internal/deterministic_prechecks.py
@@ -416,9 +416,35 @@ def check_diff(
     # T1: Untested behavior change (diff-level)
     all_findings.extend(_check_untested_behavior_change(changed_files))
 
-    # Plan-audit mode: check referenced file paths exist
+    # Plan-audit mode: check referenced file paths exist.
+    #
+    # Exclusion: when the PR diff touches ONLY markdown files under plans/**,
+    # skip the path-existence precheck.  Governance plan prose frequently
+    # mentions filenames conversationally (e.g. `task_queue.py`, `ops/dashboard.py`
+    # in discussion) that the precheck misinterprets as asserted repo-root
+    # paths.  On pure governance-plan PRs this pattern produced 20–130
+    # false-positive findings with zero actual blockers (see issue #2761).
+    # Mixed PRs (plans + code) still run the check — the heuristic is narrow
+    # so code-changing diffs never bypass path validation.
     if mode == "plan-audit":
-        all_findings.extend(_check_plan_paths(changed_files, repo_root))
+        if _should_run_path_existence_check(changed_files):
+            all_findings.extend(_check_plan_paths(changed_files, repo_root))
+        else:
+            all_findings.append(
+                Finding(
+                    severity="P2",
+                    file="<plan-audit>",
+                    line=0,
+                    category="process",
+                    check_id="PX",
+                    message=(
+                        "path-existence check skipped: PR touches only "
+                        "plans/**/*.md files (per #2761 exclusion — prose "
+                        "path references in governance plans are not "
+                        "asserted repo-root paths)"
+                    ),
+                )
+            )
 
     # V1–V6: verification-contract prechecks (Pattern 10, §10.9 governing plan).
     all_findings.extend(
@@ -505,6 +531,35 @@ def _check_untested_behavior_change(
             ),
         )
     ]
+
+
+def _should_run_path_existence_check(diff_paths: list[str]) -> bool:
+    """Return True when the path-existence precheck should run for *diff_paths*.
+
+    The check is skipped when the PR touches ONLY markdown files under
+    ``plans/**``.  Governance plan prose frequently mentions filenames
+    conversationally (e.g. ``task_queue.py`` inside a sentence) that the
+    precheck misinterprets as asserted repo-root paths.  See issue #2761
+    for concrete examples (PR #2749: 21 findings / 0 blockers; PR #2751:
+    132 findings / 0 blockers).
+
+    Rationale for the narrow heuristic:
+      * Pure governance-plan PRs are entirely under ``plans/**/*.md`` —
+        matching this shape means any "referenced path" is prose, not a
+        real path claim to audit.
+      * Mixed PRs (plans + code) still run the check: a single non-plan
+        file or non-markdown file flips the gate back on, so code-changing
+        diffs cannot bypass path validation.
+
+    An empty ``diff_paths`` list returns True (the check runs) so we never
+    accidentally suppress findings when no diff is available.
+    """
+    if not diff_paths:
+        return True
+    all_are_plan_markdown = all(
+        p.startswith("plans/") and p.endswith(".md") for p in diff_paths
+    )
+    return not all_are_plan_markdown
 
 
 def _check_plan_paths(changed_files: list[str], repo_root: Path) -> list[Finding]:

--- a/tests/unit/test_deterministic_prechecks.py
+++ b/tests/unit/test_deterministic_prechecks.py
@@ -540,7 +540,13 @@ class TestCheckDiffChangedFiles:
         assert findings[0].severity == "P0"
 
     def test_plan_audit_restricted_to_provided_files(self, tmp_path: Path) -> None:
-        """Plan-audit only scans plans in the provided changed_files list."""
+        """Plan-audit only scans plans in the provided changed_files list.
+
+        Note: per issue #2761, the path-existence check is skipped on
+        all-plan-markdown diffs.  This test keeps the check active by
+        including a non-plan file so it can still assert the scoping
+        behavior (plan_a is audited, plan_b is not).
+        """
         plans_dir = tmp_path / "plans" / "sessions"
         plans_dir.mkdir(parents=True)
 
@@ -552,11 +558,16 @@ class TestCheckDiffChangedFiles:
         plan_b = plans_dir / "plan_b.md"
         plan_b.write_text("# Plan B\n\nReferences `also/missing.py` here.\n")
 
-        # Only plan_a is in the PR's changed files
+        # Include a non-plan file so the #2761 exclusion does not skip the
+        # path-existence check.  plan_a is the only plan in the diff.
+        code = tmp_path / "src" / "bid_euchre" / "foo.py"
+        code.parent.mkdir(parents=True)
+        code.write_text("# stub\n")
+
         findings = check_diff(
             mode="plan-audit",
             repo_root=tmp_path,
-            changed_files=["plans/sessions/plan_a.md"],
+            changed_files=["plans/sessions/plan_a.md", "src/bid_euchre/foo.py"],
         )
 
         # Should find broken refs in plan_a but NOT plan_b

--- a/tests/unit/test_verification_contract_prechecks.py
+++ b/tests/unit/test_verification_contract_prechecks.py
@@ -15,8 +15,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "internal"))
 
 from deterministic_prechecks import (  # noqa: E402
+    _should_run_path_existence_check,
     _vc_is_trigger_path,
     _vc_surface_exists,
+    check_diff,
     check_verification_contract,
 )
 
@@ -317,3 +319,155 @@ def test_no_triggers_emits_no_findings(tmp_path: Path) -> None:
         pr_body="",
     )
     assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Path-existence check exclusion (issue #2761)
+#
+# Governance plan markdown PRs triggered 20–130 false-positive findings
+# from the plan-audit path-existence check treating prose path mentions
+# (e.g. ``task_queue.py`` inside a sentence) as asserted repo-root paths.
+# The exclusion skips the check when the diff touches only plans/**/*.md
+# while mixed/code diffs still run it.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_plans_markdown_only_returns_false() -> None:
+    """All-plan-markdown diffs skip the path-existence check."""
+    assert not _should_run_path_existence_check(
+        [
+            "plans/steward_platform/governing_plan.md",
+            "plans/steward_platform/draft7_review_analyst-d.md",
+            "plans/sessions/2026-04-23_foo.md",
+        ]
+    )
+
+
+def test_gate_mixed_pr_returns_true() -> None:
+    """Plan markdown + any non-plan file → run the check."""
+    assert _should_run_path_existence_check(
+        ["plans/steward_platform/governing_plan.md", "src/bid_euchre/foo.py"]
+    )
+
+
+def test_gate_code_only_returns_true() -> None:
+    """Pure code diffs still run the check."""
+    assert _should_run_path_existence_check(
+        ["src/bid_euchre/core/rules.py", "tests/unit/test_rules.py"]
+    )
+
+
+def test_gate_plans_non_markdown_returns_true() -> None:
+    """plans/**/*.yaml or plans/**/*.json still run the check."""
+    assert _should_run_path_existence_check(["plans/browser_game/config.yaml"])
+
+
+def test_gate_non_plans_markdown_returns_true() -> None:
+    """docs/ or README markdown still run the check."""
+    assert _should_run_path_existence_check(["README.md", "docs/01_core/RULES.md"])
+
+
+def test_gate_empty_diff_returns_true() -> None:
+    """Empty diff → run the check (safe default)."""
+    assert _should_run_path_existence_check([])
+
+
+def test_plan_markdown_only_pr_skips_path_check(tmp_path: Path) -> None:
+    """Plans-only PR produces the PX skip marker and zero path-existence findings."""
+    plan = tmp_path / "plans" / "foo.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text(
+        "# Plan\n\n"
+        "See `scripts/internal/missing_script.py` for implementation.\n"
+        "Edit `src/bid_euchre/nonexistent_module.py` and update `ops/dashboard.py`.\n"
+    )
+    findings = check_diff(
+        changed_files=["plans/foo.md"],
+        mode="plan-audit",
+        repo_root=tmp_path,
+        commit_messages=["docs: plan\n\nVerification: plans/foo.md\n"],
+        pr_body="## Summary\n",
+    )
+    px_markers = [f for f in findings if f.check_id == "PX"]
+    assert len(px_markers) == 1, f"expected 1 PX marker, got {len(px_markers)}"
+    assert px_markers[0].severity == "P2"
+    assert "plans/**/*.md" in px_markers[0].message
+    path_findings = [
+        f for f in findings if f.message.startswith("Referenced path does not exist")
+    ]
+    assert (
+        path_findings == []
+    ), f"expected 0 path-existence findings on plans-only PR, got {len(path_findings)}"
+
+
+def test_mixed_pr_runs_path_check(tmp_path: Path) -> None:
+    """Mixed plans + code PR runs the path-existence check and emits findings."""
+    plan = tmp_path / "plans" / "foo.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n\nReferences `tests/unit/nope.py` which is missing.\n")
+    code = tmp_path / "src" / "bid_euchre" / "bar.py"
+    code.parent.mkdir(parents=True)
+    code.write_text("# stub\n")
+    findings = check_diff(
+        changed_files=["plans/foo.md", "src/bid_euchre/bar.py"],
+        mode="plan-audit",
+        repo_root=tmp_path,
+        commit_messages=["feat: bar\n\nVerification: tests/unit/test_bar.py\n"],
+        pr_body="## Summary\n",
+    )
+    # No PX skip marker when the gate says run.
+    assert not any(f.check_id == "PX" for f in findings)
+    # Path-existence check did run — flags the missing tests/unit/nope.py.
+    path_findings = [
+        f for f in findings if f.message.startswith("Referenced path does not exist")
+    ]
+    assert path_findings, "expected path-existence findings on mixed PR"
+
+
+def test_code_only_pr_runs_path_check(tmp_path: Path) -> None:
+    """Code-only PR in plan-audit mode — gate is True (check would run)."""
+    # No plans/*.md in the diff, so `_check_plan_paths` loops find nothing
+    # to audit regardless; the important guarantee is that the gate doesn't
+    # short-circuit and emit a skip marker.
+    code = tmp_path / "src" / "bid_euchre" / "bar.py"
+    code.parent.mkdir(parents=True)
+    code.write_text("# stub\n")
+    findings = check_diff(
+        changed_files=["src/bid_euchre/bar.py"],
+        mode="plan-audit",
+        repo_root=tmp_path,
+        commit_messages=["feat: bar\n\nVerification: tests/unit/test_bar.py\n"],
+        pr_body="## Summary\n",
+    )
+    assert not any(f.check_id == "PX" for f in findings)
+
+
+def test_plan_markdown_prose_references_not_flagged_after_exclusion() -> None:
+    """Golden fixture: plans/steward_platform/draft7_review_analyst-d.md
+
+    Before #2761 fix: the file triggered 132 path-existence findings from
+    prose references.  After the exclusion: zero path-existence findings
+    (plus one PX skip marker).  Regression-locks the fix against future
+    code paths that might re-enable the check on plans-only diffs.
+    """
+    fixture = Path("plans/steward_platform/draft7_review_analyst-d.md")
+    if not fixture.exists():  # pragma: no cover — guards local/CI symmetry
+        import pytest
+
+        pytest.skip(f"golden fixture not present: {fixture}")
+    findings = check_diff(
+        changed_files=[str(fixture)],
+        mode="plan-audit",
+        repo_root=Path("."),
+        commit_messages=[f"docs: review\n\nVerification: {fixture}\n"],
+        pr_body="## Summary\n",
+    )
+    path_findings = [
+        f for f in findings if f.message.startswith("Referenced path does not exist")
+    ]
+    assert path_findings == [], (
+        f"golden fixture regression: expected 0 path-existence findings "
+        f"after #2761 exclusion, got {len(path_findings)}"
+    )
+    px_markers = [f for f in findings if f.check_id == "PX"]
+    assert len(px_markers) == 1, f"expected exactly 1 PX marker, got {len(px_markers)}"


### PR DESCRIPTION
## Summary

- Governance plan markdown PRs triggered 20–137 false-positive findings from the plan-audit path-existence check, which treats prose path mentions (e.g. `task_queue.py` inside a sentence) as asserted repo-root paths.
- Adds a narrow exclusion in `scripts/internal/deterministic_prechecks.py`: when the PR diff touches ONLY `plans/**/*.md`, the path-existence check is skipped and a single `P2/PX` marker finding is emitted.
- Mixed (plans + code) and code-only diffs still run the check — genuine missing-path issues in code-changing PRs remain flagged at BLOCK.

## Why

Issue #2761 documents 4 governance-plan PRs (#2749, #2751, #2759, #2760) where the advisory `reviewing-changes` check produced 20–132 false-positive blocking findings, all from prose. Because the status is advisory and auto-merge uses `tests` + `governance` + `changes`, the PRs landed — but (a) operator cognitive load re-confirming the finding class each time and (b) the risk that a genuine precheck finding on a governance PR would be buried in the noise were the motivating costs.

Implements **Option 1** from the issue (exclusion rule) per the task packet. Options 2 (tighter heuristic) and 3 (severity demotion) are explicitly out of scope.

## Repro / Validation

**Before fix (baseline):**
```
$ uv run python -c "from deterministic_prechecks import _check_plan_paths; …
Total findings: 137
```

**After fix (plans-only):**
```
$ uv run python -c "from deterministic_prechecks import check_diff; …
Total findings: 1
Path-existence findings: 0 (was 137)
PX skip markers: 1
```

**After fix (mixed PR — check still runs):**
```
Path-existence findings: 137 (genuine prose-ref flags preserved on code-changing PRs)
PX skip markers: 0
```

## Tests

- `uv run python -m pytest tests/unit/test_verification_contract_prechecks.py` — 37 passed (9 new tests covering the gate, skip marker, mixed/code-only behavior, and a golden fixture regression-lock using `plans/steward_platform/draft7_review_analyst-d.md`)
- `uv run python -m pytest tests/unit/test_deterministic_prechecks.py` — 69 passed (updated `test_plan_audit_restricted_to_provided_files` to include a non-plan file so the exclusion doesn't short-circuit the scoping assertion)
- `make check-gated` — all checks passed

## Verification Performed

- **Golden fixture regression-lock:** `tests/unit/test_verification_contract_prechecks.py::test_plan_markdown_prose_references_not_flagged_after_exclusion` asserts 0 path-existence findings + exactly 1 PX marker on `plans/steward_platform/draft7_review_analyst-d.md` (was 137 before fix).
- **Gate unit tests:** 6 tests covering every trigger shape — plans-only markdown (skip), mixed (run), code-only (run), plans non-markdown (run), non-plans markdown (run), empty (run).
- **Exclusion end-to-end:** `test_plan_markdown_only_pr_skips_path_check` exercises `check_diff` with a synthetic plans-only diff containing three prose path references — all suppressed, single PX marker emitted.
- **Mixed-diff preserves behavior:** `test_mixed_pr_runs_path_check` asserts that adding any non-plan file to the diff restores the path-existence check.

## Worktree proof

- pwd: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author`
- branch: `fix/precheck-plans-markdown-exclusion-2761`
- Refs #2761 (Tier 2 per `.claude/rules/deferred/55_issue_closure.md` — issue surface spans future governance PRs; verified-close workflow applies once the next governance plan PR passes with <10 precheck findings)

## Scope

- `scripts/internal/deterministic_prechecks.py` — adds `_should_run_path_existence_check()` gate + PX marker emission
- `tests/unit/test_verification_contract_prechecks.py` — 9 new tests
- `tests/unit/test_deterministic_prechecks.py` — updated one scoping test to keep the check active

Verification: tests/unit/test_verification_contract_prechecks.py