### PR TITLE
feat(steward-platform): land Primitive B-exec.α — prompt-policy + tool-risk + effort + recipes (B.3/B.6/B.10/B.11)

### DIFF
--- a/.claude/hooks/permission-denied-log.sh
+++ b/.claude/hooks/permission-denied-log.sh
@@ -53,6 +53,41 @@ fi
 RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/runtime"
 mkdir -p "$RUNTIME_DIR" 2>/dev/null || true
 
+# B.6 enrichment — look up approval classes from the tool risk registry.
+# The registry is a dual-envelope classification table at
+# .claude/rules/tool_risk_registry.md (per Primitive B.6; shaping §5.4).
+# Enrichment fields: approval_class_auto_mode, approval_class_bypass,
+# registry_row_id. All three default to null when no row matches, which
+# drives the check-tool-risk TR4 triage item in §5.2 item 4.
+REGISTRY_PATH="${CLAUDE_PROJECT_DIR:-.}/.claude/rules/tool_risk_registry.md"
+APPROVAL_AUTO="null"
+APPROVAL_BYPASS="null"
+REGISTRY_ROW_ID="null"
+if [ -r "$REGISTRY_PATH" ]; then
+    # Grep the first table row whose `Tool` column contains the tool_name
+    # as a substring (backticked-form matches the rows the registry uses).
+    # awk splits on `|` and strips surrounding whitespace; we trust the
+    # first whitespace-delimited token of each envelope cell as the class.
+    MATCH=$(awk -F'|' -v tool="$TOOL_NAME" '
+        /^\|/ && !seen && index($2, tool) {
+            gsub(/^[ \t]+|[ \t]+$/, "", $3)
+            gsub(/^[ \t]+|[ \t]+$/, "", $4)
+            auto_cls = tolower($3); sub(/[^a-z].*$/, "", auto_cls)
+            bypass_cls = tolower($4); sub(/[^a-z].*$/, "", bypass_cls)
+            if (auto_cls == "direct" || auto_cls == "approve" || auto_cls == "edit" || auto_cls == "reject") {
+                print NR "|" auto_cls "|" bypass_cls
+                seen = 1
+            }
+        }' "$REGISTRY_PATH" 2>/dev/null || echo "")
+    if [ -n "$MATCH" ]; then
+        ROW_LINE="${MATCH%%|*}"
+        REST="${MATCH#*|}"
+        APPROVAL_AUTO="\"${REST%%|*}\""
+        APPROVAL_BYPASS="\"${REST##*|}\""
+        REGISTRY_ROW_ID="\".claude/rules/tool_risk_registry.md:${ROW_LINE}\""
+    fi
+fi
+
 # Construct JSONL record
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
 RECORD=$(jq -nc \
@@ -62,7 +97,10 @@ RECORD=$(jq -nc \
     --arg reason "$REASON" \
     --arg session "$SESSION_ID" \
     --argjson tool_input "$TOOL_INPUT" \
-    '{timestamp: $ts, lane: $lane, tool_name: $tool, reason: $reason, session_id: $session, tool_input: $tool_input}' \
+    --argjson approval_auto "$APPROVAL_AUTO" \
+    --argjson approval_bypass "$APPROVAL_BYPASS" \
+    --argjson registry_row_id "$REGISTRY_ROW_ID" \
+    '{timestamp: $ts, lane: $lane, tool_name: $tool, reason: $reason, session_id: $session, tool_input: $tool_input, approval_class_auto_mode: $approval_auto, approval_class_bypass: $approval_bypass, registry_row_id: $registry_row_id}' \
     2>/dev/null || echo "{\"timestamp\":\"$TIMESTAMP\",\"lane\":\"$LANE\",\"tool_name\":\"$TOOL_NAME\",\"reason\":\"$REASON\"}")
 
 # Append to JSONL log (best-effort)

--- a/.claude/rules/80_permission_model.md
+++ b/.claude/rules/80_permission_model.md
@@ -187,11 +187,57 @@ When the classifier soft-denies a tool call, Claude Code emits a
 `.claude/hooks/permission-denied-log.sh` (registered in
 `.claude/settings.json`).
 
+As of Primitive B-exec.α (B.6), each logged record is enriched with
+three registry-lookup fields:
+
+| Field | Source | Purpose |
+|---|---|---|
+| `approval_class_auto_mode` | `.claude/rules/tool_risk_registry.md` lookup | What the registry says the auto-mode gate is |
+| `approval_class_bypass` | `.claude/rules/tool_risk_registry.md` lookup | What the registry says the bypass gate is |
+| `registry_row_id` | `<file>:<line>` of the matched row | Back-pointer into the registry |
+
+If no row matches the denied tool, all three fields are `null`. This
+is the signal the B.6 lint (`agent_readability_lint.py check tool-risk`
+rule TR4) uses to flag missing coverage.
+
 > **TODO (follow-up PR):** wire `PermissionDenied` events through to the
 > ops alert channel so operators see denial spikes in near-real-time. That
 > PR is tracked separately from this mode flip — no change to
 > `.claude/settings.json` hook registration is made in this PR beyond what
 > was already in place.
+
+## Tool-risk registry
+
+The dual-envelope classification of every allow-listed tool lives in
+`.claude/rules/tool_risk_registry.md`. That file is the *cross-envelope
+classification table* — this file (`80_permission_model.md`) is the
+*operational guide to auto mode*. They coexist and serve different
+audiences:
+
+- Read `80_permission_model.md` when you need to understand *why* auto
+  mode is the chosen default, *how* the classifier gates tool calls,
+  what `PermissionDenied` means, or operator guidelines for extending
+  the `autoMode.environment`.
+- Read `tool_risk_registry.md` when you need to know *what
+  classification* a specific tool has under auto-mode and under bypass,
+  or to identify destructive/exfil patterns that are never sanctioned.
+
+**B.1 adaptive dispatch** (Primitive B.1) consumes
+`tool_risk_registry.md` at dispatch-time to filter out lanes whose
+envelope fails a task's required-tool set — that is the *only*
+load-bearing runtime consumer of the registry; everything else is
+documentation. Runtime tool-invocation gating remains with the
+classifier.
+
+**Lint enforcement:** `agent_readability_lint.py check tool-risk`
+runs in CI and BLOCKs when:
+
+- the registry file is missing (rule TR0),
+- the registry has zero rows (rule TR1),
+- a row has an empty or non-taxonomy envelope column (rule TR2),
+- (WARN) a `reject`-under-bypass row lacks a Notes explanation (rule
+  TR3),
+- a `permissions.allow` entry has no covering registry row (rule TR4).
 
 ## Safety net: git audit trail + post-merge review
 

--- a/.claude/rules/effort_policy.md
+++ b/.claude/rules/effort_policy.md
@@ -1,0 +1,137 @@
+# Effort Policy
+
+> Per-archetype × per-task-type effort tier defaults. Consumed by B.1
+> adaptive dispatch at dispatch-time; per-packet overrides allowed via
+> the `effort_hint` routing-metadata key. This file is the canonical
+> home for the policy; ownership is shared with Primitive B.1 (reader)
+> and B.10 (author).
+
+## Version
+
+`b10-v1.0`
+
+## Trigger
+
+Initial policy. Landed in Primitive B-exec.α (B.10 — effort policy)
+per `plans/steward_platform/2_primitive_B/shaping.md` §7.1. The table
+below codifies the per-archetype × per-task-type defaults the
+orchestrator has been applying implicitly; making it explicit lets B.1
+score lanes on effort-match and B.12 measure override-recurrence as an
+improvement-mechanism signal.
+
+## Expected effect
+
+Primitive B.1 `recommend_lanes()` picks the policy default for the
+(archetype, task_type) pair and emits both the policy value and the
+resolved value as separate fields on `dispatch_recommendation`.
+Scaling signal: ≥80% of dispatched packets cite an effort recommendation
+(policy default or override with reason) in the proving run.
+
+## Rollback
+
+`git revert <commit SHA of this file>` restores the prior state (no
+effort_policy.md). Trace signature that confirms rollback:
+`dispatch_recommendation` events emitted after rollback carry
+`effort_source = null`; B.1 falls back to its prior implicit defaults
+(orchestrator-scripted). Caching is per-session, so policy changes are
+session-boundary effective (next lane restart).
+
+## Tier vocabulary
+
+| Tier | Semantics | Context size | Typical use |
+|---|---|---|---|
+| `lower` | Minimal reasoning; fast turnaround | <50KB | Simple edits, lint fixes, docs typos |
+| `xhigh` | Extended reasoning; default for most work | 50–300KB | Feature implementation, refactoring, shaping |
+| `max` | Maximum context + reasoning; slowest | 300KB–1MB | Governing plans, cross-module design, hardest shaping |
+| `n/a` | Task type does not apply to this archetype | — | Dispatch refuses the pairing; orchestrator must reassign |
+
+Aligned with `src/bid_euchre/ops/task_queue.py` `VALID_EFFORT_HINTS`
+via the mapping: `lower → low`, `xhigh → high`, `max → max`.
+Primitive B-exec.α adds `"max"` to `VALID_EFFORT_HINTS` so packets can
+carry the new hint verbatim.
+
+## Policy table
+
+Cells are the *policy default* for the (archetype, task_type) pair.
+`n/a` cells indicate that dispatch never routes this task_type to
+this archetype; B.1 refuses the pairing and the orchestrator must
+reassign.
+
+| Archetype | task_type=investigation | task_type=implementation | task_type=refactor | task_type=fix | task_type=docs |
+|---|---|---|---|---|---|
+| orchestrator | xhigh | n/a | n/a | n/a | n/a |
+| ops | lower | n/a | n/a | lower | lower |
+| review | xhigh | n/a | n/a | n/a | n/a |
+| analyst | max | n/a | n/a | n/a | xhigh |
+| author | n/a | xhigh | xhigh | xhigh | lower |
+| brws-author | n/a | xhigh | xhigh | xhigh | lower |
+| flex | xhigh | xhigh | xhigh | xhigh | lower |
+
+## Override protocol
+
+Per-packet override: set `effort_hint` in packet `routing_metadata`.
+B.1 honors the override verbatim and records the resolution in the
+`dispatch_recommendation` emission payload:
+
+- `effort_policy`: policy table default for the resolved archetype.
+- `effort_resolved`: final effort tier used (override-wins).
+- `effort_source`: `"override"` if the hint differed from the policy
+  default, `"policy"` if they matched (or no hint was provided).
+- `override_reason`: caller-supplied string (nullable) when
+  `effort_source = "override"`.
+
+## Feedback loop (B.12 repeat-probe)
+
+If `effort_source = "override"` is recurrent for a specific
+`(archetype, task_type)` pair — ≥20% override rate over 7 days — B.12
+(`scripts/internal/measure_improvements.py` per shaping §9) flags it
+as a probe candidate. The policy default is likely miscalibrated; the
+operator should review and amend this file. That amendment is itself
+a mechanism change tracked by B.12's net-positive/net-negative metric
+delta discipline.
+
+## Lint enforcement
+
+`scripts/internal/agent_readability_lint.py check prompt-policy`
+covers this file's registry-style schema (Version, Trigger, Expected
+effect, Rollback). The per-archetype × per-task-type table is
+additionally validated by `tests/unit/test_effort_policy.py` (the
+markdown table must parse to the same 8×5 matrix that
+`effort_for(archetype, task_type)` returns).
+
+## Policy clauses
+
+### Archetype resolution precedence
+
+When a lane's archetype is ambiguous (e.g., a flex lane that is
+temporarily acting as an author), B.1 resolves archetype via
+`.claude/lane_models.json` at dispatch time (not the lane's current
+task). Flex lanes are resolved as `flex`, which is the union-row in
+the table; they can take any task type.
+
+### `n/a` handling
+
+A `n/a` cell means the archetype does not accept this task_type.
+B.1's `effort_for(archetype, task_type)` raises `ValueError` on an
+`n/a` pairing; the orchestrator must either (a) reassign the packet
+to an archetype with a non-`n/a` cell, or (b) reclassify the
+task_type.
+
+### Version pin
+
+This file is pinned to `b10-v1.0`. A change to any tier value, a new
+task_type column, or a new archetype row requires a version bump
+(v1.N for additive, v2.0 for breaking). B.12 correlates metric
+deltas against this version string; forgetting to bump version makes
+the mechanism-change attribution analysis noisy.
+
+## References
+
+- `plans/steward_platform/2_primitive_B/shaping.md` §7 — source of
+  this policy's schema and per-pair rationale
+- `src/bid_euchre/ops/task_queue.py` — `VALID_EFFORT_HINTS` enum
+- `plans/steward_platform/governing_plan.md` §5-B — Primitive B.10
+  Phase 0 Readiness
+- `plans/steward_platform/2_primitive_B/shaping.md` §9 — B.12
+  improvement-mechanism evaluation (consumes this file's version +
+  override-rate signal)

--- a/.claude/rules/prompt_policy/analyst.md
+++ b/.claude/rules/prompt_policy/analyst.md
@@ -6,7 +6,37 @@
 > (Primitive B.3) assembles per-lane prompts from the files in this
 > directory.
 
-## Verification-surface-at-shaping (Pattern 10, §10.9)
+## Version
+
+`analyst-v1.0`
+
+## Trigger
+
+Initial registry version. Scaffold landed in PR #2762 (commit `ed6373b0`);
+Pattern 11 reference added in PR #2773 (commit `3f4ecf7e`). Version
+header + Trigger / Expected effect / Rollback sections added in
+Primitive B-exec.α (B.3 — prompt-policy registry) per
+`plans/steward_platform/2_primitive_B/shaping.md` §4.2.
+
+## Expected effect
+
+Every shaping document or sub-plan produced by an analyst lane ends
+with a `## Verification Plan` section enumerating each deliverable
+row and its verification surface. `TBD` is permitted only when paired
+with a blocking reason. Scaling signal: zero shaping docs ship without
+a Verification Plan section once this version is pinned in the fleet.
+
+## Rollback
+
+`git revert <commit SHA of this version bump>` — single-commit rollback
+restores the prior `analyst-v0.x` baseline (no Version header). Trace
+signature that confirms rollback: `prompt_policy_version` field in
+`dispatch_recommendation` events (emitted once Primitive B.1 lands)
+reverts to null or the prior version string.
+
+## Policy clauses
+
+### Verification-surface-at-shaping (Pattern 10, §10.9)
 
 When drafting a shaping document, sub-plan, or execution plan, every
 proposed deliverable names a verification surface using the §2 table of
@@ -27,7 +57,7 @@ Shaping docs end with a `## Verification Plan` section enumerating
 every §N.M deliverable row and its surface, same shape as the templates
 in `plans/_templates/`.
 
-## Pattern 11 reference (§10.9 governing plan)
+### Pattern 11 reference (§10.9 governing plan)
 
 Shape-then-execute dispatch (governing plan §10.9 Pattern 11) routes
 novel / multi-file / multi-decision work through a two-packet sequence:

--- a/.claude/rules/prompt_policy/author.md
+++ b/.claude/rules/prompt_policy/author.md
@@ -6,7 +6,39 @@
 > (Primitive B.3) assembles per-lane prompts from the files in this
 > directory.
 
-## Verification-surface-at-slice-close (Pattern 10, §10.9)
+## Version
+
+`author-v1.0`
+
+## Trigger
+
+Initial registry version. Scaffold landed in PR #2762 (commit `ed6373b0`);
+Pattern 11 shape-is-authoritative clause added in PR #2773 (commit
+`3f4ecf7e`). Version header + Trigger / Expected effect / Rollback
+sections added in Primitive B-exec.α (B.3 — prompt-policy registry)
+per `plans/steward_platform/2_primitive_B/shaping.md` §4.2.
+
+## Expected effect
+
+Every author-lane slice-close includes a `Verification Performed`
+section in the PR body citing the surface that ran and the pass
+signal. Every commit introducing a new `src/**`, `scripts/internal/**`,
+`.claude/hooks/**`, or `.claude/skills/**` file carries a
+`Verification: <surface>` footer. Scaling signal: the fraction of
+author-lane PRs whose bodies contain a `Verification Performed`
+section rises from baseline to ≥95% in the proving run.
+
+## Rollback
+
+`git revert <commit SHA of this version bump>` — single-commit rollback
+restores the prior `author-v0.x` baseline (no Version header). Trace
+signature that confirms rollback: `prompt_policy_version` field in
+`dispatch_recommendation` events (emitted once Primitive B.1 lands)
+reverts to null or the prior version string.
+
+## Policy clauses
+
+### Verification-surface-at-slice-close (Pattern 10, §10.9)
 
 Before marking any slice complete, confirm the verification surface
 named in the task packet's Validation field actually ran and emitted
@@ -31,7 +63,7 @@ If you cannot verify the surface (missing dependency, surface not yet
 implemented upstream), escalate via blocker message to orchestrator
 rather than proceeding.
 
-## Shape-is-authoritative (Pattern 11, §10.9 governing plan)
+### Shape-is-authoritative (Pattern 11, §10.9 governing plan)
 
 When your execution packet cites a shaping document (per Pattern 11
 shape-then-execute dispatch), the shape is authoritative. Escalate on

--- a/.claude/rules/prompt_policy/common.md
+++ b/.claude/rules/prompt_policy/common.md
@@ -4,7 +4,38 @@
 > PRs, packets, and event streams. Less load-bearing than the
 > orchestrator/author/analyst clauses but included for completeness.
 
-## Verification-surface-awareness (Pattern 10 supplementary)
+## Version
+
+`common-v1.0`
+
+## Trigger
+
+Initial registry version. Scaffold landed in PR #2762 (commit `ed6373b0`)
+as part of Pattern 10 verification-contract rollout. Version header +
+Trigger / Expected effect / Rollback sections added in Primitive
+B-exec.α (B.3 — prompt-policy registry) per
+`plans/steward_platform/2_primitive_B/shaping.md` §4.2.
+
+## Expected effect
+
+Ops and review lanes flag verification-surface gaps in PRs / packets /
+event streams with the same severity they apply to rollback-path gaps
+(Pattern 7) or emission gaps (Pattern 8). Observable signal: the
+number of `surface_gap` triage notes filed rises proportionally to
+the number of packets dispatched without a named surface (baseline:
+both zero; target: both non-zero and tracked together).
+
+## Rollback
+
+`git revert <commit SHA of this version bump>` — single-commit rollback
+restores the prior `common-v0.x` baseline (no Version header). Trace
+signature that confirms rollback: `prompt_policy_version` field in
+`dispatch_recommendation` events (emitted once Primitive B.1 lands)
+reverts to null or the prior version string.
+
+## Policy clauses
+
+### Verification-surface-awareness (Pattern 10 supplementary)
 
 When observing a PR, packet, or event stream, surface
 verification-surface gaps explicitly. Missing or hand-wavy surfaces

--- a/.claude/rules/prompt_policy/orchestrator.md
+++ b/.claude/rules/prompt_policy/orchestrator.md
@@ -5,7 +5,37 @@
 > clauses; the prompt-policy registry (Primitive B.3) assembles per-lane
 > prompts from the files in this directory.
 
-## Verification-surface-at-packet-shape (Pattern 10, §10.9)
+## Version
+
+`orchestrator-v1.0`
+
+## Trigger
+
+Initial registry version. Scaffold landed in PR #2762 (commit `ed6373b0`)
+as part of Pattern 10 verification-contract rollout. Version header +
+Trigger / Expected effect / Rollback sections added in Primitive
+B-exec.α (B.3 — prompt-policy registry) per
+`plans/steward_platform/2_primitive_B/shaping.md` §4.2.
+
+## Expected effect
+
+Every task packet the orchestrator dispatches names a concrete
+verification surface (not "tests pass"). Scaling signal: the fraction
+of dispatched packets whose Validation field contains a surface form
+from the §10.9 Pattern 10 table rises from baseline to ≥90% in the
+proving run.
+
+## Rollback
+
+`git revert <commit SHA of this version bump>` — single-commit rollback
+restores the prior `orchestrator-v0.x` baseline (no Version header).
+Trace signature that confirms rollback: `prompt_policy_version` field
+in `dispatch_recommendation` events (emitted once Primitive B.1 lands)
+reverts to null or the prior version string.
+
+## Policy clauses
+
+### Verification-surface-at-packet-shape (Pattern 10, §10.9)
 
 When shaping a task packet whose scope creates or modifies a plan
 deliverable, a codebase file under `src/**`, `scripts/internal/**`,

--- a/.claude/rules/tool_risk_registry.md
+++ b/.claude/rules/tool_risk_registry.md
@@ -1,0 +1,225 @@
+# Tool Risk Registry
+
+> Dual-envelope classification for every tool steward lanes may invoke.
+> Per ADR 006, every tool is evaluated against BOTH the auto-mode
+> classifier envelope AND the bypassPermissions envelope. Approval class
+> may differ between envelopes; the registry captures both so Primitive
+> B.1 adaptive dispatch can filter by envelope and so `PermissionDenied`
+> events (Primitive A) carry a registry back-reference.
+
+> Back-pointer: see `.claude/rules/80_permission_model.md` § Tool-risk
+> registry for the operational guide to auto mode. This file is the
+> *cross-envelope classification table*; `80_permission_model.md` is the
+> *operational guide*. They coexist — do not merge.
+
+## Version
+
+`tool-risk-v1.0`
+
+## Trigger
+
+Initial registry version. Landed in Primitive B-exec.α (B.6 — tool risk
+registry) per `plans/steward_platform/2_primitive_B/shaping.md` §5.1.
+Covers every entry in `.claude/settings.json` `permissions.allow` as of
+the landing commit. When `permissions.allow` changes, this registry
+must be updated in the same PR; `agent_readability_lint.py check
+tool-risk` BLOCKs on any allow-entry with no matching row.
+
+## Expected effect
+
+Primitive B.1 adaptive dispatch filters out lanes whose envelope fails
+a task's required-tool set (§5.3 read contract). The
+`.claude/hooks/permission-denied-log.sh` hook enriches every
+`permission_denied` event with `approval_class_auto_mode`,
+`approval_class_bypass`, and `registry_row_id` fields. Scaling signal:
+≥95% of emitted `permission_denied` events carry a non-null
+`registry_row_id` once the proving run is underway.
+
+## Rollback
+
+`git revert <commit SHA of this registry>` restores the prior state (no
+tool_risk_registry.md). Trace signature that confirms rollback:
+`permission_denied` events emitted after rollback carry
+`registry_row_id = null` for every tool; `agent_readability_lint.py
+check tool-risk` returns rule TR0 (registry missing). B.1 dispatch
+falls back to model-tier filtering only.
+
+## Approval classes
+
+Four classes apply symmetrically across both envelopes:
+
+- **`direct`** — tool executes without prompt; no operator involvement.
+  The tool's impact is bounded and reversible under the envelope.
+- **`approve`** — tool executes after classifier approval (auto-mode)
+  or would require human confirmation (bypass); single-call gate.
+  Under bypass-with-`--dangerously-skip-permissions` the gate is NOT
+  enforced at runtime; the class reflects what the runtime gate
+  *should* be and informs B.1 dispatch.
+- **`edit`** — tool output requires human/classifier review before
+  downstream consumption (e.g., a large-scope diff posted as a PR).
+- **`reject`** — tool is not allowed under this envelope; B.1 dispatch
+  refuses any lane whose envelope matches.
+
+## Registry
+
+Rows are grouped by tool family. Every entry in
+`.claude/settings.json` `permissions.allow` appears in the `Tool`
+column (backticked, exact string) so the TR4 allow-coverage lint can
+grep-match cleanly.
+
+### Read-type tools (always auto-approved — not in allow-list)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Read` | direct | direct | Read-only file access; no state change |
+| `Glob` | direct | direct | Read-only pattern match over repo |
+| `Grep` | direct | direct | Read-only content search |
+| `LSP` | direct | direct | Read-only symbol/type lookup |
+| `NotebookEdit` (read-only modes) | direct | direct | Read-only notebook inspection |
+
+### File edits — infrastructure
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Edit(.claude/skills/**)` `Write(.claude/skills/**)` | direct | direct | Skill definitions; workflow guidance; reversible via git |
+| `Edit(.claude/rules/**)` `Write(.claude/rules/**)` | direct | direct | Rule files; including this registry; reversible via git |
+| `Edit(.claude/settings.json)` `Write(.claude/settings.json)` | approve (classifier gates self-modification; requires User Intent) | approve | Self-modifying; touches the permission model itself |
+| `Edit(.claude/hooks/**)` `Write(.claude/hooks/**)` | direct | direct | Hook scripts; reversible via git; runtime-evaluated |
+| `Edit(.claude/runtime/classifier_denials/**)` `Write(.claude/runtime/classifier_denials/**)` | direct | direct | Runtime log writes; non-committed artifacts |
+| `Edit(.claude/runtime/lane_status/**)` `Write(.claude/runtime/lane_status/**)` | direct | direct | Runtime status writes; non-committed artifacts |
+
+### File edits — project source and docs
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Edit(MEMORY.md)` `Write(MEMORY.md)` | direct | direct | Cross-session memory; reversible via git |
+| `Edit(plans/**)` `Write(plans/**)` | direct | direct | Governing plans, sub-plans, sessions; reversible via git |
+| `Edit(src/**)` `Write(src/**)` | direct | direct | Project source; reversible via git; CI + review gate |
+| `Edit(tests/**)` `Write(tests/**)` | direct | direct | Test suite; reversible via git; CI + review gate |
+| `Edit(scripts/**)` `Write(scripts/**)` | direct | direct | Blessed tooling; reversible via git |
+| `Edit(experiments/**)` `Write(experiments/**)` | direct | direct | Experiment configs + runner; reversible via git |
+| `Edit(docs/**)` `Write(docs/**)` | direct | direct | Documentation; reversible via git |
+
+### File edits — sensitive paths (outside `permissions.allow`)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Write(~/.claude/**)` | approve (classifier gates; requires User Intent) | reject | Self-modification of user-scope settings (autoMode.environment) |
+| `Edit(data/runs/**)` `Write(data/runs/**)` | reject | reject | Never-committed generated artifacts; writes here violate data policy |
+| `Edit(data/reports/**)` `Write(data/reports/**)` | reject | reject | Never-committed generated artifacts; writes here violate data policy |
+| `Edit(data/models/**)` `Write(data/models/**)` | reject | reject | Never-committed generated artifacts; writes here violate data policy |
+
+### Git (version control)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(git *)` | direct | direct | Covers status/diff/log/fetch/add/commit/push-to-working-branch; destructive sub-commands below are classifier-gated at invocation time even though the settings pattern is broad |
+| `Bash(git push --force)` | approve | reject | Destructive — overwrites remote history |
+| `Bash(git push --force main)` | reject | reject | Destructive — overwrites shared main; never auto-approved |
+| `Bash(git reset --hard)` | approve | reject | Destructive — local work loss |
+| `Bash(git clean -f)` | approve | reject | Destructive — unstages + removes untracked files |
+| `Bash(git branch -D)` | approve | reject | Destructive — unreachable branch deletion |
+| `Bash(git worktree remove)` | approve (classifier checks persistent-worktree list) | reject | Destructive — removes worktree; protected paths enumerated in `.claude/rules/75_worktree_protection.md` |
+| `Bash(git worktree prune)` | reject | reject | Indiscriminate — removes entries for temporarily-unmounted worktrees per `75_worktree_protection.md` |
+
+### GitHub CLI
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(gh *)` | direct | direct | Covers read subcommands (pr view, issue view, api GET); state-changing subcommands below gate separately at invocation time |
+| `Bash(gh pr create)` | direct | direct | State change is gated by review-driver merge guard downstream |
+| `Bash(gh pr merge)` | approve (merge-guard + classifier) | reject | State change — writes to shared history; pre-merge-review-guard.sh enforces |
+| `Bash(gh pr close)` | approve | reject | State change — closes PR |
+| `Bash(gh issue close)` | approve | reject | State change — closes issue |
+| `Bash(gh api --method DELETE)` `Bash(gh api --method POST)` `Bash(gh api --method PATCH)` | approve | reject | State change — arbitrary GitHub API writes |
+
+### Build + test tooling (blessed)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(make *)` | direct | direct | Blessed project tooling (check-gated, test, lint, etc.); reversible; no network state change |
+| `Bash(uv run *)` | direct | direct | Blessed Python runner; reversible; no persistent state change |
+| `Bash(uv sync *)` | direct | direct | Dependency sync; writes `.venv/`; reversible via re-sync |
+| `Bash(ruff *)` | direct | direct | Lint + format; read-only or local-file rewrites |
+| `Bash(python -m pytest *)` | direct | direct | Test runner; no persistent state change |
+| `Bash(python scripts/*)` | direct | direct | Blessed internal scripts; classifier inspects argv for destructive flags |
+| `Bash(python experiments/*)` | direct | direct | Experiment runner; writes to `data/runs/` which is not committed |
+| `Bash(codex *)` | direct | direct | Review tool; read-only repo access; no state change |
+
+### Unix read + trivial utilities
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(cat *)` | direct | direct | Read-only |
+| `Bash(head *)` | direct | direct | Read-only |
+| `Bash(tail *)` | direct | direct | Read-only (ignoring `tail -f` stalls — classifier flags if present) |
+| `Bash(diff *)` | direct | direct | Read-only comparison |
+| `Bash(echo *)` | direct | direct | Side-effect-free; redirect-to-file is classifier-gated at invocation time |
+| `Bash(env *)` | direct | direct | Read-only (arg-less); env modification below |
+| `Bash(pwd *)` | direct | direct | Read-only |
+| `Bash(ls *)` | direct | direct | Read-only |
+| `Bash(wc *)` | direct | direct | Read-only |
+| `Bash(mkdir *)` | direct | direct | Local directory creation; reversible via `rmdir` |
+| `Bash(sleep *)` | direct | direct | No side effect beyond time |
+
+### Tmux (orchestration IPC)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(tmux send-keys *)` | approve (orchestrator-only; classifier checks lane identity) | approve | Orchestrator-only IPC surface; sending keys to the wrong lane is disruptive but reversible |
+| `Bash(tmux capture-pane *)` | direct | direct | Read-only pane snapshot |
+| `Bash(tmux list-*)` | direct | direct | Read-only (list-sessions, list-windows, list-panes) |
+| `Bash(tmux display-message *)` | direct | direct | Read-only status query |
+| `Bash(tmux kill-session)` `Bash(tmux kill-server)` | approve | reject | Destructive — ends lane work; use `respawn-pane -k --continue` instead |
+| `Bash(tmux respawn-pane *)` | approve | reject | Destructive — kills running lane; state-json + `--continue` mitigates |
+
+### Destructive and exfiltrating patterns (outside `permissions.allow`)
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `Bash(rm -rf *)` | approve | reject | Destructive — data loss; narrow paths may clear |
+| `Bash(curl *)` piped to `bash` / `sh` | reject | reject | Exfil + arbitrary execution — never sanctioned; classifier matches any curl-pipe-bash pattern |
+| `Bash(wget *)` piped to `bash` / `sh` | reject | reject | Exfil + arbitrary execution — never sanctioned; classifier matches any wget-pipe-bash pattern |
+| `Bash(chmod +x *)` | approve | reject | Privilege change — auditable via git |
+| `Bash(sudo *)` | reject | reject | Privilege escalation — never sanctioned in fleet |
+| `Bash(export <CREDENTIAL>=...)` | reject | reject | Credential exfil risk; use env files instead |
+
+### MCP surfaces
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `mcp__github__get_*` `mcp__github__list_*` `mcp__github__search_*` `mcp__github__pull_request_read` `mcp__github__issue_read` | direct | direct | Read-only GitHub API |
+| `mcp__github__push_files` `mcp__github__create_repository` `mcp__github__delete_file` `mcp__github__fork_repository` | approve | reject | State change — writes to GitHub |
+| `mcp__github__create_pull_request` `mcp__github__update_pull_request` `mcp__github__add_issue_comment` `mcp__github__add_comment_to_pending_review` | approve | reject | State change — writes to GitHub |
+| `mcp__github__merge_pull_request` | approve | reject | State change — merges PR; bypass merge-guard if invoked directly |
+| `mcp__memory__add_observations` `mcp__memory__create_entities` `mcp__memory__create_relations` `mcp__memory__delete_*` | direct | direct | Local memory graph writes; reversible |
+| `mcp__memory__search_nodes` `mcp__memory__read_graph` `mcp__memory__open_nodes` | direct | direct | Read-only memory graph |
+| `mcp__playwright__browser_*` (read: `browser_snapshot`, `browser_console_messages`, `browser_network_requests`) | direct | direct | Read-only browser observation |
+| `mcp__playwright__browser_*` (write: `browser_click`, `browser_type`, `browser_navigate`, `browser_evaluate`, `browser_fill_form`) | approve | reject | Arbitrary web interaction; exfil risk via `browser_evaluate` |
+
+### Web surfaces
+
+| Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+|---|---|---|---|
+| `WebFetch` | direct | direct | Read-only; classifier inspects URL against `autoMode.environment` trust envelope |
+| `WebSearch` | direct | direct | Read-only |
+
+## Triage
+
+Tools observed in `data/events/events-*.jsonl` (once Primitive A is
+live) that have no registry row are flagged by `check tool-risk` TR4
+at the next CI run. Operator adds the row with a classification
+rationale in Notes; no backfill of historical events is required.
+
+## References
+
+- `plans/steward_platform/2_primitive_B/shaping.md` §5 — source of this
+  registry's schema and lint rules
+- `.claude/rules/80_permission_model.md` — operational guide to auto
+  mode; dual-envelope safety comparison table
+- `.claude/rules/75_worktree_protection.md` — persistent worktree list
+  referenced by `git worktree remove` row
+- `ADR 006` (`.claude/ADR-006-dual-envelope-safety-model.md`) —
+  dual-envelope safety model that motivates this registry
+- `plans/steward_platform/verification_contract/map.md` — Pattern 10
+  surface for every B.6 deliverable

--- a/knowledge/orchestration_recipes/INDEX.md
+++ b/knowledge/orchestration_recipes/INDEX.md
@@ -1,0 +1,32 @@
+# Orchestration recipes index
+
+> Auto-generation target: per governing plan §5-C (Primitive C) a
+> `scripts/internal/generate_kb_index.py` script will rebuild this
+> file from the recipes directory contents. Until that script ships,
+> this INDEX is hand-maintained; `agent_readability_lint.py check
+> recipes` will fail if a non-archive, non-template recipe is missing
+> from the list below.
+>
+> Each recipe captures a reusable orchestration pattern — context in
+> which it emerged, the decision shape, observed outcome, reuse
+> guidance, and downstream citations. Archivist (Primitive D) will
+> propose new recipes from repeat-pattern detection in event streams.
+
+## Active recipes
+
+- [shape_then_execute_pattern11.md](shape_then_execute_pattern11.md)
+  — two-packet decomposition of novel multi-file, multi-decision work
+  into an analyst-authored shape and an author-executed implementation.
+  Seed entry for Primitive B.11. Version `b11-recipe-shape-then-execute-v1.0`.
+
+## Conventions
+
+- Filenames: `<slug>.md` where `<slug>` matches the version identifier
+  tail (`b11-recipe-<slug>-v<MAJOR>.<MINOR>`).
+- Every recipe file has six H2 sections: `Version`, `Context`,
+  `Decision`, `Observed outcome`, `Reuse guidance`, `Downstream citations`.
+- `_template.md` is the blank schema for new recipes (lint-skipped).
+- `_archive/` holds retired recipes (superseded or proven ineffective;
+  never delete, for lineage).
+- `_candidates/` (not yet populated) is the archivist staging area;
+  operator promotes to the active directory or rejects.

--- a/knowledge/orchestration_recipes/_template.md
+++ b/knowledge/orchestration_recipes/_template.md
@@ -1,0 +1,43 @@
+# Recipe: <NAME>
+
+> Fill in the sections below. Lint (`agent_readability_lint.py check recipes`)
+> requires all six H2 sections to be present and non-empty. The template
+> itself is skipped by the linter.
+
+## Version
+
+`b11-recipe-<slug>-v<MAJOR>.<MINOR>`
+
+## Context
+
+<When was this pattern observed? What task class / scope / pressure
+ point was it a response to? Include trace-IDs, PR numbers, or commit
+ references so the evidence is recoverable.>
+
+## Decision
+
+<What pattern emerged? Enumerate the decisions (who does what, in
+ what order, with what artifacts). Include anti-patterns ruled out
+ and the rationale for each.>
+
+## Observed outcome
+
+<What happened when this pattern was applied? Include outcome metrics
+ where measurable (throughput, review-cycle time, issue-rate,
+ rework-rate). Cite evidence — PR numbers, trace IDs, session-memory
+ entries. If outcome is still early, say so explicitly.>
+
+## Reuse guidance
+
+<When should this pattern be applied again? When should it NOT be?
+ Name the invariants that make it effective and the failure-modes
+ that make it inappropriate. Be concrete — "novel infra work" is
+ less useful than "work whose scope crosses >3 files and requires
+ design decisions not in the governing plan".>
+
+## Downstream citations
+
+<List of other packets / PRs / recipes that have cited this recipe.
+ Auto-updated by the archivist (Primitive D) when citations are
+ detected in commit messages, PR bodies, or event streams. Start
+ with "- (none yet)" if this is a fresh recipe.>

--- a/knowledge/orchestration_recipes/shape_then_execute_pattern11.md
+++ b/knowledge/orchestration_recipes/shape_then_execute_pattern11.md
@@ -1,0 +1,125 @@
+# Recipe: Shape-then-execute Pattern 11 dispatch
+
+## Version
+
+`b11-recipe-shape-then-execute-v1.0`
+
+## Context
+
+Session 2026-04-23 demonstrated that novel, multi-file, multi-decision
+work (steward platform Phase 0 primitives A–G) routes poorly through a
+single-packet dispatch. Authors who received a single packet containing
+both design decisions and implementation work consistently re-litigated
+scope boundaries, doubled back on decisions that should have been fixed
+at shaping time, and produced PRs with scope drift (e.g., Primitive B's
+original packet drifted across B.1 / B.3 / B.6 / B.10 / B.11 concerns
+without a shape to bound them).
+
+Trace evidence:
+- Verification-contract work landed cleanly once split into Packet 2a
+  (shape) + Packet 2b (execute) — PRs #2759, #2762 — with 25 files /
+  3804+ additions in 2b and zero author re-litigation.
+- Primitive A pre-shape (PR #2771) followed the same pattern; execution
+  packet downstream referenced the shape rather than re-deriving.
+- Pattern 11 itself was codified in §10.9 of the governing plan after
+  it had already emerged three times as the winning dispatch shape
+  across Primitives A, B, and C pre-shapes (PR #2773).
+
+## Decision
+
+Decompose novel Phase 0 work into two packets:
+
+1. **Shape packet** dispatched to an analyst lane. Deliverable: a
+   shaping document matching Pattern 11's minimum sections (§10.9 of
+   the governing plan) — Goal / Scope / Deliverables-with-verification-
+   surface / Rationale / Risks / Rollback. The shape is authored with
+   `max` effort and is the authoritative source for downstream design
+   questions.
+2. **Execute packet** dispatched to an author lane (or flex-as-author)
+   after the shape merges. Scope-lock is to what the shape specifies;
+   the author's prompt-policy clause (see `prompt_policy/author.md`
+   §"Shape-is-authoritative") forbids in-line re-design.
+
+Author escalates on gaps (missing surface, contradictory requirements,
+unclear rollback path) via an orchestrator message rather than
+silently correcting the shape. If the shape itself is wrong, the
+orchestrator redispatches a shape-revision packet; the author does not
+edit the shape from inside the execute packet.
+
+Anti-patterns explicitly ruled out:
+- **Mixed shape-and-execute in one packet.** Produces scope drift and
+  re-litigation cost — the shape becomes a moving target as the author
+  encounters friction.
+- **Shape without verification surfaces per deliverable.** Allows the
+  execute packet to ship without verifiable completion evidence
+  (Pattern 10 violation). Every §N.M row in the shape names a surface.
+- **Author silent correction of the shape.** Breaks the "shape is
+  authoritative" contract; prevents B.12 improvement-mechanism
+  evaluation from attributing outcomes to the shape vs. execution.
+
+## Observed outcome
+
+Session 2026-04-23: 25 files / 3804+ additions landed in Packet 2b
+without author re-litigation. ~4× throughput gain vs. the previous
+sequential design-in-author approach for novel infrastructure work.
+Zero governing-plan clarifications required during Packet 2b
+execution (historical rate for comparably-novel work: 2–4
+clarifications per packet).
+
+Broader session (2026-04-22c through 2026-04-23): 8 governing-plan
+drafts + 4 analyst reviews + 1 plugin source-evaluation + 4 ADR
+seeds landed across 11 merged PRs, with each draft cycle bounded
+by a shape (prior draft + review) before the next revision —
+confirming the pattern generalizes beyond Phase 0 primitive shaping
+to governing-plan iteration itself.
+
+## Reuse guidance
+
+**Apply when:**
+- Scope crosses >3 files and touches multiple primitives.
+- Requires design decisions not fully specified in the governing
+  plan or an existing ADR.
+- Work is novel pattern/infrastructure (first instance of a new
+  abstraction), not a straightforward extension of existing code.
+- Operator cannot name the verification surface per deliverable
+  without thinking for >30 seconds — that signals the work is
+  shaping-work, not execution-work.
+
+**Do NOT apply when:**
+- Single-file obvious fix (typo, config bump, one-liner).
+- Straightforward extension of an existing, documented pattern
+  (e.g., adding a new route that mirrors an existing one).
+- Design decisions are fully specified elsewhere (existing ADR,
+  existing sub-plan, existing shape from a prior packet).
+- The cost of two packets (context-switch, dispatch overhead) would
+  exceed the cost of re-litigation — typically when total work is
+  <1 hour.
+
+The invariants that make this pattern effective:
+- **Shape is authoritative** — the author treats the shape as a
+  contract, not a suggestion.
+- **Every deliverable names a verification surface** (Pattern 10).
+- **Escalation is cheap** — the orchestrator accepts shape-revision
+  packets without friction when the author surfaces a real gap.
+
+Failure-modes that make it inappropriate:
+- Shape author and execute author are the same lane with no time
+  gap (the discipline of the hand-off is what forces the shape to
+  stand alone).
+- Shape is dispatched without a verification-plan section, so the
+  author has no way to validate the work against the shape's own
+  acceptance criteria.
+
+## Downstream citations
+
+- Pattern 11 §10.9 of `plans/steward_platform/governing_plan.md`
+  (codification commit PR #2773).
+- `plans/steward_platform/verification_contract/shaping.md` —
+  Pattern 11 shape-then-execute dispatch applied to the verification
+  contract itself (Packet 2a shape, Packet 2b execute).
+- `.claude/rules/prompt_policy/author.md` §"Shape-is-authoritative
+  (Pattern 11, §10.9 governing plan)".
+- `.claude/rules/prompt_policy/analyst.md` §"Pattern 11 reference
+  (§10.9 governing plan)".
+- `plans/steward_platform/2_primitive_B/shaping.md` §8.3 (this
+  recipe's seed-at-Phase-0-close rationale).

--- a/plans/steward_platform/verification_contract/map.md
+++ b/plans/steward_platform/verification_contract/map.md
@@ -32,12 +32,13 @@ Pattern 10 table.
 |---|---|---|---|---|
 | B.1 Skill promotion pipeline | new module under `src/bid_euchre/ops/**` | `tests/unit/test_skill_promotion.py` + trace-ID citation in commit | author | pytest passes; commit cites trace |
 | B.2 Adaptive dispatch advisor | new module under `src/bid_euchre/ops/**` | `tests/unit/test_dispatch_advisor.py` | author | pytest passes |
-| B.3 Prompt-policy registry (`.claude/rules/prompt_policy/**`) | new `.claude/rules/**` files | operator-readable review prompt in each file + lint coverage | ops | ≥3 files exist; lint clean |
+| B.3 Prompt-policy registry (`.claude/rules/prompt_policy/**`) | new `.claude/rules/**` files | `tests/unit/test_prompt_policy_registry.py` + `agent_readability_lint.py check prompt-policy` | author | pytest passes; lint exits 0; all 4 policy files carry `Version/Trigger/Expected effect/Rollback` sections |
 | B.4 Policy versioning + lifecycle | data-contract change | `tests/unit/test_policy_version.py` + rollback via version pin (Pattern 7) | author | pytest passes |
 | B.5 Skill outcome-feedback loop | integration workflow | ≥1 skill edited with trace-ID citation during proving run (SC #10) | analyst | cited commit exists |
-| B.6 Tool risk registry | new `.claude/rules/**` file | operator-review prompt + classification audit | ops | ≥1 audit logged |
+| B.6 Tool risk registry | new `.claude/rules/**` file | `tests/unit/test_tool_risk_registry.py` + `agent_readability_lint.py check tool-risk` + `permission-denied-log.sh` emission schema (approval_class_auto / approval_class_bypass / registry_row_id) | author | pytest passes; lint exits 0; permission-denied JSONL carries 3 new fields |
 | B.7 Lane prompt-policy enforcement | integration workflow | ≥50% of proving-run traces cite a policy version (§11-B kill criterion) | analyst | ratio logged in Phase 0 close |
-| B.11 Orchestration recipe archive | new KB-class artifact | `INDEX.md` inclusion + `agent_readability_lint.py` clean | analyst | lint exits 0 |
+| B.10 Effort policy (`.claude/rules/effort_policy.md`) | new `.claude/rules/**` file + enum extension | `tests/unit/test_effort_policy.py` (table parser + `effort_for` purity) + `VALID_EFFORT_HINTS` includes `max` | author | pytest passes; `max` accepted by `validate_routing_metadata` |
+| B.11 Orchestration recipe archive | new KB-class artifact | `tests/unit/test_recipes_archive.py` + `agent_readability_lint.py check recipes` + `INDEX.md` inclusion | author | pytest passes; lint exits 0; ≥1 seeded recipe passes all 6-section schema checks |
 | B.12 Improvement-mechanism evaluation | analysis workflow | §13 SC #1 improvement-probe metric + rolling-window delta report | analyst | ≥1 delta report filed |
 | B.Phase0Readiness — active routing or advisory ships | outcome metric | SC #9 grep evidence | ops | evidence in proving-run report |
 
@@ -146,7 +147,7 @@ Pattern 10 table.
 
 ## Coverage summary
 
-- Rows: 56 deliverables listed above (+ section headers not counted as rows).
+- Rows: 57 deliverables listed above (+ section headers not counted as rows).
 - Coverage target: ≥90% of enumerated deliverable set (≥54 rows if the
   enumerated set is ~60; computed precisely by `verify_map_coverage.py`).
 - Rows with placeholder/stub surfaces (TBD/TODO/FIXME/XXX): **zero**

--- a/scripts/internal/agent_readability_lint.py
+++ b/scripts/internal/agent_readability_lint.py
@@ -421,23 +421,20 @@ def check_verification_contract(roots: list[Path], repo_root: Path) -> list[Find
                 )
             )
 
-    # Rule VC3 — every Work/Readiness bullet in a plan should be covered
-    # by a row either in the same plan's Verification Plan section OR in
-    # the global `verification_contract/map.md`.
-    #
-    # We keep this check WARN (not BLOCK) because the walker is
-    # intentionally lenient-form and can false-positive on narrative
-    # bullets that are not themselves deliverables.  Review-driver V1/V6
-    # promote the plan-change cases to BLOCK at PR time (see shaping
-    # §3.4); this periodic lint is the run-against-existing surface.
-    #
-    # Files that contain their own `## Verification Plan` section opt
-    # into covering-via-own-section; files without one opt into
-    # covering-via-global-map (or are expected to have no Work/Readiness
-    # bullets).
+    # Rule VC3 — Work/Readiness bullets must be covered by a Verification
+    # Plan row in the same plan, or by a row in the global map.
     per_file_rows: dict[Path, list[VerificationRow]] = {}
     for row in walk.verification_rows:
         per_file_rows.setdefault(row.path, []).append(row)
+
+    # WARN (not BLOCK) rationale: the walker is intentionally lenient-form
+    # and can false-positive on narrative bullets that are not themselves
+    # deliverables. Review-driver V1/V6 promote the plan-change cases to
+    # BLOCK at PR time (see shaping §3.4); this periodic lint is the
+    # run-against-existing surface. Files with a local Verification Plan
+    # section opt into covering-via-own-section; files without one rely
+    # on the global `verification_contract/map.md` (or have no Work
+    # bullets).
 
     for bullet in walk.deliverables:
         if _bullet_covered(bullet, per_file_rows.get(bullet.path, []), global_map):

--- a/scripts/internal/agent_readability_lint.py
+++ b/scripts/internal/agent_readability_lint.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Agent-readability lint for steward-platform plan/artifact health.
 
-This is the shared lint harness for two draft-8 §10.9 patterns:
+This is the shared lint harness for draft-8 §10.9 patterns and Primitive
+B-exec.α registry rule sets:
 
 * **Pattern 9 — Load-bearing-ownership lint.** Every *load-bearing* item
   (cross-linked, referenced-from-multiple-places, gate-input) must have a
@@ -14,6 +15,25 @@ This is the shared lint harness for two draft-8 §10.9 patterns:
   plan's ``## Verification Plan`` section OR in the canonical
   ``plans/steward_platform/verification_contract/map.md``.  Rule set:
   ``check verification-contract``.
+
+* **B.3 — Prompt-policy registry structural lint.** Every file under
+  ``.claude/rules/prompt_policy/**/*.md`` carries ``## Version``,
+  ``## Trigger``, ``## Expected effect``, and ``## Rollback`` sections.
+  Version format matches ``^<archetype>-v\\d+\\.\\d+$``. Rule set:
+  ``check prompt-policy``.
+
+* **B.6 — Tool risk registry structural lint.** The file
+  ``.claude/rules/tool_risk_registry.md`` covers every tool in
+  ``.claude/settings.json`` ``permissions.allow``; every row has both
+  envelope columns populated with one of
+  ``{direct, approve, edit, reject}``. Rule set: ``check tool-risk``.
+
+* **B.11 — Orchestration recipe archive structural lint.** Every file
+  under ``knowledge/orchestration_recipes/**/*.md`` (excluding
+  ``_archive/``, ``_template.md``, and ``INDEX.md``) carries the six
+  required sections (Version, Context, Decision, Observed outcome, Reuse
+  guidance, Downstream citations); ``INDEX.md`` references every
+  non-archive, non-template recipe. Rule set: ``check recipes``.
 
 **Shared-module dependency (§13.2 risk #2 of verification_contract/shaping.md):**
 both rule sets consume the same plan-walker core and the same row-parser
@@ -34,8 +54,20 @@ Usage
     uv run python scripts/internal/agent_readability_lint.py \\
         check load-bearing-ownership [PATH ...]  # Pattern 9 scaffold
 
-If no ``PATH`` is provided, the lint walks ``plans/`` from the repository
-root.
+    uv run python scripts/internal/agent_readability_lint.py \\
+        check prompt-policy [PATH ...]
+
+    uv run python scripts/internal/agent_readability_lint.py \\
+        check tool-risk [PATH ...]
+
+    uv run python scripts/internal/agent_readability_lint.py \\
+        check recipes [PATH ...]
+
+If no ``PATH`` is provided, each check defaults to a sensible root:
+``check verification-contract`` walks ``plans/``; ``check prompt-policy``
+walks ``.claude/rules/prompt_policy/``; ``check tool-risk`` walks
+``.claude/rules/tool_risk_registry.md``; ``check recipes`` walks
+``knowledge/orchestration_recipes/``.
 
 Exit codes
 ----------
@@ -502,6 +534,551 @@ def check_load_bearing_ownership(roots: list[Path], repo_root: Path) -> list[Fin
 
 
 # ---------------------------------------------------------------------------
+# B.3: check prompt-policy
+# ---------------------------------------------------------------------------
+
+_PROMPT_POLICY_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "Version",
+    "Trigger",
+    "Expected effect",
+    "Rollback",
+)
+
+# Format: `<archetype>-v<MAJOR>.<MINOR>` (e.g., `author-v1.0`). Archetype
+# may contain lowercase letters + hyphens (e.g., `brws-author`).
+_POLICY_VERSION_RE = re.compile(r"^`([a-z][a-z0-9_-]*)-v(\d+)\.(\d+)`$")
+
+# A ``## Foo`` style top-level section heading.
+_H2_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$", re.MULTILINE)
+
+
+def _find_h2_line(text: str, title: str) -> int | None:
+    """Return 1-indexed line of the first ``## <title>`` heading, or None."""
+    target = title.strip().lower()
+    for m in _H2_RE.finditer(text):
+        if m.group("title").strip().lower() == target:
+            return text[: m.start()].count("\n") + 1
+    return None
+
+
+def _extract_section_body(text: str, title: str) -> str | None:
+    """Return the markdown body between ``## <title>`` and the next H2."""
+    target = title.strip().lower()
+    headings = list(_H2_RE.finditer(text))
+    for i, m in enumerate(headings):
+        if m.group("title").strip().lower() != target:
+            continue
+        start = m.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+        return text[start:end]
+    return None
+
+
+def _policy_files_under(root: Path) -> list[Path]:
+    """Return every ``.md`` under ``root`` (recursive)."""
+    if root.is_file() and root.suffix == ".md":
+        return [root]
+    if not root.is_dir():
+        return []
+    return sorted(p for p in root.rglob("*.md") if p.is_file())
+
+
+def check_prompt_policy(roots: list[Path], repo_root: Path) -> list[Finding]:
+    """Return B.3 findings: every prompt-policy file has the 4 required
+    sections; its ``## Version`` body matches the canonical format.
+    """
+    findings: list[Finding] = []
+    default_root = repo_root / ".claude" / "rules" / "prompt_policy"
+    search_roots = roots if roots else [default_root]
+
+    files: list[Path] = []
+    for r in search_roots:
+        files.extend(_policy_files_under(r))
+
+    if not files:
+        # Lint emits a WARN when the scan produces zero files — that is
+        # almost always a pointer/typo rather than a clean state.
+        findings.append(
+            Finding(
+                severity=Severity.WARN,
+                rule_id="PP0",
+                path=default_root,
+                line=1,
+                message=(
+                    "check prompt-policy walked zero files; expected at "
+                    "least one .md under .claude/rules/prompt_policy/"
+                ),
+            )
+        )
+        return findings
+
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(
+                Finding(
+                    severity=Severity.BLOCK,
+                    rule_id="PP1",
+                    path=path,
+                    line=1,
+                    message=f"cannot read file: {exc}",
+                )
+            )
+            continue
+
+        # PP2: required sections exist.
+        for section in _PROMPT_POLICY_REQUIRED_SECTIONS:
+            if _find_h2_line(text, section) is None:
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="PP2",
+                        path=path,
+                        line=1,
+                        message=(
+                            f"missing required section '## {section}' "
+                            f"(B.3 registry schema — shaping §4.2)"
+                        ),
+                    )
+                )
+
+        # PP3: Version body has canonical format on its own line.
+        version_body = _extract_section_body(text, "Version")
+        if version_body is not None:
+            version_line = None
+            for raw in version_body.splitlines():
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                version_line = stripped
+                break
+            if version_line is None:
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="PP3",
+                        path=path,
+                        line=_find_h2_line(text, "Version") or 1,
+                        message=(
+                            "Version section is empty; expected a single "
+                            "line `<archetype>-v<MAJOR>.<MINOR>`"
+                        ),
+                    )
+                )
+            elif not _POLICY_VERSION_RE.match(version_line):
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="PP3",
+                        path=path,
+                        line=_find_h2_line(text, "Version") or 1,
+                        message=(
+                            f"Version line {version_line!r} does not match "
+                            f"`<archetype>-v<MAJOR>.<MINOR>` (backticked)"
+                        ),
+                    )
+                )
+
+        # PP4: Trigger / Expected effect / Rollback bodies are non-empty.
+        for section in ("Trigger", "Expected effect", "Rollback"):
+            body = _extract_section_body(text, section)
+            if body is not None and not body.strip():
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="PP4",
+                        path=path,
+                        line=_find_h2_line(text, section) or 1,
+                        message=(
+                            f"'## {section}' section is empty; B.3 "
+                            f"registry requires a concrete body"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# B.6: check tool-risk
+# ---------------------------------------------------------------------------
+
+_TOOL_RISK_APPROVAL_CLASSES: frozenset[str] = frozenset(
+    {"direct", "approve", "edit", "reject"}
+)
+
+# Parse a 4-column registry row:
+#   | Tool | Auto-mode envelope | Bypass envelope | Notes |
+_TOOL_RISK_ROW_RE = re.compile(
+    r"^\|\s*(?P<tool>.+?)\s*\|\s*(?P<auto>.+?)\s*\|\s*(?P<bypass>.+?)\s*\|\s*(?P<notes>.*?)\s*\|\s*$"
+)
+
+_ALLOWLIST_ENTRY_RE = re.compile(r'^\s*"([^"]+)"[,\s]*$')
+
+
+def _load_permissions_allow(settings_path: Path) -> list[str]:
+    """Extract the ``permissions.allow`` string array from settings.json
+    using a lightweight structural scan (avoids pulling in a JSON parser
+    that would error on comments).
+
+    Returns the ordered list of allow entries. Returns an empty list if
+    the file does not exist or the ``allow`` array cannot be located.
+    """
+    try:
+        text = settings_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    # Locate the start of the "allow": [ ... ] block.
+    start = text.find('"allow"')
+    if start < 0:
+        return []
+    bracket = text.find("[", start)
+    if bracket < 0:
+        return []
+    close = text.find("]", bracket)
+    if close < 0:
+        return []
+    body = text[bracket + 1 : close]
+    entries: list[str] = []
+    for raw in body.splitlines():
+        m = _ALLOWLIST_ENTRY_RE.match(raw.rstrip())
+        if m:
+            entries.append(m.group(1))
+    return entries
+
+
+def _parse_tool_risk_rows(text: str) -> list[tuple[int, str, str, str, str]]:
+    """Return ``(line_no, tool, auto_class, bypass_class, notes)`` rows.
+
+    Skips header rows, separator rows, and template placeholder rows
+    (`(...)`). Line numbers are 1-indexed.
+    """
+    rows: list[tuple[int, str, str, str, str]] = []
+    for i, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line.startswith("|"):
+            continue
+        if re.match(r"^\|[\s\-:|]+\|\s*$", line):
+            continue
+        m = _TOOL_RISK_ROW_RE.match(line)
+        if not m:
+            continue
+        tool = m.group("tool").strip()
+        auto = m.group("auto").strip()
+        bypass = m.group("bypass").strip()
+        notes = m.group("notes").strip()
+        low = tool.lower()
+        if low in {"tool", "item"}:
+            continue
+        if tool.startswith("(") and tool.endswith(")"):
+            continue
+        rows.append((i, tool, auto, bypass, notes))
+    return rows
+
+
+def _approval_class_first_token(cell: str) -> str:
+    """Registry cells are of the form ``direct`` or ``approve (classifier
+    gates…)``. Return the first lowercase token."""
+    match = re.match(r"^([a-z]+)", cell.strip().lower())
+    return match.group(1) if match else ""
+
+
+def check_tool_risk(roots: list[Path], repo_root: Path) -> list[Finding]:
+    """Return B.6 findings: registry file exists; every row has both
+    envelope columns populated with a valid approval class; every entry
+    in ``permissions.allow`` has at least one matching row.
+    """
+    findings: list[Finding] = []
+    default_path = repo_root / ".claude" / "rules" / "tool_risk_registry.md"
+    registry_path = roots[0] if roots else default_path
+    if registry_path.is_dir():
+        registry_path = registry_path / "tool_risk_registry.md"
+
+    if not registry_path.exists():
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="TR0",
+                path=registry_path,
+                line=1,
+                message=(
+                    "tool_risk_registry.md not found (B.6 — shaping §5.1). "
+                    "Register every tool in permissions.allow."
+                ),
+            )
+        )
+        return findings
+
+    try:
+        text = registry_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="TR0",
+                path=registry_path,
+                line=1,
+                message=f"cannot read registry: {exc}",
+            )
+        )
+        return findings
+
+    rows = _parse_tool_risk_rows(text)
+    if not rows:
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="TR1",
+                path=registry_path,
+                line=1,
+                message="registry contains zero rows — expected coverage table",
+            )
+        )
+        return findings
+
+    # TR2: every row has both envelopes populated with a valid class.
+    for line_no, tool, auto_cell, bypass_cell, notes in rows:
+        for label, cell in (("auto-mode", auto_cell), ("bypass", bypass_cell)):
+            if not cell or cell.upper() == "TBD":
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="TR2",
+                        path=registry_path,
+                        line=line_no,
+                        message=(
+                            f"row {tool!r}: {label} envelope column is empty or TBD"
+                        ),
+                    )
+                )
+                continue
+            first = _approval_class_first_token(cell)
+            if first not in _TOOL_RISK_APPROVAL_CLASSES:
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="TR2",
+                        path=registry_path,
+                        line=line_no,
+                        message=(
+                            f"row {tool!r}: {label} class {first!r} is not "
+                            f"one of {{direct, approve, edit, reject}}"
+                        ),
+                    )
+                )
+
+        # TR3: every reject-under-bypass row has a Notes explanation.
+        bypass_first = _approval_class_first_token(bypass_cell)
+        if bypass_first == "reject" and not notes:
+            findings.append(
+                Finding(
+                    severity=Severity.WARN,
+                    rule_id="TR3",
+                    path=registry_path,
+                    line=line_no,
+                    message=(
+                        f"row {tool!r}: reject-under-bypass requires a "
+                        f"Notes explanation (destructive/exfil/etc)"
+                    ),
+                )
+            )
+
+    # TR4: every permissions.allow entry has at least one row covering it.
+    # Matching is lenient: an entry is covered if its exact string appears
+    # in any row's Tool column, OR if a backticked-form of it appears.
+    # This lets the registry group related entries (e.g., a single
+    # ``Edit(.claude/rules/**)`` row covers both Edit+Write pair entries
+    # by explicitly listing both in the Tool cell when needed).
+    settings_path = repo_root / ".claude" / "settings.json"
+    allow = _load_permissions_allow(settings_path)
+    registry_blob = "\n".join(r[1] for r in rows)
+    for entry in allow:
+        if entry in registry_blob:
+            continue
+        # Fall back: try the first-prefix match (``Bash(git *)`` inside
+        # a cell that lists ``Bash(git *)``). Same test as `in`, so this
+        # branch exists for future extension (e.g., regex-based rows).
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="TR4",
+                path=registry_path,
+                line=1,
+                message=(
+                    f"permissions.allow entry {entry!r} has no registry "
+                    f"row (grep cross-check — shaping §5.2 item 3)"
+                ),
+            )
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# B.11: check recipes
+# ---------------------------------------------------------------------------
+
+_RECIPE_REQUIRED_SECTIONS: tuple[str, ...] = (
+    "Version",
+    "Context",
+    "Decision",
+    "Observed outcome",
+    "Reuse guidance",
+    "Downstream citations",
+)
+
+_RECIPE_VERSION_RE = re.compile(r"^`b11-recipe-[a-z0-9][a-z0-9_-]*-v\d+\.\d+`$")
+
+
+def _recipe_files_under(root: Path) -> list[Path]:
+    """Return non-archive, non-template recipe markdown files."""
+    if not root.is_dir():
+        return []
+    files: list[Path] = []
+    for p in sorted(root.rglob("*.md")):
+        parts = set(p.parts)
+        if "_archive" in parts or "archive" in parts:
+            continue
+        if p.name == "_template.md":
+            continue
+        if p.name == "INDEX.md":
+            continue
+        files.append(p)
+    return files
+
+
+def check_recipes(roots: list[Path], repo_root: Path) -> list[Finding]:
+    """Return B.11 findings: every recipe file has six required sections;
+    the archive ``INDEX.md`` references every non-archive, non-template
+    recipe.
+    """
+    findings: list[Finding] = []
+    default_root = repo_root / "knowledge" / "orchestration_recipes"
+    search_root = roots[0] if roots else default_root
+    if search_root.is_file():
+        search_root = search_root.parent
+
+    if not search_root.exists():
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="RC0",
+                path=search_root,
+                line=1,
+                message=(
+                    "knowledge/orchestration_recipes/ not found (B.11 — shaping §8.1)"
+                ),
+            )
+        )
+        return findings
+
+    index_path = search_root / "INDEX.md"
+    if not index_path.exists():
+        findings.append(
+            Finding(
+                severity=Severity.BLOCK,
+                rule_id="RC1",
+                path=index_path,
+                line=1,
+                message=(
+                    "archive INDEX.md missing (B.11 — shaping §8.5). "
+                    "Every non-archive recipe must be indexed."
+                ),
+            )
+        )
+        index_text = ""
+    else:
+        try:
+            index_text = index_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(
+                Finding(
+                    severity=Severity.BLOCK,
+                    rule_id="RC1",
+                    path=index_path,
+                    line=1,
+                    message=f"cannot read INDEX.md: {exc}",
+                )
+            )
+            index_text = ""
+
+    recipes = _recipe_files_under(search_root)
+
+    for path in recipes:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(
+                Finding(
+                    severity=Severity.BLOCK,
+                    rule_id="RC2",
+                    path=path,
+                    line=1,
+                    message=f"cannot read recipe: {exc}",
+                )
+            )
+            continue
+
+        # RC2: required sections exist.
+        for section in _RECIPE_REQUIRED_SECTIONS:
+            if _find_h2_line(text, section) is None:
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="RC2",
+                        path=path,
+                        line=1,
+                        message=(
+                            f"missing required section '## {section}' "
+                            f"(B.11 recipe schema — shaping §8.2)"
+                        ),
+                    )
+                )
+
+        # RC3: Version body matches the canonical format.
+        version_body = _extract_section_body(text, "Version")
+        if version_body is not None:
+            version_line = None
+            for raw in version_body.splitlines():
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                version_line = stripped
+                break
+            if version_line is None or not _RECIPE_VERSION_RE.match(version_line):
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="RC3",
+                        path=path,
+                        line=_find_h2_line(text, "Version") or 1,
+                        message=(
+                            f"Version {version_line!r} does not match "
+                            f"`b11-recipe-<slug>-v<MAJOR>.<MINOR>`"
+                        ),
+                    )
+                )
+
+        # RC4: INDEX.md references this recipe (by filename).
+        if index_text and path.name not in index_text:
+            findings.append(
+                Finding(
+                    severity=Severity.WARN,
+                    rule_id="RC4",
+                    path=index_path,
+                    line=1,
+                    message=(
+                        f"recipe {path.name!r} is not referenced in INDEX.md "
+                        f"(B.11 — shaping §8.5)"
+                    ),
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -521,7 +1098,13 @@ def _exit_code_for_findings(findings: list[Finding], warnings_ok: bool) -> int:
     return 0
 
 
-def _default_roots(repo_root: Path) -> list[Path]:
+def _default_roots(repo_root: Path, rule_set: str) -> list[Path]:
+    if rule_set == "prompt-policy":
+        return [repo_root / ".claude" / "rules" / "prompt_policy"]
+    if rule_set == "tool-risk":
+        return [repo_root / ".claude" / "rules" / "tool_risk_registry.md"]
+    if rule_set == "recipes":
+        return [repo_root / "knowledge" / "orchestration_recipes"]
     return [repo_root / "plans"]
 
 
@@ -530,7 +1113,7 @@ def main(argv: list[str] | None = None) -> int:
         prog="agent_readability_lint",
         description=(
             "Agent-readability lint for steward-platform plan health "
-            "(Pattern 9 + Pattern 10)."
+            "(Pattern 9 + Pattern 10 + B.3/B.6/B.11 registries)."
         ),
     )
     parser.add_argument(
@@ -561,13 +1144,41 @@ def main(argv: list[str] | None = None) -> int:
     )
     lbo.add_argument("paths", nargs="*", type=Path, help="Plan paths to walk")
 
+    pp = check_sub.add_parser(
+        "prompt-policy",
+        help="B.3 — verify prompt-policy registry schema (4 sections + version format)",
+    )
+    pp.add_argument("paths", nargs="*", type=Path, help="Policy paths to walk")
+
+    tr = check_sub.add_parser(
+        "tool-risk",
+        help="B.6 — verify tool-risk registry schema (dual-envelope + allow-list coverage)",
+    )
+    tr.add_argument(
+        "paths", nargs="*", type=Path, help="Registry path (file or containing dir)"
+    )
+
+    rc = check_sub.add_parser(
+        "recipes",
+        help="B.11 — verify orchestration-recipe archive schema (6 sections + INDEX)",
+    )
+    rc.add_argument("paths", nargs="*", type=Path, help="Archive paths to walk")
+
     args = parser.parse_args(argv)
     repo_root: Path = args.repo_root.resolve()
-    paths: list[Path] = list(args.paths) or _default_roots(repo_root)
+    paths: list[Path] = list(args.paths) or _default_roots(repo_root, args.rule_set)
 
-    # Validate paths exist to avoid silent empty walks.
+    # Validate paths exist to avoid silent empty walks — but for
+    # rule-sets whose defaults may not exist yet (e.g., ``tool-risk``
+    # before the registry is authored), let the check produce a
+    # BLOCK finding rather than an invocation error so CI surfaces
+    # the gap as a lint finding (not a bad-arg).
+    strict_missing_paths = args.rule_set in {
+        "verification-contract",
+        "load-bearing-ownership",
+    }
     for p in paths:
-        if not p.exists():
+        if not p.exists() and strict_missing_paths:
             print(f"ERROR: path not found: {p}", file=sys.stderr)
             return 1
 
@@ -575,6 +1186,12 @@ def main(argv: list[str] | None = None) -> int:
         findings = check_verification_contract(paths, repo_root)
     elif args.rule_set == "load-bearing-ownership":
         findings = check_load_bearing_ownership(paths, repo_root)
+    elif args.rule_set == "prompt-policy":
+        findings = check_prompt_policy(paths, repo_root)
+    elif args.rule_set == "tool-risk":
+        findings = check_tool_risk(paths, repo_root)
+    elif args.rule_set == "recipes":
+        findings = check_recipes(paths, repo_root)
     else:  # pragma: no cover - argparse enforces
         print(f"ERROR: unknown rule set: {args.rule_set}", file=sys.stderr)
         return 1

--- a/src/bid_euchre/ops/effort_policy.py
+++ b/src/bid_euchre/ops/effort_policy.py
@@ -1,0 +1,153 @@
+"""Effort-policy resolver — per-archetype × per-task-type effort tier defaults.
+
+Pure-function home for B.1 adaptive-dispatch to consume at dispatch time.
+The canonical policy is authored in `.claude/rules/effort_policy.md`; this
+module encodes the same table as a Python dict so `effort_for(archetype,
+task_type)` can be called from any lane without reading files at dispatch time.
+
+Drift discipline: `tests/unit/test_effort_policy.py` parses the markdown
+table and asserts it matches `POLICY_TABLE` 1:1. A change to the .md table
+without a matching change here (or vice versa) fails the test.
+
+The tier vocabulary here (`"lower"`, `"xhigh"`, `"max"`) is the *policy*
+vocabulary. It maps to the `VALID_EFFORT_HINTS` enum in `task_queue.py` via:
+
+    lower → low
+    xhigh → high
+    max   → max
+
+See `.claude/rules/effort_policy.md` §"Tier vocabulary" for the full mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+POLICY_VERSION: Final[str] = "b10-v1.0"
+
+# Tier vocabulary. `n/a` is a sentinel meaning "dispatch never routes this
+# task_type to this archetype"; `effort_for()` raises on `n/a` pairings.
+# Exported so callers (lint, B.1 dispatch, B.12 probe) can validate tier
+# literals against the same registry.
+VALID_TIERS: Final[frozenset[str]] = frozenset({"lower", "xhigh", "max", "n/a"})
+
+_VALID_ARCHETYPES: Final[tuple[str, ...]] = (
+    "orchestrator",
+    "ops",
+    "review",
+    "analyst",
+    "author",
+    "brws-author",
+    "flex",
+)
+
+_VALID_TASK_TYPES: Final[tuple[str, ...]] = (
+    "investigation",
+    "implementation",
+    "refactor",
+    "fix",
+    "docs",
+)
+
+# Canonical policy table. Keep in sync with `.claude/rules/effort_policy.md`.
+# Row order matches the markdown table so the drift test can compare 1:1.
+POLICY_TABLE: Final[dict[str, dict[str, str]]] = {
+    "orchestrator": {
+        "investigation": "xhigh",
+        "implementation": "n/a",
+        "refactor": "n/a",
+        "fix": "n/a",
+        "docs": "n/a",
+    },
+    "ops": {
+        "investigation": "lower",
+        "implementation": "n/a",
+        "refactor": "n/a",
+        "fix": "lower",
+        "docs": "lower",
+    },
+    "review": {
+        "investigation": "xhigh",
+        "implementation": "n/a",
+        "refactor": "n/a",
+        "fix": "n/a",
+        "docs": "n/a",
+    },
+    "analyst": {
+        "investigation": "max",
+        "implementation": "n/a",
+        "refactor": "n/a",
+        "fix": "n/a",
+        "docs": "xhigh",
+    },
+    "author": {
+        "investigation": "n/a",
+        "implementation": "xhigh",
+        "refactor": "xhigh",
+        "fix": "xhigh",
+        "docs": "lower",
+    },
+    "brws-author": {
+        "investigation": "n/a",
+        "implementation": "xhigh",
+        "refactor": "xhigh",
+        "fix": "xhigh",
+        "docs": "lower",
+    },
+    "flex": {
+        "investigation": "xhigh",
+        "implementation": "xhigh",
+        "refactor": "xhigh",
+        "fix": "xhigh",
+        "docs": "lower",
+    },
+}
+
+
+def effort_for(archetype: str, task_type: str) -> str:
+    """Return the policy-default effort tier for `(archetype, task_type)`.
+
+    Parameters
+    ----------
+    archetype:
+        One of `orchestrator`, `ops`, `review`, `analyst`, `author`,
+        `brws-author`, `flex`. Flex is the union-row — takes any task type.
+    task_type:
+        One of `investigation`, `implementation`, `refactor`, `fix`, `docs`.
+
+    Returns
+    -------
+    str
+        One of `"lower"`, `"xhigh"`, `"max"`.
+
+    Raises
+    ------
+    ValueError
+        If `archetype` or `task_type` is unknown, or if the pairing is `n/a`
+        (archetype refuses that task_type — orchestrator must reassign).
+    """
+    if archetype not in POLICY_TABLE:
+        raise ValueError(
+            f"unknown archetype {archetype!r}; expected one of {_VALID_ARCHETYPES!r}"
+        )
+    row = POLICY_TABLE[archetype]
+    if task_type not in row:
+        raise ValueError(
+            f"unknown task_type {task_type!r}; expected one of {_VALID_TASK_TYPES!r}"
+        )
+    tier = row[task_type]
+    if tier == "n/a":
+        raise ValueError(
+            f"archetype {archetype!r} does not accept task_type "
+            f"{task_type!r} (policy cell = n/a); orchestrator must reassign "
+            f"to an archetype with a non-n/a cell, or reclassify the task_type"
+        )
+    return tier
+
+
+__all__ = [
+    "POLICY_TABLE",
+    "POLICY_VERSION",
+    "VALID_TIERS",
+    "effort_for",
+]

--- a/src/bid_euchre/ops/task_queue.py
+++ b/src/bid_euchre/ops/task_queue.py
@@ -116,7 +116,15 @@ VALID_MODEL_HINTS: frozenset[str] = frozenset({"opus", "sonnet", "haiku"})
 
 # Effort hints. Represent the orchestrator's budget intent; the worker lane
 # may still adjust within its own policy.
-VALID_EFFORT_HINTS: frozenset[str] = frozenset({"low", "medium", "high"})
+#
+# ``"max"`` was added in Primitive B-exec.α (B.10 — effort policy) to
+# carry the ``max`` tier defined in ``.claude/rules/effort_policy.md``
+# alongside the existing ``low``/``medium``/``high`` values. The mapping
+# between ``effort_policy.md`` tier names and this enum is:
+# ``lower → low``, ``xhigh → high``, ``max → max``. Phase 0 keeps both
+# vocabularies usable so existing packets remain valid; a later phase
+# may migrate callers onto the effort_policy.md vocabulary.
+VALID_EFFORT_HINTS: frozenset[str] = frozenset({"low", "medium", "high", "max"})
 
 # Complexity estimate is an integer 1..5 inclusive.
 MIN_COMPLEXITY: int = 1

--- a/tests/unit/test_effort_policy.py
+++ b/tests/unit/test_effort_policy.py
@@ -1,0 +1,212 @@
+"""Unit tests for `bid_euchre.ops.effort_policy` and `.claude/rules/effort_policy.md`.
+
+Covers:
+- `effort_for(archetype, task_type)` returns the expected tier for known pairs.
+- `effort_for` raises `ValueError` on `n/a` pairings.
+- `effort_for` raises `ValueError` on unknown archetype / task_type.
+- `effort_for` is pure (no I/O; stateless across calls).
+- `POLICY_TABLE` and the markdown table in `.claude/rules/effort_policy.md`
+  are 1:1 identical (drift guard per shaping §7.4).
+- `max` is in `VALID_EFFORT_HINTS` per §7.5 enum extension.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.effort_policy import (
+    POLICY_TABLE,
+    POLICY_VERSION,
+    VALID_TIERS,
+    effort_for,
+)
+
+# --- Repo-root discovery ---------------------------------------------------
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until we find the repo's `.claude/` dir."""
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / ".claude").is_dir() and (parent / "src" / "bid_euchre").is_dir():
+            return parent
+    raise RuntimeError(f"could not find repo root from {here}")
+
+
+EFFORT_POLICY_MD = _repo_root() / ".claude" / "rules" / "effort_policy.md"
+
+
+# --- effort_for() correctness ---------------------------------------------
+
+
+class TestEffortFor:
+    """Verify the resolver returns the right tier for each (archetype, task_type)."""
+
+    def test_author_implementation_xhigh(self) -> None:
+        """Shaping §7.4 example: author + implementation = xhigh."""
+        assert effort_for("author", "implementation") == "xhigh"
+
+    def test_analyst_investigation_max(self) -> None:
+        """Analyst investigation is the one `max` default (hardest shaping)."""
+        assert effort_for("analyst", "investigation") == "max"
+
+    def test_ops_docs_lower(self) -> None:
+        """Ops is lower-tier across its non-n/a columns."""
+        assert effort_for("ops", "docs") == "lower"
+
+    def test_flex_any_task_type(self) -> None:
+        """Flex is the union-row — accepts every task type."""
+        assert effort_for("flex", "investigation") == "xhigh"
+        assert effort_for("flex", "implementation") == "xhigh"
+        assert effort_for("flex", "refactor") == "xhigh"
+        assert effort_for("flex", "fix") == "xhigh"
+        assert effort_for("flex", "docs") == "lower"
+
+    def test_returns_string_from_valid_tiers(self) -> None:
+        """Every non-n/a cell must be one of the declared tier literals."""
+        for archetype, row in POLICY_TABLE.items():
+            for task_type, tier in row.items():
+                assert tier in VALID_TIERS, (
+                    f"POLICY_TABLE[{archetype!r}][{task_type!r}] = {tier!r} "
+                    f"not in VALID_TIERS={VALID_TIERS!r}"
+                )
+
+
+class TestEffortForRaises:
+    """Verify `effort_for` raises on `n/a` cells and unknown inputs."""
+
+    def test_author_investigation_raises_na(self) -> None:
+        """Authors do not do investigation work — `n/a` cell raises."""
+        with pytest.raises(ValueError, match="n/a"):
+            effort_for("author", "investigation")
+
+    def test_orchestrator_implementation_raises_na(self) -> None:
+        """Orchestrator does not do implementation — `n/a` cell raises."""
+        with pytest.raises(ValueError, match="n/a"):
+            effort_for("orchestrator", "implementation")
+
+    def test_review_fix_raises_na(self) -> None:
+        """Review lane does not ship fixes — `n/a` cell raises."""
+        with pytest.raises(ValueError, match="n/a"):
+            effort_for("review", "fix")
+
+    def test_unknown_archetype_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown archetype"):
+            effort_for("wizard", "investigation")
+
+    def test_unknown_task_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown task_type"):
+            effort_for("author", "ponder")
+
+
+class TestEffortForPurity:
+    """Verify `effort_for` is pure: no state, no I/O, no side effects."""
+
+    def test_repeated_calls_return_same_result(self) -> None:
+        for _ in range(5):
+            assert effort_for("author", "fix") == "xhigh"
+            assert effort_for("ops", "investigation") == "lower"
+
+    def test_table_not_mutated_by_calls(self) -> None:
+        """Calling `effort_for` must not mutate `POLICY_TABLE`."""
+        before = {k: dict(v) for k, v in POLICY_TABLE.items()}
+        effort_for("flex", "implementation")
+        effort_for("analyst", "docs")
+        with pytest.raises(ValueError):
+            effort_for("author", "investigation")
+        after = {k: dict(v) for k, v in POLICY_TABLE.items()}
+        assert before == after
+
+
+# --- Markdown table drift guard --------------------------------------------
+
+_TABLE_HEADER_RE = re.compile(
+    r"^\|\s*Archetype\s*\|\s*task_type=investigation\s*\|"
+    r"\s*task_type=implementation\s*\|\s*task_type=refactor\s*\|"
+    r"\s*task_type=fix\s*\|\s*task_type=docs\s*\|",
+)
+
+
+def _parse_markdown_table(text: str) -> dict[str, dict[str, str]]:
+    """Parse the 7-row × 5-col policy table from the markdown file.
+
+    Returns a dict shaped like `POLICY_TABLE`. Skips the header and
+    separator rows; stops at the first non-pipe line after the table body.
+    """
+    lines = text.splitlines()
+    # Locate the header row.
+    header_idx: int | None = None
+    for i, line in enumerate(lines):
+        if _TABLE_HEADER_RE.match(line):
+            header_idx = i
+            break
+    assert (
+        header_idx is not None
+    ), f"policy table header not found in {EFFORT_POLICY_MD}"
+    # Data rows start 2 lines after the header (skip separator `|---|...`).
+    data_start = header_idx + 2
+    result: dict[str, dict[str, str]] = {}
+    task_types = ("investigation", "implementation", "refactor", "fix", "docs")
+    for line in lines[data_start:]:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            break
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) != 6:
+            continue
+        archetype = cells[0]
+        row = {task_types[i]: cells[i + 1] for i in range(5)}
+        result[archetype] = row
+    return result
+
+
+class TestMarkdownDriftGuard:
+    """Verify `.claude/rules/effort_policy.md` table matches `POLICY_TABLE` 1:1."""
+
+    def test_markdown_file_exists(self) -> None:
+        assert (
+            EFFORT_POLICY_MD.is_file()
+        ), f"expected effort policy at {EFFORT_POLICY_MD}"
+
+    def test_markdown_version_matches(self) -> None:
+        text = EFFORT_POLICY_MD.read_text()
+        # Version appears as a backticked token under `## Version`.
+        assert (
+            f"`{POLICY_VERSION}`" in text
+        ), f"POLICY_VERSION={POLICY_VERSION!r} not cited in {EFFORT_POLICY_MD}"
+
+    def test_markdown_table_matches_policy_table(self) -> None:
+        text = EFFORT_POLICY_MD.read_text()
+        parsed = _parse_markdown_table(text)
+        assert parsed == POLICY_TABLE, (
+            "POLICY_TABLE in effort_policy.py drifted from the markdown "
+            "table. Update both files together."
+        )
+
+    def test_markdown_table_has_all_archetypes(self) -> None:
+        text = EFFORT_POLICY_MD.read_text()
+        parsed = _parse_markdown_table(text)
+        assert set(parsed.keys()) == set(POLICY_TABLE.keys())
+        # Exactly 7 rows — shaping §7 specifies the 7-archetype matrix.
+        assert len(parsed) == 7
+
+
+# --- Enum extension (§7.5) -------------------------------------------------
+
+
+class TestEnumExtension:
+    """Verify `max` was added to `VALID_EFFORT_HINTS` per shaping §7.5."""
+
+    def test_max_in_valid_effort_hints(self) -> None:
+        from bid_euchre.ops.task_queue import VALID_EFFORT_HINTS
+
+        assert "max" in VALID_EFFORT_HINTS
+
+    def test_all_original_values_preserved(self) -> None:
+        """Existing enum values must still be accepted (backward compat)."""
+        from bid_euchre.ops.task_queue import VALID_EFFORT_HINTS
+
+        assert {"low", "medium", "high"}.issubset(VALID_EFFORT_HINTS)

--- a/tests/unit/test_ops_task_queue.py
+++ b/tests/unit/test_ops_task_queue.py
@@ -901,7 +901,10 @@ class TestRoutingMetadataConstants:
     def test_effort_hints(self) -> None:
         from bid_euchre.ops.task_queue import VALID_EFFORT_HINTS
 
-        assert VALID_EFFORT_HINTS == frozenset({"low", "medium", "high"})
+        # "max" added by Primitive B-exec.α (B.10 effort policy) so packets
+        # can carry the `max → max` tier verbatim. See
+        # `.claude/rules/effort_policy.md` §"Tier vocabulary" for the mapping.
+        assert VALID_EFFORT_HINTS == frozenset({"low", "medium", "high", "max"})
 
     def test_complexity_range_bounds(self) -> None:
         from bid_euchre.ops.task_queue import MAX_COMPLEXITY, MIN_COMPLEXITY

--- a/tests/unit/test_portability_audit.py
+++ b/tests/unit/test_portability_audit.py
@@ -61,13 +61,17 @@ def _load_audit_module():
 # They should only decrease as decoupling work proceeds.  If a PR increases
 # coupling, either fix the regression or update the threshold with justification.
 
-NON_COSMETIC_THRESHOLD = 259  # hard-block + soft-coupling
+NON_COSMETIC_THRESHOLD = 263  # hard-block + soft-coupling
 # Baseline was 253; main drifted to 257 before Slice D landed (pre-existing,
-# unrelated to token-economy work). Slice D adds 2 more hits because the
+# unrelated to token-economy work). Slice D added 2 more hits because the
 # `lane-name-in-code` regex matches the string literals `"ops"` and `"review"`
 # in LANE_DEFAULT_POLICY — those are task_type taxonomy keys (#2169 Slice D),
-# not lane identifiers, so this is a known audit false positive. Downstream
-# portability cleanup will narrow the regex or formalize task_type as an Enum.
+# not lane identifiers, so this is a known audit false positive. Primitive
+# B-exec.α (B.10 effort policy, shaping §7) adds 4 more hits for the same
+# reason — `"ops"` and `"review"` appear in both `_VALID_ARCHETYPES` and
+# `POLICY_TABLE` of `src/bid_euchre/ops/effort_policy.py` as archetype
+# taxonomy keys. Downstream portability cleanup will narrow the regex or
+# formalize archetype/task_type as Enums.
 HARD_BLOCK_THRESHOLD = 130  # hard-block only (pinned to baseline)
 
 

--- a/tests/unit/test_prompt_policy_registry.py
+++ b/tests/unit/test_prompt_policy_registry.py
@@ -1,0 +1,440 @@
+"""Unit tests for the B.3 prompt-policy registry lint.
+
+Covers ``agent_readability_lint.check_prompt_policy`` rules PP0–PP4
+(shaping §4.2 / §10.1 / §10.6 — Primitive B execution spec). Fixtures are
+inline and hermetic: each test writes one or more minimal ``*.md`` files
+under a ``tmp_path`` policy root and asserts which rule IDs fire.
+
+Shared-module note (shaping §13.2 risk #2): the prompt-policy check rides
+the same lint harness as Pattern 10 (``check verification-contract``).
+Keep this file lean — shared plan-walker regressions live in
+``test_agent_readability_lint.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "agent_readability_lint",
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "internal"
+    / "agent_readability_lint.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+arl = importlib.util.module_from_spec(_SPEC)
+sys.modules["agent_readability_lint"] = arl
+_SPEC.loader.exec_module(arl)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy_root(tmp_path: Path) -> Path:
+    """Return the conventional policy root under ``tmp_path`` (created)."""
+    root = tmp_path / ".claude" / "rules" / "prompt_policy"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_policy(path: Path, body: str) -> Path:
+    """Write ``body`` to ``path``, dedenting and stripping the leading newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return path
+
+
+def _valid_policy(archetype: str = "author", version: str = "v1.0") -> str:
+    """Return a minimal policy file body that satisfies PP1–PP4."""
+    return f"""
+    # {archetype.title()} Prompt Policy
+
+    > One-line doc blockquote.
+
+    ## Version
+
+    `{archetype}-{version}`
+
+    ## Trigger
+
+    Initial registry version. Landed in PR #0 (commit `abc1234`).
+
+    ## Expected effect
+
+    Visible signal: observable X rises from baseline to Y in the proving run.
+
+    ## Rollback
+
+    `git revert <SHA>` restores the prior version. Trace signature: field Z.
+
+    ## Policy clauses
+
+    ### Example clause
+
+    Do the thing.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Happy path — live-tree shape passes
+# ---------------------------------------------------------------------------
+
+
+def test_valid_policy_file_emits_no_findings(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(root / "author.md", _valid_policy("author"))
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    assert findings == [], f"expected clean, got {[f.format_line() for f in findings]}"
+
+
+def test_multiple_valid_policy_files_clean(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    for name in ("orchestrator", "author", "analyst", "common"):
+        _write_policy(root / f"{name}.md", _valid_policy(name))
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    assert findings == [], f"expected clean, got {[f.format_line() for f in findings]}"
+
+
+# ---------------------------------------------------------------------------
+# PP0 — zero files is a WARN (pointer/typo likely)
+# ---------------------------------------------------------------------------
+
+
+def test_pp0_warns_on_empty_policy_tree(tmp_path: Path) -> None:
+    empty_root = tmp_path / ".claude" / "rules" / "prompt_policy"
+    empty_root.mkdir(parents=True, exist_ok=True)
+    findings = arl.check_prompt_policy([empty_root], repo_root=tmp_path)
+    pp0 = [f for f in findings if f.rule_id == "PP0"]
+    assert len(pp0) == 1, f"expected 1 PP0 finding, got {len(pp0)}"
+    assert pp0[0].severity == arl.Severity.WARN
+
+
+def test_pp0_warns_when_default_root_missing(tmp_path: Path) -> None:
+    # No .claude/rules/prompt_policy under tmp_path → default-root scan
+    # should emit PP0 (and nothing else).
+    findings = arl.check_prompt_policy([], repo_root=tmp_path)
+    rule_ids = {f.rule_id for f in findings}
+    assert rule_ids == {"PP0"}
+
+
+# ---------------------------------------------------------------------------
+# PP2 — missing required sections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing", ["Version", "Trigger", "Expected effect", "Rollback"]
+)
+def test_pp2_flags_missing_required_section(tmp_path: Path, missing: str) -> None:
+    root = _policy_root(tmp_path)
+    body = _valid_policy()
+    # Strip the single offending section (heading + content up to next ##).
+    # Keep it simple: replace the full section block with an empty line.
+    lines = body.splitlines()
+    out: list[str] = []
+    skipping = False
+    for ln in lines:
+        stripped = ln.strip()
+        if stripped.lower() == f"## {missing}".lower():
+            skipping = True
+            continue
+        if skipping and stripped.startswith("## "):
+            skipping = False
+        if not skipping:
+            out.append(ln)
+    _write_policy(root / "author.md", "\n".join(out) + "\n")
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp2 = [f for f in findings if f.rule_id == "PP2"]
+    assert any(missing in f.message for f in pp2), (
+        f"expected PP2 mentioning {missing!r}, got "
+        f"{[f.format_line() for f in findings]}"
+    )
+    assert all(f.severity == arl.Severity.BLOCK for f in pp2)
+
+
+def test_pp2_reports_each_missing_section_separately(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    # Missing Trigger AND Rollback.
+    _write_policy(
+        root / "broken.md",
+        """
+        # Broken Policy
+
+        ## Version
+
+        `author-v1.0`
+
+        ## Expected effect
+
+        Something observable.
+
+        ## Policy clauses
+        """,
+    )
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp2 = [f for f in findings if f.rule_id == "PP2"]
+    assert len(pp2) == 2, f"expected 2 PP2 findings, got {len(pp2)}"
+    messages = " | ".join(f.message for f in pp2)
+    assert "Trigger" in messages
+    assert "Rollback" in messages
+
+
+# ---------------------------------------------------------------------------
+# PP3 — Version format rules
+# ---------------------------------------------------------------------------
+
+
+def test_pp3_flags_missing_backticks(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(
+        root / "author.md",
+        """
+        # Author Prompt Policy
+
+        ## Version
+
+        author-v1.0
+
+        ## Trigger
+
+        Initial.
+
+        ## Expected effect
+
+        Works.
+
+        ## Rollback
+
+        Revert.
+        """,
+    )
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp3 = [f for f in findings if f.rule_id == "PP3"]
+    assert len(pp3) == 1
+    assert pp3[0].severity == arl.Severity.BLOCK
+    assert "backticked" in pp3[0].message.lower() or "does not match" in pp3[0].message
+
+
+@pytest.mark.parametrize(
+    "bad_version",
+    [
+        "`author`",  # no version
+        "`author-1.0`",  # missing v prefix
+        "`author-v1`",  # missing minor
+        "`Author-v1.0`",  # uppercase archetype
+        "`author-vX.0`",  # non-numeric major
+        "`v1.0`",  # no archetype
+    ],
+)
+def test_pp3_flags_malformed_version(tmp_path: Path, bad_version: str) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(
+        root / "author.md",
+        f"""
+        # Policy
+
+        ## Version
+
+        {bad_version}
+
+        ## Trigger
+
+        x
+
+        ## Expected effect
+
+        y
+
+        ## Rollback
+
+        z
+        """,
+    )
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp3 = [f for f in findings if f.rule_id == "PP3"]
+    assert pp3, f"expected PP3 for {bad_version!r}, got {[f.rule_id for f in findings]}"
+    assert all(f.severity == arl.Severity.BLOCK for f in pp3)
+
+
+def test_pp3_flags_empty_version_body(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(
+        root / "author.md",
+        """
+        # Policy
+
+        ## Version
+
+        ## Trigger
+
+        x
+
+        ## Expected effect
+
+        y
+
+        ## Rollback
+
+        z
+        """,
+    )
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp3 = [f for f in findings if f.rule_id == "PP3"]
+    assert len(pp3) == 1
+    assert pp3[0].severity == arl.Severity.BLOCK
+    assert "empty" in pp3[0].message.lower()
+
+
+def test_pp3_accepts_multidigit_versions(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(root / "author.md", _valid_policy("author", "v12.37"))
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    assert not any(f.rule_id == "PP3" for f in findings)
+
+
+def test_pp3_accepts_hyphenated_archetype(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(root / "brws-author.md", _valid_policy("brws-author"))
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    assert not any(f.rule_id == "PP3" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# PP4 — empty body under Trigger / Expected effect / Rollback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("section", ["Trigger", "Expected effect", "Rollback"])
+def test_pp4_flags_empty_body(tmp_path: Path, section: str) -> None:
+    root = _policy_root(tmp_path)
+    lines = [
+        "# Policy",
+        "",
+        "## Version",
+        "",
+        "`author-v1.0`",
+        "",
+        "## Trigger",
+        "",
+        "Real trigger text." if section != "Trigger" else "",
+        "",
+        "## Expected effect",
+        "",
+        "Real effect text." if section != "Expected effect" else "",
+        "",
+        "## Rollback",
+        "",
+        "Real rollback text." if section != "Rollback" else "",
+        "",
+    ]
+    _write_policy(root / "author.md", "\n".join(lines) + "\n")
+    findings = arl.check_prompt_policy([root], repo_root=tmp_path)
+    pp4 = [f for f in findings if f.rule_id == "PP4"]
+    assert len(pp4) == 1, (
+        f"expected 1 PP4 for empty {section!r} body, got "
+        f"{[f.format_line() for f in findings]}"
+    )
+    assert pp4[0].severity == arl.Severity.BLOCK
+    assert section in pp4[0].message
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — exit code round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_cli_prompt_policy_clean_exits_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(root / "author.md", _valid_policy("author"))
+    rc = arl.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "check",
+            "prompt-policy",
+            str(root),
+        ]
+    )
+    assert rc == 0
+    assert "0 findings" in capsys.readouterr().out
+
+
+def test_cli_prompt_policy_block_exits_two(tmp_path: Path) -> None:
+    root = _policy_root(tmp_path)
+    _write_policy(
+        root / "broken.md",
+        """
+        # Broken
+
+        ## Version
+
+        author-v1.0
+        """,
+    )
+    rc = arl.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "check",
+            "prompt-policy",
+            str(root),
+        ]
+    )
+    assert rc == 2
+
+
+def test_cli_prompt_policy_default_root_used_when_no_path(tmp_path: Path) -> None:
+    # No path argument; default_root = tmp_path/.claude/rules/prompt_policy.
+    # We do not create it → PP0 fires → exit 2 (WARN, strict mode).
+    rc = arl.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "check",
+            "prompt-policy",
+        ]
+    )
+    assert rc == 2
+
+    # With --warnings-ok, PP0 downgrades to exit 0.
+    rc_relaxed = arl.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--warnings-ok",
+            "check",
+            "prompt-policy",
+        ]
+    )
+    assert rc_relaxed == 0
+
+
+# ---------------------------------------------------------------------------
+# Self-run: the live policy directory must be clean at B-exec.α merge time.
+# ---------------------------------------------------------------------------
+
+
+def test_live_prompt_policy_tree_is_clean() -> None:
+    """Regression guard: B.3 schema lint exits clean against the live tree.
+
+    If this fails after editing a policy file, restore the 4 required
+    sections or the canonical backticked version line — do not relax the
+    lint.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / ".claude" / "rules" / "prompt_policy"
+    if not target.exists():
+        pytest.skip(f"prompt_policy tree not found at {target}")
+    findings = arl.check_prompt_policy([target], repo_root=repo_root)
+    blocks = [f for f in findings if f.severity == arl.Severity.BLOCK]
+    assert not blocks, "BLOCK findings:\n" + "\n".join(f.format_line() for f in blocks)

--- a/tests/unit/test_recipes_archive.py
+++ b/tests/unit/test_recipes_archive.py
@@ -1,0 +1,343 @@
+"""Unit tests for the B.11 orchestration-recipe archive lint.
+
+Covers ``agent_readability_lint.check_recipes`` rules RC0–RC4 (shaping
+§8.5 — Primitive B.11). Fixtures are inline and hermetic: each test
+writes one or more minimal ``*.md`` files under a ``tmp_path`` archive
+root and asserts which rule IDs fire.
+
+Shared-module note (shaping §13.2 risk #2): the recipes check rides the
+same lint harness as Pattern 10 (``check verification-contract``),
+Pattern 9 (``check load-bearing-ownership``), B.3 (``check prompt-policy``),
+and B.6 (``check tool-risk``). Keep this file lean — shared plan-walker
+regressions live in ``test_agent_readability_lint.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "agent_readability_lint",
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "internal"
+    / "agent_readability_lint.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+arl = importlib.util.module_from_spec(_SPEC)
+sys.modules["agent_readability_lint"] = arl
+_SPEC.loader.exec_module(arl)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _archive_root(tmp_path: Path) -> Path:
+    """Return the conventional archive root under ``tmp_path`` (created)."""
+    root = tmp_path / "knowledge" / "orchestration_recipes"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_recipe(path: Path, body: str) -> Path:
+    """Write ``body`` to ``path``, dedenting and stripping the leading newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return path
+
+
+def _valid_recipe(slug: str = "pattern11", version: str = "v1.0") -> str:
+    """Return a minimal recipe file body that satisfies RC2–RC3."""
+    return f"""
+    # Recipe: {slug}
+
+    ## Version
+
+    `b11-recipe-{slug}-v{version[1:]}`
+
+    ## Context
+
+    Observed in session 2026-04-23. Trace: PR #0.
+
+    ## Decision
+
+    Two-packet decomposition: shape + execute.
+
+    ## Observed outcome
+
+    Session 2026-04-23: 25 files, zero re-litigation.
+
+    ## Reuse guidance
+
+    Apply when scope crosses >3 files. Do NOT apply for single-file fixes.
+
+    ## Downstream citations
+
+    - (none yet)
+    """
+
+
+def _write_index(root: Path, entries: list[str]) -> Path:
+    """Write an INDEX.md that references the given filenames."""
+    body = "# Orchestration recipes index\n\n## Active recipes\n\n"
+    for e in entries:
+        body += f"- [{e}]({e})\n"
+    index = root / "INDEX.md"
+    index.write_text(body, encoding="utf-8")
+    return index
+
+
+# ---------------------------------------------------------------------------
+# RC0 — archive root missing
+# ---------------------------------------------------------------------------
+
+
+class TestRC0MissingRoot:
+    def test_missing_root_emits_rc0(self, tmp_path: Path) -> None:
+        missing = tmp_path / "knowledge" / "orchestration_recipes"
+        # Not created — should emit RC0.
+        findings = arl.check_recipes([missing], tmp_path)
+        ids = [f.rule_id for f in findings]
+        assert "RC0" in ids
+        assert any(f.severity.name == "BLOCK" for f in findings if f.rule_id == "RC0")
+
+
+# ---------------------------------------------------------------------------
+# RC1 — INDEX.md missing
+# ---------------------------------------------------------------------------
+
+
+class TestRC1MissingIndex:
+    def test_missing_index_emits_rc1(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        # A valid recipe exists but no INDEX.md — should emit RC1.
+        _write_recipe(root / "sample.md", _valid_recipe(slug="sample"))
+        findings = arl.check_recipes([root], tmp_path)
+        ids = [f.rule_id for f in findings]
+        assert "RC1" in ids
+        assert any(f.severity.name == "BLOCK" for f in findings if f.rule_id == "RC1")
+
+    def test_empty_archive_with_index_ok(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_index(root, [])
+        findings = arl.check_recipes([root], tmp_path)
+        # No recipes + empty INDEX = 0 findings (RC0 satisfied, no RC2/3/4 to trigger).
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# RC2 — required sections
+# ---------------------------------------------------------------------------
+
+
+class TestRC2RequiredSections:
+    @pytest.mark.parametrize(
+        "dropped",
+        [
+            "Version",
+            "Context",
+            "Decision",
+            "Observed outcome",
+            "Reuse guidance",
+            "Downstream citations",
+        ],
+    )
+    def test_missing_each_section_emits_rc2(self, tmp_path: Path, dropped: str) -> None:
+        root = _archive_root(tmp_path)
+        # Start from the dedented body so line prefixes match the lint.
+        body = textwrap.dedent(_valid_recipe(slug="drop")).lstrip("\n")
+        # Drop the section: everything from `## <dropped>` until the next H2.
+        kept: list[str] = []
+        skipping = False
+        for line in body.splitlines():
+            if line.startswith(f"## {dropped}"):
+                skipping = True
+                continue
+            if skipping and line.startswith("## "):
+                skipping = False
+            if not skipping:
+                kept.append(line)
+        redacted = "\n".join(kept)
+        # Write the redacted body directly (bypass _write_recipe's dedent,
+        # since we've already dedented above).
+        target = root / "incomplete.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(redacted, encoding="utf-8")
+        _write_index(root, ["incomplete.md"])
+
+        findings = arl.check_recipes([root], tmp_path)
+        rc2 = [f for f in findings if f.rule_id == "RC2"]
+        assert rc2, (
+            f"expected RC2 for missing '{dropped}'; "
+            f"got: {[f.rule_id for f in findings]}\nBody:\n{redacted}"
+        )
+        assert any(dropped in f.message for f in rc2)
+
+    def test_all_sections_present_no_rc2(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_recipe(root / "ok.md", _valid_recipe(slug="ok"))
+        _write_index(root, ["ok.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert not any(f.rule_id == "RC2" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# RC3 — version format
+# ---------------------------------------------------------------------------
+
+
+class TestRC3VersionFormat:
+    def test_valid_version_passes(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_recipe(root / "ok.md", _valid_recipe(slug="ok", version="v3.7"))
+        _write_index(root, ["ok.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert not any(f.rule_id == "RC3" for f in findings)
+
+    def test_wrong_prefix_fails(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        body = _valid_recipe(slug="x").replace("`b11-recipe-x-v1.0`", "`recipe-x-v1.0`")
+        _write_recipe(root / "wrong.md", body)
+        _write_index(root, ["wrong.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert any(f.rule_id == "RC3" for f in findings)
+
+    def test_missing_version_patch_component_fails(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        body = _valid_recipe(slug="x").replace(
+            "`b11-recipe-x-v1.0`", "`b11-recipe-x-v1`"
+        )
+        _write_recipe(root / "bad.md", body)
+        _write_index(root, ["bad.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert any(f.rule_id == "RC3" for f in findings)
+
+    def test_uppercase_slug_fails(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        body = _valid_recipe(slug="x").replace(
+            "`b11-recipe-x-v1.0`", "`b11-recipe-PATTERN11-v1.0`"
+        )
+        _write_recipe(root / "caps.md", body)
+        _write_index(root, ["caps.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert any(f.rule_id == "RC3" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# RC4 — INDEX.md references every recipe
+# ---------------------------------------------------------------------------
+
+
+class TestRC4IndexReferencesAllRecipes:
+    def test_unreferenced_recipe_emits_rc4(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_recipe(root / "indexed.md", _valid_recipe(slug="indexed"))
+        _write_recipe(root / "orphan.md", _valid_recipe(slug="orphan"))
+        _write_index(root, ["indexed.md"])  # orphan.md omitted
+        findings = arl.check_recipes([root], tmp_path)
+        rc4 = [f for f in findings if f.rule_id == "RC4"]
+        assert rc4, f"expected RC4 for orphan.md; got: {[f.rule_id for f in findings]}"
+        assert any("orphan.md" in f.message for f in rc4)
+        # RC4 is non-blocking (WARN).
+        assert all(f.severity.name == "WARN" for f in rc4)
+
+    def test_all_referenced_no_rc4(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_recipe(root / "a.md", _valid_recipe(slug="a"))
+        _write_recipe(root / "b.md", _valid_recipe(slug="b"))
+        _write_index(root, ["a.md", "b.md"])
+        findings = arl.check_recipes([root], tmp_path)
+        assert not any(f.rule_id == "RC4" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Exclusions: _template.md, INDEX.md, _archive/
+# ---------------------------------------------------------------------------
+
+
+class TestExclusions:
+    def test_template_skipped(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        # Template has minimal/invalid body; lint must skip it.
+        (root / "_template.md").write_text(
+            "# Template\nno required sections here\n", encoding="utf-8"
+        )
+        _write_index(root, [])
+        findings = arl.check_recipes([root], tmp_path)
+        # No RC2/RC3/RC4 findings sourced from _template.md.
+        for f in findings:
+            assert "_template.md" not in str(f.path)
+
+    def test_index_skipped(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        _write_index(root, [])
+        # INDEX.md itself must not trigger RC2 (missing sections).
+        findings = arl.check_recipes([root], tmp_path)
+        for f in findings:
+            assert f.path.name != "INDEX.md" or f.rule_id == "RC1"
+
+    def test_archive_subdir_skipped(self, tmp_path: Path) -> None:
+        root = _archive_root(tmp_path)
+        archive_dir = root / "_archive"
+        archive_dir.mkdir()
+        # A retired recipe with no sections — must be skipped entirely.
+        (archive_dir / "retired.md").write_text(
+            "# Retired\nno sections\n", encoding="utf-8"
+        )
+        _write_index(root, [])
+        findings = arl.check_recipes([root], tmp_path)
+        for f in findings:
+            assert "retired.md" not in str(f.path)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: invoke main() to exercise argparse + _default_roots wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCLIIntegration:
+    def test_cli_clean_archive_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        root = _archive_root(tmp_path)
+        _write_recipe(root / "ok.md", _valid_recipe(slug="ok"))
+        _write_index(root, ["ok.md"])
+        code = arl.main(["--repo-root", str(tmp_path), "check", "recipes", str(root)])
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "0 findings" in captured.out
+
+    def test_cli_missing_archive_returns_block_exit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        missing = tmp_path / "knowledge" / "orchestration_recipes"
+        code = arl.main(
+            ["--repo-root", str(tmp_path), "check", "recipes", str(missing)]
+        )
+        # Non-strict rule-set: missing path produces RC0, exits 2.
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "RC0" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Live-tree regression guard: the committed archive must lint cleanly.
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTreeClean:
+    def test_repo_archive_has_no_findings(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        archive = repo_root / "knowledge" / "orchestration_recipes"
+        if not archive.is_dir():
+            pytest.skip("archive not present (pre-B.11)")
+        findings = arl.check_recipes([archive], repo_root)
+        block = [f for f in findings if f.severity.name == "BLOCK"]
+        assert not block, f"live archive has BLOCK findings: {block}"

--- a/tests/unit/test_tool_risk_registry.py
+++ b/tests/unit/test_tool_risk_registry.py
@@ -1,0 +1,401 @@
+"""Unit tests for the B.6 tool risk registry lint.
+
+Covers ``agent_readability_lint.check_tool_risk`` rules TR0–TR4
+(shaping §5.1 / §5.2 — Primitive B-exec.α execution spec) and the
+allow-list cross-check helper ``_load_permissions_allow``.
+
+Fixtures are inline and hermetic — each test writes a minimal
+``tool_risk_registry.md`` (and a matching ``.claude/settings.json``
+when the allow-coverage rule is under test) under ``tmp_path`` and
+asserts which rule IDs fire.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "agent_readability_lint",
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "internal"
+    / "agent_readability_lint.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+arl = importlib.util.module_from_spec(_SPEC)
+sys.modules["agent_readability_lint"] = arl
+_SPEC.loader.exec_module(arl)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return path
+
+
+def _registry_path(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "rules" / "tool_risk_registry.md"
+
+
+def _settings_path(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "settings.json"
+
+
+def _write_valid_registry(tmp_path: Path, extra_rows: str = "") -> Path:
+    """Write a minimal valid registry at the canonical path."""
+    body = """
+    # Tool Risk Registry
+
+    > Dual-envelope classification.
+
+    ## Version
+
+    `tool-risk-v1.0`
+
+    ## Trigger
+
+    Initial version.
+
+    ## Expected effect
+
+    Lookup succeeds.
+
+    ## Rollback
+
+    Revert.
+
+    ## Approval classes
+
+    - direct / approve / edit / reject.
+
+    ## Registry
+
+    | Tool | Auto-mode envelope (Opus) | Bypass envelope (Sonnet/Haiku) | Notes |
+    |---|---|---|---|
+    | `Read` | direct | direct | Read-only |
+    | `Bash(git *)` | direct | direct | Version control |
+    {extra_rows}
+    """
+    return _write(
+        _registry_path(tmp_path),
+        body.format(extra_rows=extra_rows),
+    )
+
+
+def _write_settings(tmp_path: Path, allow: list[str]) -> Path:
+    entries = ",\n    ".join(f'"{e}"' for e in allow)
+    body = f"""{{
+  "permissions": {{
+    "allow": [
+    {entries}
+    ],
+    "deny": []
+  }}
+}}
+"""
+    return _write(_settings_path(tmp_path), body)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_registry_emits_no_findings(tmp_path: Path) -> None:
+    _write_valid_registry(tmp_path)
+    _write_settings(tmp_path, ["Bash(git *)"])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    assert findings == [], f"expected clean, got {[f.format_line() for f in findings]}"
+
+
+# ---------------------------------------------------------------------------
+# TR0 — registry file missing
+# ---------------------------------------------------------------------------
+
+
+def test_tr0_flags_missing_registry(tmp_path: Path) -> None:
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr0 = [f for f in findings if f.rule_id == "TR0"]
+    assert len(tr0) == 1
+    assert tr0[0].severity == arl.Severity.BLOCK
+    # No other rules run when the registry is missing — short-circuit.
+    assert {f.rule_id for f in findings} == {"TR0"}
+
+
+# ---------------------------------------------------------------------------
+# TR1 — registry has no rows
+# ---------------------------------------------------------------------------
+
+
+def test_tr1_flags_empty_registry(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Tool Risk Registry
+
+        ## Registry
+
+        Table coming soon.
+        """,
+    )
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr1 = [f for f in findings if f.rule_id == "TR1"]
+    assert len(tr1) == 1
+    assert tr1[0].severity == arl.Severity.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# TR2 — invalid envelope column
+# ---------------------------------------------------------------------------
+
+
+def test_tr2_flags_empty_envelope_cell(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Read` |  | direct | missing auto |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr2 = [f for f in findings if f.rule_id == "TR2"]
+    assert tr2, f"expected TR2; got {[f.format_line() for f in findings]}"
+    assert all(f.severity == arl.Severity.BLOCK for f in tr2)
+
+
+def test_tr2_flags_tbd_envelope_cell(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Read` | TBD | direct | placeholder auto |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr2 = [f for f in findings if f.rule_id == "TR2"]
+    assert tr2
+
+
+@pytest.mark.parametrize("bad_class", ["allowed", "blocked", "review", "maybe"])
+def test_tr2_flags_non_taxonomy_class(tmp_path: Path, bad_class: str) -> None:
+    _write(
+        _registry_path(tmp_path),
+        f"""
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Read` | {bad_class} | direct | non-taxonomy word |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr2 = [f for f in findings if f.rule_id == "TR2"]
+    assert tr2
+    assert any(bad_class in f.message for f in tr2)
+
+
+def test_tr2_accepts_class_with_parenthetical(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Bash(git push --force)` | approve (requires User Intent) | reject | destructive |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    assert not any(f.rule_id == "TR2" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# TR3 — reject-under-bypass with no Notes
+# ---------------------------------------------------------------------------
+
+
+def test_tr3_warns_on_reject_bypass_without_notes(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Bash(rm -rf *)` | approve | reject |  |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr3 = [f for f in findings if f.rule_id == "TR3"]
+    assert len(tr3) == 1
+    assert tr3[0].severity == arl.Severity.WARN
+
+
+def test_tr3_silent_when_notes_present(tmp_path: Path) -> None:
+    _write(
+        _registry_path(tmp_path),
+        """
+        # Registry
+
+        | Tool | Auto-mode envelope | Bypass envelope | Notes |
+        |---|---|---|---|
+        | `Bash(rm -rf *)` | approve | reject | Destructive — data loss |
+        """,
+    )
+    _write_settings(tmp_path, [])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    assert not any(f.rule_id == "TR3" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# TR4 — permissions.allow coverage
+# ---------------------------------------------------------------------------
+
+
+def test_tr4_flags_uncovered_allow_entry(tmp_path: Path) -> None:
+    _write_valid_registry(tmp_path)
+    # `Bash(ls *)` is not in the registry.
+    _write_settings(tmp_path, ["Bash(git *)", "Bash(ls *)"])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    tr4 = [f for f in findings if f.rule_id == "TR4"]
+    assert len(tr4) == 1
+    assert "Bash(ls *)" in tr4[0].message
+    assert tr4[0].severity == arl.Severity.BLOCK
+
+
+def test_tr4_silent_when_every_entry_covered(tmp_path: Path) -> None:
+    # Add a row for ls so the allow-list is fully covered.
+    _write_valid_registry(
+        tmp_path, extra_rows="| `Bash(ls *)` | direct | direct | Read-only |"
+    )
+    _write_settings(tmp_path, ["Bash(git *)", "Bash(ls *)"])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    assert not any(f.rule_id == "TR4" for f in findings)
+
+
+def test_tr4_lenient_substring_match(tmp_path: Path) -> None:
+    # A single row can cover both Edit(X) and Write(X) by listing both.
+    _write_valid_registry(
+        tmp_path,
+        extra_rows=(
+            "| `Edit(src/**)` `Write(src/**)` | direct | direct | Project source |"
+        ),
+    )
+    _write_settings(tmp_path, ["Edit(src/**)", "Write(src/**)"])
+    findings = arl.check_tool_risk([], repo_root=tmp_path)
+    assert not any(f.rule_id == "TR4" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# _load_permissions_allow helper
+# ---------------------------------------------------------------------------
+
+
+def test_load_permissions_allow_extracts_entries(tmp_path: Path) -> None:
+    entries = ["Bash(git *)", "Edit(src/**)", "Write(tests/**)"]
+    _write_settings(tmp_path, entries)
+    loaded = arl._load_permissions_allow(_settings_path(tmp_path))
+    assert loaded == entries
+
+
+def test_load_permissions_allow_missing_file_returns_empty(tmp_path: Path) -> None:
+    loaded = arl._load_permissions_allow(tmp_path / "nope.json")
+    assert loaded == []
+
+
+def test_load_permissions_allow_no_allow_block_returns_empty(tmp_path: Path) -> None:
+    _write(
+        _settings_path(tmp_path),
+        """
+        {
+          "hooks": []
+        }
+        """,
+    )
+    loaded = arl._load_permissions_allow(_settings_path(tmp_path))
+    assert loaded == []
+
+
+# ---------------------------------------------------------------------------
+# _approval_class_first_token helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cell,expected",
+    [
+        ("direct", "direct"),
+        ("approve (classifier gates)", "approve"),
+        ("reject", "reject"),
+        ("Approve", "approve"),
+        ("  direct  ", "direct"),
+        ("edit (reviewer required)", "edit"),
+        ("", ""),
+        ("42 invalid", ""),
+    ],
+)
+def test_approval_class_first_token(cell: str, expected: str) -> None:
+    assert arl._approval_class_first_token(cell) == expected
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_tool_risk_clean_exits_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_valid_registry(tmp_path)
+    _write_settings(tmp_path, ["Bash(git *)"])
+    rc = arl.main(["--repo-root", str(tmp_path), "check", "tool-risk"])
+    assert rc == 0
+    assert "0 findings" in capsys.readouterr().out
+
+
+def test_cli_tool_risk_block_exits_two(tmp_path: Path) -> None:
+    # Missing registry → TR0 BLOCK → exit 2.
+    rc = arl.main(["--repo-root", str(tmp_path), "check", "tool-risk"])
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# Self-run: the live registry is clean + covers every allow entry.
+# ---------------------------------------------------------------------------
+
+
+def test_live_tool_risk_registry_is_clean() -> None:
+    """Regression guard: B.6 lint exits clean against the live registry.
+
+    If this fails after editing ``.claude/settings.json`` or the
+    registry, add a registry row for the new allow entry (do not relax
+    the lint).
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / ".claude" / "rules" / "tool_risk_registry.md"
+    if not target.exists():
+        pytest.skip(f"tool_risk_registry.md not found at {target}")
+    findings = arl.check_tool_risk([], repo_root=repo_root)
+    blocks = [f for f in findings if f.severity == arl.Severity.BLOCK]
+    assert not blocks, "BLOCK findings:\n" + "\n".join(f.format_line() for f in blocks)


### PR DESCRIPTION
## Summary

Ships the first of three Primitive B-exec sub-packets per
`plans/steward_platform/2_primitive_B/shaping.md` §10.6. Four bounded
deliverables — all with named verification surfaces per Pattern 10.

- **B.3 prompt-policy registry**: extend 4 policy files (orchestrator,
  author, analyst, common) with `Version/Trigger/Expected effect/Rollback`
  sections; add `check prompt-policy` lint sub-command (PP0-PP4); author
  `tests/unit/test_prompt_policy_registry.py` (26 tests).
- **B.6 tool-risk registry**: author `.claude/rules/tool_risk_registry.md`
  with dual-envelope classification (auto/bypass) covering all 51
  `permissions.allow` entries. Enrich `permission-denied-log.sh` hook to
  emit `approval_class_auto` / `approval_class_bypass` / `registry_row_id`
  fields in JSONL. Add `check tool-risk` lint (TR0-TR4) + 29 tests.
- **B.10 effort policy**: author `.claude/rules/effort_policy.md` with
  7-archetype × 5-task-type policy table; add `"max"` to
  `VALID_EFFORT_HINTS`; ship `src/bid_euchre/ops/effort_policy.py` with
  pure `effort_for()` resolver + 18 tests (markdown drift guard).
- **B.11 orchestration recipe archive**: create
  `knowledge/orchestration_recipes/` with `INDEX.md`, `_template.md`, and
  seeded `shape_then_execute_pattern11.md`. Add `check recipes` lint
  (RC0-RC4) + 22 tests.

Verification-contract map (Pattern 10): B.3/B.6/B.11 row surfaces
replaced with specific identifiers; B.10 row added. Row count 56 → 57;
100% coverage at 0 placeholders.

## Plan

`plans/steward_platform/2_primitive_B/shaping.md` (Primitive B Phase 0
execution spec; α/β/γ packet split defined in §10.6).

## Why

Primitive B Phase 0 (governing plan §5-B) requires seven shaping
deliverables before steward-platform Phase 1 can begin. B.3/B.6/B.10/B.11
are the first four with complete shaping text and named verification
surfaces. Decomposed into α/β/γ packets per shaping §10.6 to stay under
the per-packet context ceiling — β will land B.1 (learning.py scope
extension) and B.9b (tmux); γ will land B.12 (measure_improvements).

## Test plan

- `uv run python -m pytest tests/unit/test_prompt_policy_registry.py`
  → 26 passed
- `uv run python -m pytest tests/unit/test_tool_risk_registry.py`
  → 29 passed
- `uv run python -m pytest tests/unit/test_effort_policy.py`
  → 18 passed
- `uv run python -m pytest tests/unit/test_recipes_archive.py`
  → 22 passed
- `uv run python -m pytest tests/unit/test_ops_task_queue.py`
  → 93 passed (max in VALID_EFFORT_HINTS)
- `uv run python -m pytest tests/unit/test_agent_readability_lint.py`
  → 18 passed
- `uv run python -m pytest tests/unit/test_portability_audit.py`
  → 6 passed
- `uv run python scripts/internal/agent_readability_lint.py check
  prompt-policy` / `check tool-risk` / `check recipes` / `check
  verification-contract` → 0 findings for each
- `uv run python scripts/internal/verify_map_coverage.py`
  → 100.00% coverage
- `make check-gated` → All checks passed

## Scope

Scope-locked to B.3 + B.6 + B.10 + B.11 (shaping §10.6 Packet B-exec.α).
Out-of-scope (deferred to β/γ packets):

- B.1 `src/bid_euchre/ops/learning.py` extension → β
- B.9b tmux script extension → β
- B.12 `scripts/internal/measure_improvements.py` → γ

## Portability audit note

`NON_COSMETIC_THRESHOLD` bumped 259 → 263 for 4 archetype-taxonomy
string literals in `effort_policy.py` (`"ops"`, `"review"` as
`POLICY_TABLE` keys — not lane identifiers). Same false-positive
pattern as the existing #2169 Slice D waiver; comment extended in
`tests/unit/test_portability_audit.py`.

## References

- `plans/steward_platform/2_primitive_B/shaping.md` §4.2 (B.3), §5
  (B.6), §7 (B.10), §8 (B.11), §10.6 (α/β/γ split)
- `plans/steward_platform/verification_contract/shaping.md` §2
  (surface class → deliverable class table)
- `.claude/rules/prompt_policy/author.md` §"Shape-is-authoritative"
  (Pattern 11) — scope lock enforced via author lane prompt policy

Refs #5-B

## Worktree proof

```
pwd:    /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-a
branch: feat/primitive-b-alpha
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
