### PR TITLE
fix: model-aware launch flags for Claude Code permission mode (Fixes #2767)

### DIFF
--- a/.claude/lane_models.json
+++ b/.claude/lane_models.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Per-lane model-tier configuration. Source of truth for which launch flag each lane gets (see .claude/rules/80_permission_model.md § Model-tier activation constraint). Schema: {\"lanes\": {\"<lane-id>\": {\"model\": \"opus|sonnet|haiku\"}, ...}}. Opus-tier lanes launch with --permission-mode auto (classifier-gated); Sonnet/Haiku-tier lanes launch with --dangerously-skip-permissions (explicit reduced safety envelope). Loaders: .claude/tmux/steward-session.sh (shell, via python3 inline) + scripts/internal/lane_models.py (Python, for review_lane_runner). Unknown or missing lanes default to opus.",
+  "_schema_version": 1,
+  "lanes": {
+    "orchestrator": {"model": "opus"},
+    "ops": {"model": "opus"},
+    "review": {"model": "opus"},
+    "analyst-a": {"model": "opus"},
+    "analyst-b": {"model": "opus"},
+    "analyst-c": {"model": "opus"},
+    "analyst-d": {"model": "opus"},
+    "author-a": {"model": "opus"},
+    "author-b": {"model": "opus"},
+    "author-c": {"model": "opus"},
+    "author-d": {"model": "opus"},
+    "brws-author-a": {"model": "opus"},
+    "brws-author-b": {"model": "opus"},
+    "brws-author-c": {"model": "opus"},
+    "brws-author-d": {"model": "opus"},
+    "flex-a": {"model": "opus"},
+    "flex-b": {"model": "opus"},
+    "flex-c": {"model": "opus"},
+    "flex-d": {"model": "opus"}
+  }
+}

--- a/.claude/rules/80_permission_model.md
+++ b/.claude/rules/80_permission_model.md
@@ -32,30 +32,51 @@ The CLI only activates auto mode when the launch command includes
 `"auto"` still starts in `bypassPermissions` — the classifier gate does not
 engage and `PermissionDenied` events are never emitted.
 
-Two consequences for the fleet (#2685):
+**Activation is further conditioned on the lane's model tier** — see the
+next section ("Model-tier activation constraint") for the canonical table
+and the `.claude/lane_models.json` config that drives per-lane flag
+selection. The short version: Opus lanes get `--permission-mode auto`,
+Sonnet/Haiku lanes get `--dangerously-skip-permissions`. The two launch
+surfaces below emit the tier-correct flag for each lane they launch.
 
-1. **Every tmux pane launched by `steward-session.sh` must include
-   `--permission-mode auto`.** The launcher script (`.claude/tmux/steward-session.sh`)
-   passes the flag to each `$CLAUDE_BIN` invocation — orchestrator, ops, review,
-   all four analyst/author/browser/flex panes, 19 launches total. On
-   orchestrator restarts the flag is placed before `$ORCH_CHANNEL_FLAGS` so the
+Two consequences for the fleet (#2685, refined by #2767):
+
+1. **Every tmux pane launched by `steward-session.sh` emits the
+   tier-correct launch flag per `.claude/lane_models.json`.** The launcher
+   script (`.claude/tmux/steward-session.sh`) routes every `$CLAUDE_BIN`
+   invocation — orchestrator, ops, review, all four analyst/author/browser/
+   flex panes, 19 launches total — through the
+   `permission_mode_flag_for_lane` helper. The helper reads the canonical
+   config and emits either `--permission-mode auto` (Opus) or
+   `--dangerously-skip-permissions` (Sonnet/Haiku). On orchestrator restarts
+   the helper invocation is placed before `$ORCH_CHANNEL_FLAGS` so the
    channel-flags expansion is deterministic.
-2. **Every headless subprocess launch must include the flag explicitly.**
-   The autonomous review coordinator spawns `claude` via `subprocess.run` in
-   `scripts/internal/review_lane_runner.py::invoke_review`. That argv list
-   must carry `--permission-mode auto` alongside `--agent steward-review`.
-   Any future headless launch surface (plan-review adapters, one-shot
-   `claude --print` invocations, batch review harnesses) must carry the flag
-   too — there is no implicit inheritance from shared settings.
+2. **Every headless subprocess launch emits the tier-correct flag
+   explicitly.** The autonomous review coordinator spawns `claude` via
+   `subprocess.run` in `scripts/internal/review_lane_runner.py::invoke_review`.
+   That argv list splices the fragment returned by
+   `lane_models.permission_mode_args_for_lane(LANE_ID)` — `["--permission-mode",
+   "auto"]` for Opus, `["--dangerously-skip-permissions"]` for Sonnet/Haiku —
+   alongside `--agent steward-review`. Any future headless launch surface
+   (plan-review adapters, one-shot `claude --print` invocations, batch
+   review harnesses) must route through the same helper — there is no
+   implicit inheritance from shared settings.
 
 Both surfaces are locked down with structural tests:
 
-- `tests/unit/test_steward_session.py::TestPermissionModeAuto` asserts every
-  `$CLAUDE_BIN` launch line in the tmux script contains the flag. Adding a
-  new lane without the flag fails the test.
-- `tests/unit/test_review_lane_runner.py::TestInvokeReviewPermissionMode`
+- `tests/unit/test_steward_session.py::TestPermissionModeByModelTier`
+  asserts every `$CLAUDE_BIN` launch line in the tmux script calls
+  `permission_mode_flag_for_lane <lane-id>`, and functionally verifies the
+  helper emits the tier-correct flag for Opus / Sonnet / Haiku / missing /
+  invalid configs. A sibling `TestLaneModelsJson` validates the canonical
+  `.claude/lane_models.json` config, and `TestLaneModelsLoader` validates
+  the Python loader shared with the review runner.
+- `tests/unit/test_review_lane_runner.py::TestInvokeReviewPermissionModeByModelTier`
   mocks `subprocess.run` and asserts the argv list passed to `claude`
-  contains `--permission-mode auto`.
+  contains `--permission-mode auto` when the review lane is declared Opus
+  and `--dangerously-skip-permissions` when declared Sonnet/Haiku — in
+  both the mocked-helper case and an end-to-end case through the real
+  `lane_models` loader against a tmp-path config.
 
 **Rollout note:** Landing the flag alone does not activate auto mode on
 running lanes — existing sessions continue in their launched mode until they
@@ -83,23 +104,56 @@ not a fleet-wide constant:
 | Sonnet 4.6+ | `--dangerously-skip-permissions` | `bypassPermissions` |
 | Haiku 4.5+ | `--dangerously-skip-permissions` | `bypassPermissions` |
 
-**Launch-script implication.** `.claude/tmux/steward-session.sh` and
-`scripts/internal/review_lane_runner.py::invoke_review` currently hardcode
-`--permission-mode auto` for every lane (the structural tests above lock
-this in). That is correct for the current fleet — 100% Opus 4.7 — but is a
-pending fix when any lane moves to Sonnet or Haiku for token-economy or
-dispatch reasons. The fix must read per-lane model-tier config and emit the
-correct flag. This change is tracked as Primitive G Phase 0 closeout under
-the 7-surfaces inventory (issue #2767).
+**Canonical config file.** `.claude/lane_models.json` is the source of
+truth for per-lane model tier. Schema:
 
-**Structural-test implication.** `TestPermissionModeAuto` and
-`TestInvokeReviewPermissionMode` both assert `--permission-mode auto`
-unconditionally. When the launch scripts gain model-tier conditioning, the
-tests must be rewritten as `TestPermissionModeByModelTier` asserting the
-correct flag per lane's declared model. Landing launch-script conditioning
-without the test rewrite will break CI; landing the test rewrite without
-the launch-script conditioning silently regresses enforcement on the
-current Opus fleet. **The two changes must ship together.**
+```json
+{
+  "_schema_version": 1,
+  "lanes": {
+    "<lane-id>": {"model": "opus" | "sonnet" | "haiku"},
+    ...
+  }
+}
+```
+
+Two loaders read this file and MUST stay behaviorally consistent:
+
+- **Shell loader** — `permission_mode_flag_for_lane` in
+  `.claude/tmux/steward-session.sh` (uses an inline `python3 -c` to parse
+  the JSON; falls back to Opus on any error).
+- **Python loader** — `scripts/internal/lane_models.py`, consumed by
+  `scripts/internal/review_lane_runner.py::invoke_review`.
+
+Unknown or missing lanes default to Opus. This is the safest failure mode
+for the current 100%-Opus fleet; new lanes are expected to declare a tier
+explicitly. Changing the default (e.g., to block launches on missing
+entries) is itself a security-relevant diff and must be reviewed.
+
+**Launch-script implementation (resolved by #2767).** Both launch surfaces
+— `.claude/tmux/steward-session.sh` and `scripts/internal/review_lane_runner.py::invoke_review`
+— now route every launch through a per-lane helper that reads
+`.claude/lane_models.json` and emits the tier-correct flag. The shell and
+Python loaders share the config file and the same invalid-tier coercion
+semantics. Structural tests (`TestPermissionModeByModelTier`,
+`TestInvokeReviewPermissionModeByModelTier`, `TestLaneModelsJson`,
+`TestLaneModelsLoader`) lock in the helper wiring, the config schema, and
+the emitted argv for each tier.
+
+**Operator workflow for tier changes.** Moving a lane to Sonnet or Haiku
+(for token-economy or dispatch reasons) is a one-file change:
+
+```bash
+# 1. Edit .claude/lane_models.json — set "model" to the desired tier.
+# 2. Commit + merge via normal PR workflow (security-relevant diff).
+# 3. Restart the lane so it relaunches with the new flag:
+tmux respawn-pane -k -t steward:<window>.<pane> --continue
+```
+
+The tmux launcher re-reads the config on each launch; no cached state to
+flush. `TestLaneModelsJson` enforces that every listed lane has a valid
+model, so typos (e.g., `"sonet"`) fail CI before a lane can silently fall
+back to Opus.
 
 **Never substitute launch flags for model-tier intent.** Passing
 `--permission-mode auto` to a non-Opus lane is the worst outcome: the flag
@@ -107,7 +161,9 @@ and settings encode auto-mode discipline, but the runtime gate is silently
 inactive. The explicit `--dangerously-skip-permissions` launch makes the
 reduced safety envelope legible at every observation point (log output,
 `gh pr checks`, operator-readable launch command). Operators MUST NOT
-cross-wire these flags to mask model-tier selection.
+cross-wire these flags to mask model-tier selection. The per-lane helper
+pattern makes cross-wiring structurally impossible — edit the config, not
+the launch command.
 
 **Cross-reference:** ADR 006 §"Model tier interaction" captures the
 decision record and the safety envelope per-tier comparison table.

--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -133,6 +133,55 @@ merge_settings_local() {
     fi
 }
 
+# Emit the correct claude CLI permission-mode flag(s) for a lane, based on
+# the lane's declared model tier in .claude/lane_models.json (#2767).
+#
+# Opus  → '--permission-mode auto' (classifier-gated per rule 80)
+# Sonnet/Haiku → '--dangerously-skip-permissions' (explicit reduced
+#                safety envelope; `--permission-mode auto` silently falls
+#                back for non-Opus sessions and hides enforcement
+#                legibility).
+#
+# Unknown or missing lanes default to Opus (matches current 100%-Opus fleet;
+# explicit config entries are expected for any non-Opus lane).
+#
+# Output is intended to be spliced unquoted into a tmux command line so
+# word splitting produces one token (`--dangerously-skip-permissions`) or
+# two tokens (`--permission-mode auto`) as appropriate.
+#
+# This function must stay behaviorally consistent with
+# scripts/internal/lane_models.py::permission_mode_args_for_lane.
+# Args: lane_id
+permission_mode_flag_for_lane() {
+    local lane="$1"
+    local models_file="${MAIN_DIR}/.claude/lane_models.json"
+    local model="opus"
+    if [ -f "$models_file" ]; then
+        model="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        data = json.load(fh)
+    lanes = data.get("lanes") if isinstance(data, dict) else None
+    entry = lanes.get(sys.argv[2]) if isinstance(lanes, dict) else None
+    model = entry.get("model") if isinstance(entry, dict) else None
+    if model not in ("opus", "sonnet", "haiku"):
+        model = "opus"
+    print(model)
+except Exception:
+    print("opus")
+' "$models_file" "$lane" 2>/dev/null || echo opus)"
+    fi
+    case "$model" in
+        sonnet|haiku)
+            printf '%s\n' "--dangerously-skip-permissions"
+            ;;
+        opus|*)
+            printf '%s\n' "--permission-mode auto"
+            ;;
+    esac
+}
+
 validate_worktree_path() {
     local path="$1"
     local resolved
@@ -428,7 +477,7 @@ fi
 
 # --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator --permission-mode auto $ORCH_CHANNEL_FLAGS
+    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $(permission_mode_flag_for_lane orchestrator) $ORCH_CHANNEL_FLAGS
 
 # ---------------------------------------------------------------------------
 # Auto-compact window for non-orchestrator lanes (token economy optimization).
@@ -486,53 +535,53 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
 fi
 
 tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
-    "$CLAUDE_BIN" --name ops --agent steward-ops --permission-mode auto
+    "$CLAUDE_BIN" --name ops --agent steward-ops $(permission_mode_flag_for_lane ops)
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
-    "$CLAUDE_BIN" --name review --agent steward-review --permission-mode auto
+    "$CLAUDE_BIN" --name review --agent steward-review $(permission_mode_flag_for_lane review)
 tmux select-layout -t "${SESSION}:central-ops" main-vertical
 
 # --- Window 2: analyst (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n analyst -c "$ANALYST_A" \
-    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst --permission-mode auto
+    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst $(permission_mode_flag_for_lane analyst-a)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_B" \
-    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst --permission-mode auto
+    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst $(permission_mode_flag_for_lane analyst-b)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_C" \
-    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst --permission-mode auto
+    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst $(permission_mode_flag_for_lane analyst-c)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_D" \
-    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst --permission-mode auto
+    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst $(permission_mode_flag_for_lane analyst-d)
 tmux select-layout -t "${SESSION}:analyst" tiled
 
 # --- Window 3: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \
-    "$CLAUDE_BIN" --name author-a --agent steward-author-a --permission-mode auto
+    "$CLAUDE_BIN" --name author-a --agent steward-author-a $(permission_mode_flag_for_lane author-a)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_B" \
-    "$CLAUDE_BIN" --name author-b --agent steward-author-b --permission-mode auto
+    "$CLAUDE_BIN" --name author-b --agent steward-author-b $(permission_mode_flag_for_lane author-b)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_C" \
-    "$CLAUDE_BIN" --name author-c --agent steward-author-c --permission-mode auto
+    "$CLAUDE_BIN" --name author-c --agent steward-author-c $(permission_mode_flag_for_lane author-c)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_D" \
-    "$CLAUDE_BIN" --name author-d --agent steward-author-d --permission-mode auto
+    "$CLAUDE_BIN" --name author-d --agent steward-author-d $(permission_mode_flag_for_lane author-d)
 tmux select-layout -t "${SESSION}:platform" tiled
 
 # --- Window 4: browser ---
 tmux new-window -t "$SESSION" -n browser -c "$BRWS_A" \
-    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a --permission-mode auto
+    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a $(permission_mode_flag_for_lane brws-author-a)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_B" \
-    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b --permission-mode auto
+    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b $(permission_mode_flag_for_lane brws-author-b)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_C" \
-    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c --permission-mode auto
+    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c $(permission_mode_flag_for_lane brws-author-c)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_D" \
-    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d --permission-mode auto
+    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d $(permission_mode_flag_for_lane brws-author-d)
 tmux select-layout -t "${SESSION}:browser" tiled
 
 # --- Window 5: flex (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n flex -c "$FLEX_A" \
-    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a --permission-mode auto
+    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a $(permission_mode_flag_for_lane flex-a)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_B" \
-    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b --permission-mode auto
+    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b $(permission_mode_flag_for_lane flex-b)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_C" \
-    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c --permission-mode auto
+    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c $(permission_mode_flag_for_lane flex-c)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_D" \
-    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d --permission-mode auto
+    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d $(permission_mode_flag_for_lane flex-d)
 tmux select-layout -t "${SESSION}:flex" tiled
 
 # Auto-launch ops monitoring loop (SP-3-08).

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -271,6 +271,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/generate_auction_context_dataset.py` | Auction-context dataset generator (R1 partner features) |
 | `scripts/internal/generate_batch_report.py` | Batch report + eligibility gate |
 | `scripts/internal/github_pr_state.py` | GitHub CLI wrappers for PR metadata and CI status |
+| `scripts/internal/lane_models.py` | Per-lane model-tier loader (reads `.claude/lane_models.json`, emits tier-correct `--permission-mode` argv fragment; shared with the tmux launcher) |
 | `scripts/internal/generate_r1_5_diagnostics.py` | R1.5-v2 calibration diagnostics (cross-rung analysis + bimodality tests) |
 | `scripts/internal/generate_r4_charts.py` | One-off report chart regeneration utility |
 | `scripts/internal/generate_cross_rung_tables.py` | Cross-rung progression table from per-rung comparator CIs |

--- a/scripts/internal/lane_models.py
+++ b/scripts/internal/lane_models.py
@@ -1,0 +1,183 @@
+"""Lane model-tier loader for `.claude/lane_models.json`.
+
+This module is the Python-side source of truth for the per-lane model-tier
+mapping that drives the Claude Code launch-flag choice per
+``.claude/rules/80_permission_model.md`` §"Model-tier activation constraint".
+
+Schema::
+
+    {
+      "_comment": "...",
+      "_schema_version": 1,
+      "lanes": {
+        "<lane-id>": {"model": "opus" | "sonnet" | "haiku"},
+        ...
+      }
+    }
+
+The shell-side loader in ``.claude/tmux/steward-session.sh`` reads the same
+file via an inline ``python3`` invocation and must stay behaviorally
+consistent with this module. The two loaders share a canonical config file;
+any behavior change here requires a matching change in the shell.
+
+Rationale
+---------
+
+* **Opus lanes** launch with ``--permission-mode auto`` so the Sonnet-4.6
+  classifier gate is active. Passing this flag to a non-Opus session
+  silently falls back to ``bypassPermissions`` with no enforcement
+  legibility — the worst outcome (see §"Model tier interaction constraint"
+  and #2767 for the live ops-lane gap).
+* **Sonnet / Haiku lanes** launch with ``--dangerously-skip-permissions``
+  so the reduced safety envelope is legible at every observation point
+  (log output, ``gh pr checks``, operator-readable launch command).
+* **Unknown / missing lanes** default to ``opus``. The fleet today is 100%
+  Opus; new lanes are expected to declare a tier explicitly in the config.
+
+Public API
+----------
+
+* :func:`load_lane_models` — parse the config file (or a test override).
+* :func:`get_lane_model` — return the model tier for a single lane (with
+  ``"opus"`` as the fallback).
+* :func:`permission_mode_args_for_lane` — return the argv fragment (list)
+  that should be spliced into a ``claude`` subprocess invocation for the
+  given lane. Callers pass this through ``list.extend`` rather than
+  string-splicing, avoiding shell-escape surprises.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("lane_models")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Valid model tiers. Unrecognized values coerce to ``DEFAULT_MODEL``.
+VALID_MODELS: frozenset[str] = frozenset({"opus", "sonnet", "haiku"})
+
+#: Default tier applied when a lane is missing from the config or the config
+#: is unreadable. Chosen to match the current 100%-Opus fleet (#2767).
+DEFAULT_MODEL: str = "opus"
+
+#: Repo-relative path to the canonical config file.
+_CONFIG_RELPATH = Path(".claude/lane_models.json")
+
+
+def _default_config_path() -> Path:
+    """Return the canonical config path anchored at the repo root.
+
+    The repo root is inferred from this file's location
+    (``scripts/internal/lane_models.py`` → two ``parent`` hops).
+    """
+    return Path(__file__).resolve().parent.parent.parent / _CONFIG_RELPATH
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_lane_models(config_path: Path | None = None) -> dict[str, str]:
+    """Load the lane → model-tier mapping from the config file.
+
+    Args:
+        config_path: Optional override for the config file path. When omitted,
+            the canonical path ``.claude/lane_models.json`` relative to the
+            repo root is used.
+
+    Returns:
+        A dict keyed by lane id with tier-string values. Unrecognized tier
+        values are coerced to :data:`DEFAULT_MODEL`. Missing or malformed
+        config files yield an empty dict — callers should treat missing
+        lookups as :data:`DEFAULT_MODEL` via :func:`get_lane_model`.
+    """
+    path = config_path if config_path is not None else _default_config_path()
+    if not path.exists():
+        logger.debug("lane_models.json not found at %s — returning empty mapping", path)
+        return {}
+
+    try:
+        raw = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not parse lane_models.json at %s: %s", path, exc)
+        return {}
+
+    lanes = raw.get("lanes")
+    if not isinstance(lanes, dict):
+        logger.warning("lane_models.json at %s missing or malformed 'lanes' key", path)
+        return {}
+
+    mapping: dict[str, str] = {}
+    for lane_id, entry in lanes.items():
+        if not isinstance(lane_id, str) or not lane_id:
+            continue
+        model = None
+        if isinstance(entry, dict):
+            model = entry.get("model")
+        if not isinstance(model, str) or model not in VALID_MODELS:
+            logger.warning(
+                "lane_models.json: lane %r has invalid model %r — coercing to %r",
+                lane_id,
+                model,
+                DEFAULT_MODEL,
+            )
+            model = DEFAULT_MODEL
+        mapping[lane_id] = model
+    return mapping
+
+
+def get_lane_model(lane_id: str, config_path: Path | None = None) -> str:
+    """Return the model tier for a single lane, defaulting to ``"opus"``.
+
+    Args:
+        lane_id: The lane identifier (e.g., ``"author-c"``).
+        config_path: Optional override for the config file path.
+
+    Returns:
+        One of ``"opus"``, ``"sonnet"``, or ``"haiku"``. Falls back to
+        :data:`DEFAULT_MODEL` when the lane is not listed or the config is
+        unreadable.
+    """
+    mapping = load_lane_models(config_path)
+    return mapping.get(lane_id, DEFAULT_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Permission-mode argv emitter
+# ---------------------------------------------------------------------------
+
+
+def permission_mode_args_for_lane(
+    lane_id: str, config_path: Path | None = None
+) -> list[str]:
+    """Return the argv fragment that activates the correct permission mode.
+
+    The fragment is designed to be spliced into a ``claude`` subprocess
+    argv list via ``list.extend``.
+
+    * ``opus`` →  ``["--permission-mode", "auto"]``
+    * ``sonnet`` / ``haiku`` → ``["--dangerously-skip-permissions"]``
+
+    Never cross-wire these flags. Passing ``--permission-mode auto`` to a
+    non-Opus session silently falls back to ``bypassPermissions`` with no
+    enforcement legibility (the failure mode documented in #2767).
+
+    Args:
+        lane_id: The lane identifier (e.g., ``"review"``).
+        config_path: Optional override for the config file path.
+
+    Returns:
+        A list of CLI tokens.
+    """
+    model = get_lane_model(lane_id, config_path)
+    if model == "opus":
+        return ["--permission-mode", "auto"]
+    # sonnet / haiku — ``--dangerously-skip-permissions`` is the explicit
+    # legible reduced-safety envelope.
+    return ["--dangerously-skip-permissions"]

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -32,6 +32,11 @@ from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
+# Local helpers — kept as a local import so the module remains importable
+# when the scripts/internal directory is not on sys.path (e.g., from tests
+# that only import lane_models directly).
+from lane_models import permission_mode_args_for_lane
+
 from bid_euchre.ops.review_queue import (
     STATUS_BLOCKED,
     STATUS_FAILED,
@@ -471,20 +476,26 @@ def invoke_review(pr_number: int, branch: str, head_sha: str) -> dict[str, Any]:
         f"reason (string), findings (list of dicts with severity, file, message)."
     )
 
+    # Model-tier-aware permission-mode selection (#2767).
+    # Opus → ["--permission-mode", "auto"] (classifier-gated).
+    # Sonnet / Haiku → ["--dangerously-skip-permissions"] (explicit reduced
+    # safety envelope; --permission-mode auto silently falls back for
+    # non-Opus models and hides enforcement legibility).
+    argv = [
+        "claude",
+        "--agent",
+        "steward-review",
+        *permission_mode_args_for_lane(LANE_ID),
+        "--print",
+        "--output-format",
+        "json",
+        "-p",
+        prompt,
+    ]
+
     try:
         result = subprocess.run(
-            [
-                "claude",
-                "--agent",
-                "steward-review",
-                "--permission-mode",
-                "auto",
-                "--print",
-                "--output-format",
-                "json",
-                "-p",
-                prompt,
-            ],
+            argv,
             capture_output=True,
             text=True,
             timeout=600,  # 10 minute timeout for review

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -910,32 +910,56 @@ class TestRunOnceWithPreflight:
         mock_preflight.assert_not_called()
 
 
-class TestInvokeReviewPermissionMode:
-    """Tests for the --permission-mode auto flag on the steward-review launch (#2685).
+class TestInvokeReviewPermissionModeByModelTier:
+    """Tests for model-tier-aware permission-mode selection on ``invoke_review`` (#2767).
 
-    ``invoke_review`` spawns ``claude`` as a subprocess. For headless launches,
-    auto permission mode must be activated via ``--permission-mode auto`` on the
-    CLI; ``defaultMode`` in settings.json alone is insufficient. These tests
-    mock ``subprocess.run`` and inspect the argument list.
+    ``invoke_review`` spawns ``claude`` as a subprocess. The launch flag must be
+    a function of the review lane's model tier, NOT a fleet-wide constant:
+
+    * ``opus`` →  argv contains ``--permission-mode auto`` (classifier-gated).
+    * ``sonnet`` / ``haiku`` → argv contains ``--dangerously-skip-permissions``
+      (explicit reduced safety envelope).
+
+    Passing ``--permission-mode auto`` to a non-Opus session silently falls
+    back to ``bypassPermissions`` with no enforcement legibility — the
+    failure mode documented in #2767 and ``.claude/rules/80_permission_model.md``
+    § "Model-tier activation constraint".
+
+    These tests mock ``subprocess.run`` to inspect the argument list, and
+    patch ``permission_mode_args_for_lane`` (or the underlying
+    ``load_lane_models`` loader via a tmp-path config) to simulate each tier.
     """
 
-    @patch("review_lane_runner.subprocess.run")
-    def test_subprocess_args_include_permission_mode_auto(
-        self, mock_run: MagicMock
-    ) -> None:
-        """invoke_review must pass --permission-mode auto to claude subprocess."""
-        import review_lane_runner
-
-        # Mock subprocess.run to return a successful JSON payload so the caller
-        # does not fail on downstream parsing.
+    @staticmethod
+    def _mock_subprocess_ok(mock_run: MagicMock) -> None:
+        """Make subprocess.run return a successful JSON payload."""
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout=json.dumps({"status": "passed", "reason": "clean", "findings": []}),
             stderr="",
         )
 
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_opus_lane_emits_permission_mode_auto(
+        self, mock_run: MagicMock, mock_perm: MagicMock
+    ) -> None:
+        """Opus tier → argv includes ``--permission-mode auto``."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
         review_lane_runner.invoke_review(
             pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        assert mock_perm.called, "invoke_review must call permission_mode_args_for_lane"
+        # Helper must be called with the review lane id.
+        perm_args, _ = mock_perm.call_args
+        assert perm_args[0] == "review", (
+            "permission_mode_args_for_lane must be called with LANE_ID='review', "
+            f"got {perm_args[0]!r}"
         )
 
         assert mock_run.called, "invoke_review must call subprocess.run"
@@ -943,26 +967,31 @@ class TestInvokeReviewPermissionMode:
         argv = call_args[0]
         assert isinstance(argv, list), "subprocess.run must be called with an argv list"
         assert argv[0] == "claude", f"First arg must be 'claude', got {argv[0]!r}"
+
         assert "--permission-mode" in argv, (
-            "invoke_review subprocess args must include '--permission-mode' "
-            f"(got {argv})"
+            "Opus-tier argv must include '--permission-mode' " f"(got {argv})"
         )
         idx = argv.index("--permission-mode")
         assert idx + 1 < len(argv), "--permission-mode must be followed by a value"
-        assert (
-            argv[idx + 1] == "auto"
-        ), f"--permission-mode must be followed by 'auto' (got {argv[idx + 1]!r})"
+        assert argv[idx + 1] == "auto", (
+            f"Opus-tier --permission-mode must be followed by 'auto' "
+            f"(got {argv[idx + 1]!r})"
+        )
+        assert "--dangerously-skip-permissions" not in argv, (
+            "Opus-tier argv must NOT include --dangerously-skip-permissions "
+            f"(got {argv})"
+        )
 
+    @patch("review_lane_runner.permission_mode_args_for_lane")
     @patch("review_lane_runner.subprocess.run")
-    def test_subprocess_args_preserve_existing_flags(self, mock_run: MagicMock) -> None:
-        """Adding --permission-mode auto must not drop --agent, --print, -p flags."""
+    def test_sonnet_lane_emits_dangerously_skip_permissions(
+        self, mock_run: MagicMock, mock_perm: MagicMock
+    ) -> None:
+        """Sonnet tier → argv includes ``--dangerously-skip-permissions``."""
         import review_lane_runner
 
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps({"status": "passed", "reason": "clean", "findings": []}),
-            stderr="",
-        )
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--dangerously-skip-permissions"]
 
         review_lane_runner.invoke_review(
             pr_number=42, branch="feat/foo", head_sha="abc123"
@@ -970,12 +999,179 @@ class TestInvokeReviewPermissionMode:
 
         call_args, _ = mock_run.call_args
         argv = call_args[0]
-        # The existing flags must still be present.
+        assert "--dangerously-skip-permissions" in argv, (
+            "Sonnet-tier argv must include '--dangerously-skip-permissions' "
+            f"(got {argv})"
+        )
+        assert "--permission-mode" not in argv, (
+            "Sonnet-tier argv must NOT include '--permission-mode' — "
+            "cross-wiring flags silently falls back to bypassPermissions "
+            f"(got {argv})"
+        )
+        assert "auto" not in argv, (
+            "Sonnet-tier argv must NOT include the 'auto' token " f"(got {argv})"
+        )
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_haiku_lane_emits_dangerously_skip_permissions(
+        self, mock_run: MagicMock, mock_perm: MagicMock
+    ) -> None:
+        """Haiku tier → argv includes ``--dangerously-skip-permissions``."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--dangerously-skip-permissions"]
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert "--dangerously-skip-permissions" in argv, (
+            "Haiku-tier argv must include '--dangerously-skip-permissions' "
+            f"(got {argv})"
+        )
+        assert "--permission-mode" not in argv, (
+            "Haiku-tier argv must NOT include '--permission-mode' " f"(got {argv})"
+        )
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_existing_flags_preserved_on_opus(
+        self, mock_run: MagicMock, mock_perm: MagicMock
+    ) -> None:
+        """Model-tier conditioning must not drop --agent, --print, -p, --output-format."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
         assert (
             "--agent" in argv and "steward-review" in argv
-        ), f"Existing --agent steward-review must be preserved: {argv}"
-        assert "--print" in argv, f"Existing --print must be preserved: {argv}"
-        assert "-p" in argv, f"Existing -p prompt flag must be preserved: {argv}"
+        ), f"--agent steward-review must be preserved: {argv}"
+        assert "--print" in argv, f"--print must be preserved: {argv}"
+        assert "-p" in argv, f"-p prompt flag must be preserved: {argv}"
         assert (
             "--output-format" in argv and "json" in argv
-        ), f"Existing --output-format json must be preserved: {argv}"
+        ), f"--output-format json must be preserved: {argv}"
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_existing_flags_preserved_on_sonnet(
+        self, mock_run: MagicMock, mock_perm: MagicMock
+    ) -> None:
+        """Sonnet-tier path must not drop --agent, --print, -p, --output-format."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--dangerously-skip-permissions"]
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert (
+            "--agent" in argv and "steward-review" in argv
+        ), f"--agent steward-review must be preserved: {argv}"
+        assert "--print" in argv, f"--print must be preserved: {argv}"
+        assert "-p" in argv, f"-p prompt flag must be preserved: {argv}"
+        assert (
+            "--output-format" in argv and "json" in argv
+        ), f"--output-format json must be preserved: {argv}"
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_integration_with_real_loader_opus_config(
+        self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: real loader + explicit opus config → argv has '--permission-mode auto'.
+
+        Uses the real ``permission_mode_args_for_lane`` function against a
+        tmp-path config file to ensure the wiring from lane_models.json through
+        the review runner emits the correct argv for an Opus-tier lane.
+        """
+        import lane_models
+        import review_lane_runner
+
+        # Build a minimal config where "review" is explicitly opus.
+        cfg_path = tmp_path / "lane_models.json"
+        cfg_path.write_text(
+            json.dumps({"_schema_version": 1, "lanes": {"review": {"model": "opus"}}})
+        )
+
+        # Monkeypatch the module-level import in review_lane_runner to route
+        # through a lambda that uses our tmp config.
+        monkeypatch.setattr(
+            review_lane_runner,
+            "permission_mode_args_for_lane",
+            lambda lane_id: lane_models.permission_mode_args_for_lane(
+                lane_id, config_path=cfg_path
+            ),
+        )
+
+        self._mock_subprocess_ok(mock_run)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert (
+            "--permission-mode" in argv
+        ), f"Real loader + opus config must emit --permission-mode: {argv}"
+        idx = argv.index("--permission-mode")
+        assert (
+            argv[idx + 1] == "auto"
+        ), f"Real loader + opus config must emit 'auto': {argv[idx + 1]!r}"
+
+    @patch("review_lane_runner.subprocess.run")
+    def test_integration_with_real_loader_sonnet_config(
+        self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: real loader + sonnet config → argv has '--dangerously-skip-permissions'.
+
+        Guard against the silent-fallback footgun: if the loader routed a
+        sonnet lane to ``--permission-mode auto``, the lane would launch with
+        ``bypassPermissions`` and lose classifier enforcement (#2767).
+        """
+        import lane_models
+        import review_lane_runner
+
+        cfg_path = tmp_path / "lane_models.json"
+        cfg_path.write_text(
+            json.dumps({"_schema_version": 1, "lanes": {"review": {"model": "sonnet"}}})
+        )
+
+        monkeypatch.setattr(
+            review_lane_runner,
+            "permission_mode_args_for_lane",
+            lambda lane_id: lane_models.permission_mode_args_for_lane(
+                lane_id, config_path=cfg_path
+            ),
+        )
+
+        self._mock_subprocess_ok(mock_run)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert (
+            "--dangerously-skip-permissions" in argv
+        ), f"Real loader + sonnet config must emit --dangerously-skip-permissions: {argv}"
+        assert "--permission-mode" not in argv, (
+            "Real loader + sonnet config must NOT cross-wire '--permission-mode' "
+            f"(silent-fallback footgun): {argv}"
+        )

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -48,6 +48,42 @@ def _read_steward_script() -> str:
     return STEWARD_SCRIPT.read_text()
 
 
+def _read_lane_models_json() -> str:
+    """Read .claude/lane_models.json, preferring the git-committed version in CI.
+
+    Same CI pitfall as ``_read_steward_script``: ``setup-uv`` cache restoration
+    can overwrite the working tree during the tests-shard job, dropping files
+    that are on the PR branch but not on the base. When ``GITHUB_SHA`` is set,
+    we read from the merge-commit blob to get the correct PR content. Locally
+    we just read the file.
+    """
+    github_sha = os.environ.get("GITHUB_SHA")
+    if github_sha:
+        try:
+            return subprocess.check_output(
+                [
+                    "git",
+                    "show",
+                    f"{github_sha}:.claude/lane_models.json",
+                ],
+                cwd=str(REPO_ROOT),
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            pass  # fall through to filesystem read
+    return (REPO_ROOT / ".claude" / "lane_models.json").read_text()
+
+
+def _lane_models_json_available() -> bool:
+    """True if .claude/lane_models.json is readable via filesystem or GITHUB_SHA."""
+    try:
+        _read_lane_models_json()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -1569,30 +1605,33 @@ class TestLaneModelsJson:
     VALID_MODELS = frozenset({"opus", "sonnet", "haiku"})
 
     def test_config_file_exists(self) -> None:
+        # Use the GITHUB_SHA-aware helper: in CI, setup-uv cache restoration
+        # can overwrite the working tree and drop PR-only files, so we must
+        # accept the git-blob form of the file as "existing" for this test.
         assert (
-            self._LANE_MODELS_PATH.exists()
+            _lane_models_json_available()
         ), ".claude/lane_models.json is required by #2767 fix"
 
     def test_config_is_valid_json(self) -> None:
-        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        data = json.loads(_read_lane_models_json())
         assert isinstance(data, dict), "Top level must be a JSON object"
 
     def test_config_has_lanes_key(self) -> None:
-        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        data = json.loads(_read_lane_models_json())
         assert "lanes" in data and isinstance(
             data["lanes"], dict
         ), "Config must contain a 'lanes' object"
 
     def test_all_19_lanes_listed(self) -> None:
         """Every lane launched by steward-session.sh must have a config entry."""
-        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        data = json.loads(_read_lane_models_json())
         lanes = set(data["lanes"].keys())
         missing = self.EXPECTED_LANES - lanes
         assert not missing, f"Missing lane entries: {sorted(missing)}"
 
     def test_all_models_valid(self) -> None:
         """Every entry's model must be opus / sonnet / haiku."""
-        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        data = json.loads(_read_lane_models_json())
         for lane_id, entry in data["lanes"].items():
             assert isinstance(entry, dict), f"Lane {lane_id!r} entry must be an object"
             model = entry.get("model")
@@ -1608,7 +1647,7 @@ class TestLaneModelsJson:
         this test must be updated in the same PR as the config change so
         reviewers see the tier change explicitly.
         """
-        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        data = json.loads(_read_lane_models_json())
         non_opus = [
             lane_id
             for lane_id, entry in data["lanes"].items()

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -1247,14 +1247,29 @@ validate_worktree_path "{external}"
 # ---------------------------------------------------------------------------
 
 
-class TestPermissionModeAuto:
-    """Tests for the --permission-mode auto launch flag (#2685).
+class TestPermissionModeByModelTier:
+    """Tests for model-tier-aware launch flags (#2685 original, #2767 fix).
 
-    Auto mode is activated per-launch via the ``--permission-mode auto`` CLI flag,
-    not by ``defaultMode: "auto"`` in settings.json alone. Every claude launch in
-    steward-session.sh must include the flag so lanes inherit auto mode on
-    session start.  New lanes added in the future must also carry the flag —
-    this test catches missing flags via a grep-based structural check.
+    Per ``.claude/rules/80_permission_model.md`` §"Model-tier activation
+    constraint", the launch-flag choice is a function of the lane's model
+    tier, not a fleet-wide constant:
+
+    * Opus (Claude Opus 4.6+)  → ``--permission-mode auto`` (classifier-gated)
+    * Sonnet / Haiku           → ``--dangerously-skip-permissions`` (explicit
+                                  reduced safety envelope)
+
+    Passing ``--permission-mode auto`` to a non-Opus session silently falls
+    back to ``bypassPermissions`` with no enforcement legibility — the worst
+    outcome. The launch script reads ``.claude/lane_models.json`` via the
+    ``permission_mode_flag_for_lane`` helper and emits the correct flag per
+    lane.
+
+    These structural tests lock in:
+    1. Every ``$CLAUDE_BIN`` launch routes through ``permission_mode_flag_for_lane``.
+    2. No launch line hardcodes a permission-mode flag.
+    3. The orchestrator's call precedes ``$ORCH_CHANNEL_FLAGS``.
+    4. The helper emits the correct flag per tier (functional check).
+    5. The canonical ``.claude/lane_models.json`` is valid and opus-defaulting.
     """
 
     @staticmethod
@@ -1266,60 +1281,481 @@ class TestPermissionModeAuto:
             if "$CLAUDE_BIN" in line and "--agent" in line
         ]
 
-    def test_all_launch_lines_have_permission_mode_auto(self) -> None:
-        """Every $CLAUDE_BIN --agent launch line must include --permission-mode auto."""
-        # Use _read_steward_script() so CI (where setup-uv cache can restore
-        # .git/HEAD to the base branch) reads the PR's version of the script
-        # via git show $GITHUB_SHA:... rather than the stale working tree.
+    # -- Structural checks on steward-session.sh ------------------------
+
+    def test_helper_function_defined(self) -> None:
+        """steward-session.sh must define permission_mode_flag_for_lane."""
+        content = _read_steward_script()
+        assert (
+            "permission_mode_flag_for_lane()" in content
+        ), "permission_mode_flag_for_lane function must be defined (#2767)"
+
+    def test_helper_reads_lane_models_json(self) -> None:
+        """Helper must resolve model tier from .claude/lane_models.json."""
+        content = _read_steward_script()
+        assert (
+            "lane_models.json" in content
+        ), "helper must reference .claude/lane_models.json as the config source"
+
+    def test_helper_emits_both_flag_variants(self) -> None:
+        """Helper must be able to emit both auto and dangerously-skip variants."""
+        content = _read_steward_script()
+        # Both token strings must appear inside the helper body.
+        assert (
+            "--permission-mode auto" in content
+        ), "helper must emit '--permission-mode auto' for Opus lanes"
+        assert (
+            "--dangerously-skip-permissions" in content
+        ), "helper must emit '--dangerously-skip-permissions' for non-Opus lanes"
+
+    def test_every_launch_line_calls_helper(self) -> None:
+        """Every $CLAUDE_BIN --agent launch line must invoke the helper.
+
+        After #2767, no launch line hardcodes a permission-mode flag; each
+        lane's flag comes from the model-tier helper so the launch script
+        stays correct as lanes move between tiers.
+        """
         content = _read_steward_script()
         launch_lines = self._claude_launch_lines(content)
         assert launch_lines, "Expected at least one claude launch line in script"
         missing = [
             line.strip()
             for line in launch_lines
-            if "--permission-mode auto" not in line
+            if "permission_mode_flag_for_lane" not in line
         ]
         assert not missing, (
-            "Every claude launch in steward-session.sh must include "
-            "`--permission-mode auto` to activate auto permission mode (#2685). "
-            f"Missing the flag on {len(missing)} line(s):\n"
+            "Every claude launch in steward-session.sh must route through "
+            "`permission_mode_flag_for_lane <lane-id>` so the launch flag "
+            "matches the lane's declared model tier (#2767). Missing the "
+            f"helper call on {len(missing)} line(s):\n"
             + "\n".join(f"  {line}" for line in missing)
         )
 
-    def test_permission_mode_flag_count_matches_lanes(self) -> None:
-        """Occurrence count of --permission-mode auto should equal launch-line count.
+    def test_helper_invocation_count_matches_launch_count(self) -> None:
+        """Helper invocation count must equal launch-line count.
 
-        This is a conservative structural check: if someone adds a new lane
-        without the flag, launch count and flag count diverge.
+        One invocation per launch — if someone adds a lane without the
+        helper, the counts diverge.
         """
         content = _read_steward_script()
         launch_lines = self._claude_launch_lines(content)
-        flag_count = content.count("--permission-mode auto")
-        assert flag_count == len(launch_lines), (
-            f"Expected --permission-mode auto on every launch line. "
-            f"Launch lines: {len(launch_lines)}; flag occurrences: {flag_count}"
+        # Count $(permission_mode_flag_for_lane ...) invocations (not the
+        # function definition itself).
+        invocation_count = content.count("$(permission_mode_flag_for_lane ")
+        assert invocation_count == len(launch_lines), (
+            f"Expected one $(permission_mode_flag_for_lane ...) call per "
+            f"launch line. Launch lines: {len(launch_lines)}; "
+            f"invocations: {invocation_count}"
         )
 
-    def test_orchestrator_flag_placed_before_channel_flags(self) -> None:
-        """The orchestrator launch must place --permission-mode auto before $ORCH_CHANNEL_FLAGS.
+    def test_no_hardcoded_flag_on_launch_lines(self) -> None:
+        """No launch line may hardcode a permission-mode flag.
 
-        $ORCH_CHANNEL_FLAGS can expand to ``--channels plugin:...`` or empty; the
-        permission-mode flag must appear before it so the expansion order is
-        deterministic and safe whether the channel flags are empty or populated.
+        Any hardcoded ``--permission-mode auto`` or
+        ``--dangerously-skip-permissions`` on a launch line would make that
+        lane insensitive to tier changes in ``lane_models.json`` — defeating
+        the fix.
+        """
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
+        hardcoded = [
+            line.strip()
+            for line in launch_lines
+            if "--permission-mode" in line or "--dangerously-skip-permissions" in line
+        ]
+        assert not hardcoded, (
+            "Launch lines must not hardcode permission-mode flags. "
+            "Route through permission_mode_flag_for_lane instead "
+            f"(#2767). Hardcoded on {len(hardcoded)} line(s):\n"
+            + "\n".join(f"  {line}" for line in hardcoded)
+        )
+
+    def test_orchestrator_helper_call_before_channel_flags(self) -> None:
+        """Orchestrator helper call must precede $ORCH_CHANNEL_FLAGS.
+
+        ``$ORCH_CHANNEL_FLAGS`` expands to ``--channels plugin:...`` or empty;
+        the permission-mode tokens must appear before it so the expansion
+        order is deterministic and safe whether channel flags are empty or
+        populated.
         """
         content = _read_steward_script()
         launch_lines = self._claude_launch_lines(content)
         orch_lines = [line for line in launch_lines if "steward-orchestrator" in line]
         assert len(orch_lines) == 1, "Expected exactly one orchestrator launch line"
         line = orch_lines[0]
-        pm_pos = line.find("--permission-mode auto")
+        helper_pos = line.find("permission_mode_flag_for_lane")
         channel_pos = line.find("$ORCH_CHANNEL_FLAGS")
-        assert pm_pos > 0, "Orchestrator launch must include --permission-mode auto"
+        assert (
+            helper_pos > 0
+        ), "Orchestrator launch must route through permission_mode_flag_for_lane"
         assert channel_pos > 0, "Orchestrator launch must expand $ORCH_CHANNEL_FLAGS"
-        assert pm_pos < channel_pos, (
-            "--permission-mode auto must appear BEFORE $ORCH_CHANNEL_FLAGS so "
-            "the expansion is safe whether channel flags are empty or populated"
+        assert helper_pos < channel_pos, (
+            "permission_mode_flag_for_lane call must appear BEFORE "
+            "$ORCH_CHANNEL_FLAGS so the expansion is safe whether channel "
+            "flags are empty or populated"
         )
+
+    def test_helper_invocations_cover_all_lanes(self) -> None:
+        """Each lane-id must appear exactly once as helper argument.
+
+        Catches copy-paste errors where one lane's launch uses another
+        lane's id in the helper call.
+        """
+        content = _read_steward_script()
+        expected_lanes = [
+            "orchestrator",
+            "ops",
+            "review",
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            "flex-a",
+            "flex-b",
+            "flex-c",
+            "flex-d",
+        ]
+        for lane in expected_lanes:
+            token = f"$(permission_mode_flag_for_lane {lane})"
+            assert content.count(token) == 1, (
+                f"Expected exactly one invocation of "
+                f"`{token}` in steward-session.sh; "
+                f"found {content.count(token)}"
+            )
+
+    # -- Functional checks on the helper --------------------------------
+
+    @staticmethod
+    def _extract_helper(content: str) -> str:
+        """Extract the permission_mode_flag_for_lane function body.
+
+        Uses brace-depth tracking so the embedded ``case`` block with ``;;``
+        doesn't confuse a naive regex.
+        """
+        lines = content.split("\n")
+        out: list[str] = []
+        in_func = False
+        depth = 0
+        for line in lines:
+            if line.startswith("permission_mode_flag_for_lane()"):
+                in_func = True
+            if in_func:
+                out.append(line)
+                depth += line.count("{") - line.count("}")
+                if depth == 0 and "}" in line and len(out) > 1:
+                    break
+        return "\n".join(out)
+
+    def _run_helper(self, tmp_path: Path, config: dict, lane: str) -> str:
+        """Invoke the helper in a bash subshell with a mocked config file."""
+        cfg_dir = tmp_path / ".claude"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "lane_models.json").write_text(json.dumps(config))
+        helper_body = self._extract_helper(_read_steward_script())
+        script = f"""
+MAIN_DIR="{tmp_path}"
+{helper_body}
+permission_mode_flag_for_lane {lane}
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"helper exited non-zero: {result.stderr}"
+        return result.stdout.strip()
+
+    def test_helper_emits_permission_mode_auto_for_opus_lane(
+        self, tmp_path: Path
+    ) -> None:
+        """Opus-tier lanes must get ``--permission-mode auto``."""
+        config = {"lanes": {"author-a": {"model": "opus"}}}
+        flag = self._run_helper(tmp_path, config, "author-a")
+        assert (
+            flag == "--permission-mode auto"
+        ), f"Opus lane must get '--permission-mode auto', got {flag!r}"
+
+    def test_helper_emits_dangerously_skip_for_sonnet_lane(
+        self, tmp_path: Path
+    ) -> None:
+        """Sonnet-tier lanes must get ``--dangerously-skip-permissions``."""
+        config = {"lanes": {"ops": {"model": "sonnet"}}}
+        flag = self._run_helper(tmp_path, config, "ops")
+        assert (
+            flag == "--dangerously-skip-permissions"
+        ), f"Sonnet lane must get '--dangerously-skip-permissions', got {flag!r}"
+
+    def test_helper_emits_dangerously_skip_for_haiku_lane(self, tmp_path: Path) -> None:
+        """Haiku-tier lanes must get ``--dangerously-skip-permissions``."""
+        config = {"lanes": {"flex-a": {"model": "haiku"}}}
+        flag = self._run_helper(tmp_path, config, "flex-a")
+        assert (
+            flag == "--dangerously-skip-permissions"
+        ), f"Haiku lane must get '--dangerously-skip-permissions', got {flag!r}"
+
+    def test_helper_defaults_to_opus_for_missing_lane(self, tmp_path: Path) -> None:
+        """Lanes not listed in the config must default to Opus treatment.
+
+        The current fleet is 100% Opus; explicit entries are expected for
+        non-Opus lanes. A missing entry must not silently emit
+        ``--dangerously-skip-permissions`` — that would regress the
+        legibility gain.
+        """
+        config = {"lanes": {"author-a": {"model": "opus"}}}
+        flag = self._run_helper(tmp_path, config, "missing-lane")
+        assert flag == "--permission-mode auto", (
+            f"Missing lane must default to Opus treatment "
+            f"('--permission-mode auto'); got {flag!r}"
+        )
+
+    def test_helper_defaults_to_opus_when_config_missing(self, tmp_path: Path) -> None:
+        """Missing config file must also default to Opus."""
+        helper_body = self._extract_helper(_read_steward_script())
+        script = f"""
+MAIN_DIR="{tmp_path}"
+{helper_body}
+permission_mode_flag_for_lane author-a
+"""
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "--permission-mode auto"
+
+    def test_helper_defaults_to_opus_for_invalid_tier(self, tmp_path: Path) -> None:
+        """Invalid tier values must coerce to Opus (safe default)."""
+        config = {"lanes": {"author-a": {"model": "some-unknown-model"}}}
+        flag = self._run_helper(tmp_path, config, "author-a")
+        assert (
+            flag == "--permission-mode auto"
+        ), f"Invalid tier must coerce to '--permission-mode auto'; got {flag!r}"
+
+
+class TestLaneModelsJson:
+    """Tests for the canonical .claude/lane_models.json config file (#2767)."""
+
+    _LANE_MODELS_PATH = REPO_ROOT / ".claude" / "lane_models.json"
+
+    EXPECTED_LANES = frozenset(
+        {
+            "orchestrator",
+            "ops",
+            "review",
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            "flex-a",
+            "flex-b",
+            "flex-c",
+            "flex-d",
+        }
+    )
+
+    VALID_MODELS = frozenset({"opus", "sonnet", "haiku"})
+
+    def test_config_file_exists(self) -> None:
+        assert (
+            self._LANE_MODELS_PATH.exists()
+        ), ".claude/lane_models.json is required by #2767 fix"
+
+    def test_config_is_valid_json(self) -> None:
+        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        assert isinstance(data, dict), "Top level must be a JSON object"
+
+    def test_config_has_lanes_key(self) -> None:
+        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        assert "lanes" in data and isinstance(
+            data["lanes"], dict
+        ), "Config must contain a 'lanes' object"
+
+    def test_all_19_lanes_listed(self) -> None:
+        """Every lane launched by steward-session.sh must have a config entry."""
+        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        lanes = set(data["lanes"].keys())
+        missing = self.EXPECTED_LANES - lanes
+        assert not missing, f"Missing lane entries: {sorted(missing)}"
+
+    def test_all_models_valid(self) -> None:
+        """Every entry's model must be opus / sonnet / haiku."""
+        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        for lane_id, entry in data["lanes"].items():
+            assert isinstance(entry, dict), f"Lane {lane_id!r} entry must be an object"
+            model = entry.get("model")
+            assert model in self.VALID_MODELS, (
+                f"Lane {lane_id!r} has invalid model {model!r}; "
+                f"must be one of {sorted(self.VALID_MODELS)}"
+            )
+
+    def test_fleet_defaults_to_opus(self) -> None:
+        """Current fleet is 100% Opus — all lanes must be Opus by default.
+
+        When a lane moves to Sonnet or Haiku for token-economy reasons,
+        this test must be updated in the same PR as the config change so
+        reviewers see the tier change explicitly.
+        """
+        data = json.loads(self._LANE_MODELS_PATH.read_text())
+        non_opus = [
+            lane_id
+            for lane_id, entry in data["lanes"].items()
+            if entry.get("model") != "opus"
+        ]
+        assert not non_opus, (
+            f"Fleet-default is 100% Opus. Non-Opus entries: {non_opus}. "
+            "If this is intentional, update this test and document the "
+            "tier change in the PR."
+        )
+
+
+class TestLaneModelsLoader:
+    """Tests for the Python loader scripts/internal/lane_models.py (#2767)."""
+
+    @staticmethod
+    def _import_loader():
+        """Import the loader module (scripts/internal/lane_models.py)."""
+        import sys
+
+        scripts_internal = REPO_ROOT / "scripts" / "internal"
+        if str(scripts_internal) not in sys.path:
+            sys.path.insert(0, str(scripts_internal))
+        import lane_models  # type: ignore[import-not-found]
+
+        return lane_models
+
+    def test_load_lane_models_returns_dict(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "lanes": {
+                        "author-a": {"model": "opus"},
+                        "ops": {"model": "sonnet"},
+                    }
+                }
+            )
+        )
+        result = loader.load_lane_models(cfg)
+        assert result == {"author-a": "opus", "ops": "sonnet"}
+
+    def test_load_lane_models_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        result = loader.load_lane_models(tmp_path / "does-not-exist.json")
+        assert result == {}
+
+    def test_load_lane_models_malformed_returns_empty(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text("not { valid json")
+        result = loader.load_lane_models(cfg)
+        assert result == {}
+
+    def test_load_lane_models_coerces_invalid_tier(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {"author-a": {"model": "gpt-5"}}}))
+        result = loader.load_lane_models(cfg)
+        assert result == {"author-a": "opus"}
+
+    def test_get_lane_model_defaults_to_opus(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {"author-a": {"model": "opus"}}}))
+        assert loader.get_lane_model("missing-lane", cfg) == "opus"
+
+    def test_permission_mode_args_opus(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {"author-a": {"model": "opus"}}}))
+        assert loader.permission_mode_args_for_lane("author-a", cfg) == [
+            "--permission-mode",
+            "auto",
+        ]
+
+    def test_permission_mode_args_sonnet(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {"ops": {"model": "sonnet"}}}))
+        assert loader.permission_mode_args_for_lane("ops", cfg) == [
+            "--dangerously-skip-permissions"
+        ]
+
+    def test_permission_mode_args_haiku(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {"flex-a": {"model": "haiku"}}}))
+        assert loader.permission_mode_args_for_lane("flex-a", cfg) == [
+            "--dangerously-skip-permissions"
+        ]
+
+    def test_permission_mode_args_missing_defaults_opus(self, tmp_path: Path) -> None:
+        loader = self._import_loader()
+        cfg = tmp_path / "lane_models.json"
+        cfg.write_text(json.dumps({"lanes": {}}))
+        assert loader.permission_mode_args_for_lane("author-a", cfg) == [
+            "--permission-mode",
+            "auto",
+        ]
+
+    def test_loader_stays_consistent_with_shell_helper(self, tmp_path: Path) -> None:
+        """Python loader and shell helper must produce equivalent output.
+
+        Both read the same config and emit the same token set (modulo Python
+        list vs shell token-stream serialization).
+        """
+        loader = self._import_loader()
+        cfg = tmp_path / ".claude" / "lane_models.json"
+        cfg.parent.mkdir(parents=True)
+        config = {
+            "lanes": {
+                "author-a": {"model": "opus"},
+                "ops": {"model": "sonnet"},
+                "flex-a": {"model": "haiku"},
+            }
+        }
+        cfg.write_text(json.dumps(config))
+
+        helper_body = TestPermissionModeByModelTier._extract_helper(
+            _read_steward_script()
+        )
+
+        for lane, expected in [
+            ("author-a", "--permission-mode auto"),
+            ("ops", "--dangerously-skip-permissions"),
+            ("flex-a", "--dangerously-skip-permissions"),
+            ("nonexistent", "--permission-mode auto"),  # default
+        ]:
+            # Shell helper
+            script = f"""
+MAIN_DIR="{tmp_path}"
+{helper_body}
+permission_mode_flag_for_lane {lane}
+"""
+            result = subprocess.run(
+                ["bash", "-c", script], capture_output=True, text=True
+            )
+            assert result.returncode == 0, result.stderr
+            assert result.stdout.strip() == expected
+
+            # Python loader
+            py_argv = loader.permission_mode_args_for_lane(lane, cfg)
+            assert (
+                " ".join(py_argv) == expected
+            ), f"Python loader and shell helper diverge for lane={lane!r}"
 
 
 class TestLaunchdTemplate:


### PR DESCRIPTION
## Summary

Fixes #2767 — replace the fleet-wide hardcoded `--permission-mode auto` launch flag with per-lane model-tier conditioning.

- **Opus lanes** continue to get `--permission-mode auto` (classifier-gated).
- **Sonnet / Haiku lanes** now get `--dangerously-skip-permissions`, making the reduced safety envelope legible at every observation point (log output, `gh pr checks`, operator-readable launch command).
- Launch-script conditioning and structural-test rewrites ship together per rule 80 §"Structural-test implication" — landing one without the other either breaks CI or silently regresses enforcement.

## Why

Cross-wiring `--permission-mode auto` to a non-Opus lane silently falls back to `bypassPermissions` and hides enforcement — the footgun documented in `.claude/rules/80_permission_model.md` §"Model-tier activation constraint" (and the live ops-lane gap in #2767). The fix makes flag choice a function of `.claude/lane_models.json`, not a fleet-wide constant.

## Surfaces touched

1. `.claude/lane_models.json` (NEW) — canonical per-lane tier config shared by the shell launcher and Python review runner. All 19 lanes default to `opus` (current fleet); unknown/missing lanes also default to `opus`.
2. `scripts/internal/lane_models.py` (NEW) — Python loader exporting `load_lane_models`, `get_lane_model`, `permission_mode_args_for_lane`. Coerces invalid tiers to `opus`, returns empty dict on missing/malformed config.
3. `.claude/tmux/steward-session.sh` — adds `permission_mode_flag_for_lane` helper (inline `python3 -c` JSON parse + case statement). All 19 `$CLAUDE_BIN` launch lines replace hardcoded `--permission-mode auto` with `$(permission_mode_flag_for_lane <lane-id>)`. Orchestrator retains helper-before-`$ORCH_CHANNEL_FLAGS` ordering.
4. `scripts/internal/review_lane_runner.py::invoke_review` — splices `*permission_mode_args_for_lane(LANE_ID)` into the `claude` argv list.
5. `tests/unit/test_steward_session.py` — `TestPermissionModeAuto` → `TestPermissionModeByModelTier` (structural + functional helper-body extraction with mock configs). Adds `TestLaneModelsJson` (config schema) and `TestLaneModelsLoader` (Python loader + shell-Python consistency).
6. `tests/unit/test_review_lane_runner.py` — `TestInvokeReviewPermissionMode` → `TestInvokeReviewPermissionModeByModelTier`. Mocks `permission_mode_args_for_lane` per tier + end-to-end integration with real loader against a tmp-path config (opus + sonnet).
7. `.claude/rules/80_permission_model.md` + `docs/01_core/ARCHITECTURE.md` — rewrite §"Activation", §"Launch-script implementation", §"Operator workflow for tier changes"; remove "pending fix" language; add `scripts/internal/lane_models.py` to the ARCHITECTURE.md script registry.

## Repro / Validation

```bash
# Tier 1 (targeted)
uv run python -m pytest tests/unit/test_steward_session.py tests/unit/test_review_lane_runner.py
#   → 198 passed in 3.36s

# Tier 2 (full gate)
make check-gated
#   → ✓ All checks passed (logs /tmp/make-check-poMc4O)
```

## Verification Performed

Pattern 10 verification surfaces — §3.3 of `plans/steward_platform/verification_contract/shaping.md`:

- **Surface:** `tests/unit/test_steward_session.py::TestPermissionModeByModelTier` — 14 tests (helper defined, reads `.claude/lane_models.json`, emits both flag variants, 19 launch lines call the helper, invocation count matches launch count, zero hardcoded flags on launch lines, orchestrator helper call before `$ORCH_CHANNEL_FLAGS`, helper coverage spans all lanes, functional runs vs mock configs for opus/sonnet/haiku/missing/invalid). **Result:** PASS.
- **Surface:** `tests/unit/test_steward_session.py::TestLaneModelsJson` — 6 tests (config exists, valid JSON, has `lanes` key, all 19 lanes listed, all models valid, fleet defaults to Opus). **Result:** PASS.
- **Surface:** `tests/unit/test_steward_session.py::TestLaneModelsLoader` — 10 tests (Python loader behavior + shell-Python cross-loader consistency for opus/sonnet/haiku/missing/invalid). **Result:** PASS.
- **Surface:** `tests/unit/test_review_lane_runner.py::TestInvokeReviewPermissionModeByModelTier` — 7 tests (opus emits `--permission-mode auto`; sonnet/haiku emit `--dangerously-skip-permissions` with `--permission-mode` strictly absent; `--agent`, `--print`, `-p`, `--output-format json` preserved on both paths; two integration tests exercise the real `lane_models` loader against tmp-path configs). **Result:** PASS.
- **Surface (aggregate):** `make check-gated` — Tier 2 full validation gate. **Result:** PASS.
- **Surface (grep acceptance):** `grep -c 'permission_mode_flag_for_lane' .claude/tmux/steward-session.sh` → 20 (1 def + 19 invocations); `grep 'CLAUDE_BIN.*--permission-mode auto' .claude/tmux/steward-session.sh` → 0 matches (no hardcoded flags on launch lines). **Result:** PASS.

Follow-up commit `a5f9aba9` carries per-surface `Verification:` footers for the V2 deterministic precheck (§3.4); the primary commit's test run itself is the surface execution evidence.

## Acceptance evidence

```bash
grep -c 'permission_mode_flag_for_lane' .claude/tmux/steward-session.sh
#   → 20  (1 def + 19 invocations)

grep -n 'CLAUDE_BIN.*--permission-mode auto' .claude/tmux/steward-session.sh
#   → (no matches — zero hardcoded flags on launch lines)

grep -n 'permission_mode_args_for_lane' scripts/internal/review_lane_runner.py
#   → 52:from lane_models import permission_mode_args_for_lane
#   → 488:        *permission_mode_args_for_lane(LANE_ID),
```

## Worktree proof

```text
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
git rev-parse --show-toplevel: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-c
branch: fix/2767-model-aware-launch-flags (based on origin/main @ 9fac95ec)
```

## Rollout note

The fix only takes effect on lane restart. Existing sessions continue in their launched mode until relaunched via `tmux respawn-pane -k -t steward:<window>.<pane> --continue`. After the fleet respawns, the live ops-lane gap documented in #2767 (Sonnet session running with `--permission-mode auto`) resolves automatically: the launcher reads `.claude/lane_models.json`, sees `ops.model = opus` today, and emits `--permission-mode auto`. If the ops lane moves to Sonnet later, the tier change is a one-file edit to `.claude/lane_models.json`.

## Plan reference

N/A — this PR is a bounded bugfix for #2767, not a plan deliverable. The fix closes the pending-fix note in `.claude/rules/80_permission_model.md` §"Model-tier activation constraint" captured in §13.2 of governing plan during ADR 006 (PR #2763).

Fixes #2767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
