### PR TITLE
fix(ops): ack-all excludes blocker+escalation by default (Fixes #2792)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -2171,13 +2171,39 @@ def cmd_inbox(args: argparse.Namespace) -> int:
         if not lane:
             print(
                 "Usage: ops.py inbox ack-all --lane LANE"
-                " [--filter-summary PATTERN] [--max-age HOURS]",
+                " [--filter-summary PATTERN] [--max-age HOURS]"
+                " [--include-types T1,T2] [--exclude-types T1,T2]",
                 file=sys.stderr,
             )
             return 1
 
         # Build composable filter predicates
         predicates: list = []
+
+        # Type filter: default excludes 'blocker' + 'escalation' to prevent
+        # silent-drain of actionable signals (#2792). --include-types opts in;
+        # --exclude-types overrides the default exclusion list.
+        default_excluded_types = frozenset({"blocker", "escalation"})
+        include_types_raw = getattr(args, "include_types", None)
+        exclude_types_raw = getattr(args, "exclude_types", None)
+        include_types = (
+            frozenset(t.strip() for t in include_types_raw.split(",") if t.strip())
+            if include_types_raw
+            else frozenset()
+        )
+        if exclude_types_raw is not None:
+            exclude_types = frozenset(
+                t.strip() for t in exclude_types_raw.split(",") if t.strip()
+            )
+        else:
+            exclude_types = default_excluded_types - include_types
+
+        if exclude_types:
+
+            def _type_allowed(msg: dict) -> bool:
+                return msg.get("message_type", "") not in exclude_types
+
+            predicates.append(_type_allowed)
 
         summary_pattern = getattr(args, "filter_summary", None)
         if summary_pattern:
@@ -3239,7 +3265,7 @@ def _cmd_lane_status(args: argparse.Namespace) -> int:
 
     # Text render: fixed-width columns.  Widened lane_id to 15 chars to
     # fit `brws-author-*` and similar.
-    header = f"{'LANE':<15} {'PHASE':<14} {'FRESH':<12} " f"{'LAST_TOOL':<10} SUMMARY"
+    header = f"{'LANE':<15} {'PHASE':<14} {'FRESH':<12} {'LAST_TOOL':<10} SUMMARY"
     print(header)
     print("-" * len(header))
     for row in rows:
@@ -3732,9 +3758,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
             print(f"  Attribution gap:     {parity.attribution_gap}")
             print(f"  Token parity delta:  {parity.token_parity_delta:+,d}")
             print(f"  Commit parity delta: {parity.commit_parity_delta:+d}")
-            print(
-                f"  Model parity delta:  " f"{parity.by_model_token_parity_delta:+,d}"
-            )
+            print(f"  Model parity delta:  {parity.by_model_token_parity_delta:+,d}")
             print()
             print(_format_parity_footer(parity))
         return 0
@@ -4891,6 +4915,24 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=None,
         help="Only ack messages older than N hours (based on created_at)",
+    )
+    inbox_ack_all_parser.add_argument(
+        "--include-types",
+        default=None,
+        help=(
+            "Comma-separated message types to include (opt-in). "
+            "By default, ack-all EXCLUDES 'blocker' and 'escalation' types "
+            "to prevent silent-drain of actionable signals (#2792). Pass "
+            "e.g. --include-types blocker,escalation to override."
+        ),
+    )
+    inbox_ack_all_parser.add_argument(
+        "--exclude-types",
+        default=None,
+        help=(
+            "Comma-separated message types to exclude (overrides the default "
+            "blocker+escalation exclusion list when set)."
+        ),
     )
 
     inbox_purge_parser = inbox_sub.add_parser(

--- a/tests/unit/test_ops_inbox.py
+++ b/tests/unit/test_ops_inbox.py
@@ -1,0 +1,321 @@
+"""Tests for ops.py inbox ack-all blocker/escalation exclusion (#2792)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+
+
+@pytest.fixture(autouse=True)
+def _add_scripts_path() -> None:
+    path_str = str(SCRIPTS_DIR)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path: Path) -> Path:
+    rd = tmp_path / "runtime"
+    (rd / "worktree_registry").mkdir(parents=True)
+    (rd / "session_metadata").mkdir(parents=True)
+    (rd / "task_state").mkdir(parents=True)
+    (rd / "events").mkdir(parents=True)
+    (rd / "scheduler").mkdir(parents=True)
+    return rd
+
+
+@pytest.fixture()
+def plans_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "plans"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def bus_dir(runtime_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = runtime_dir / "message_bus"
+    (d / "inbox").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("BID_EUCHRE_BUS_DIR", str(d))
+    return d
+
+
+def _send(
+    runtime_dir: Path,
+    plans_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    to: str,
+    summary: str,
+    msg_type: str = "ack",
+    priority: str = "normal",
+) -> str:
+    """Send a message via CLI and return its id."""
+    import ops
+
+    rc = ops.main(
+        [
+            "--json",
+            "--runtime-dir",
+            str(runtime_dir),
+            "--plans-dir",
+            str(plans_dir),
+            "message",
+            "send",
+            "--from",
+            "orchestrator",
+            "--to",
+            to,
+            "--type",
+            msg_type,
+            "--priority",
+            priority,
+            "--summary",
+            summary,
+        ]
+    )
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    return data["message_id"]
+
+
+class TestAckAllExcludesBlockers:
+    """#2792: ack-all must not silently drain blocker/escalation types."""
+
+    def test_ack_all_excludes_blockers_by_default(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        blocker_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "Primitive E scope request",
+            msg_type="blocker",
+            priority="high",
+        )
+        ack_id = _send(runtime_dir, plans_dir, capsys, "author-a", "Routine ack")
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack-all",
+                "--lane",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+
+        acked_ids = [m["message_id"] for m in data["acked"]]
+        assert (
+            blocker_id not in acked_ids
+        ), f"Blocker {blocker_id} was silently acked — #2792 regression"
+        assert ack_id in acked_ids
+
+    def test_ack_all_excludes_escalations_by_default(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        esc_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "Lane stuck on permission prompt",
+            msg_type="escalation",
+            priority="urgent",
+        )
+        ack_id = _send(runtime_dir, plans_dir, capsys, "author-a", "Ack1")
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack-all",
+                "--lane",
+                "author-a",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        acked_ids = [m["message_id"] for m in data["acked"]]
+        assert esc_id not in acked_ids
+        assert ack_id in acked_ids
+
+    def test_ack_all_include_types_blocker_opts_in(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        blocker_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "Blocker summary",
+            msg_type="blocker",
+            priority="high",
+        )
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack-all",
+                "--lane",
+                "author-a",
+                "--include-types",
+                "blocker",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        acked_ids = [m["message_id"] for m in data["acked"]]
+        assert (
+            blocker_id in acked_ids
+        ), "--include-types blocker did not opt-in to acking the blocker"
+
+    def test_ack_all_include_types_both_opts_in(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import ops
+
+        blocker_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "BlockerSum",
+            msg_type="blocker",
+            priority="high",
+        )
+        esc_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "EscSum",
+            msg_type="escalation",
+            priority="urgent",
+        )
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack-all",
+                "--lane",
+                "author-a",
+                "--include-types",
+                "blocker,escalation",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        acked_ids = [m["message_id"] for m in data["acked"]]
+        assert blocker_id in acked_ids
+        assert esc_id in acked_ids
+
+    def test_ack_all_exclude_types_overrides_default(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        bus_dir: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--exclude-types explicitly overrides the default exclusion list."""
+        import ops
+
+        blocker_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "Blocker-overridden",
+            msg_type="blocker",
+            priority="high",
+        )
+        prog_id = _send(
+            runtime_dir,
+            plans_dir,
+            capsys,
+            "author-a",
+            "Progress msg",
+            msg_type="progress",
+        )
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "inbox",
+                "ack-all",
+                "--lane",
+                "author-a",
+                "--exclude-types",
+                "progress",
+            ]
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        acked_ids = [m["message_id"] for m in data["acked"]]
+        assert prog_id not in acked_ids
+        assert (
+            blocker_id in acked_ids
+        ), "--exclude-types progress should have overridden the default blocker filter"
+
+    def test_ack_all_help_mentions_exclusion(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Help text for ack-all must document the default exclusion behavior."""
+        import ops
+
+        with pytest.raises(SystemExit):
+            ops.main(["inbox", "ack-all", "--help"])
+        out = capsys.readouterr().out
+        assert "blocker" in out.lower()
+        assert "escalation" in out.lower()


### PR DESCRIPTION
## Summary

- Default `ops.py inbox ack-all` now **excludes** `blocker` and `escalation` message types to prevent silent-drain of actionable signals (#2792).
- New `--include-types TYPE[,TYPE]` opts specific types back in.
- New `--exclude-types TYPE[,TYPE]` overrides the default exclusion list.
- Help text documents the default exclusion behavior.
- New `tests/unit/test_ops_inbox.py` with 6 tests covering default exclude, include-types opt-in, exclude-types override, and help-text assertion.

## Why

Session 2026-04-24: author-d filed BLOCKER E1 at 06:02 UTC. Orchestrator's routine `ack-all` at 06:08 UTC would have drained it silently — preserved only by chance. The fix makes `blocker` + `escalation` an explicit opt-in, so routine cleanup can no longer silently lose actionable signals.

## Repro / Validation

```
uv run python -m pytest tests/unit/test_ops_inbox.py -v           # 6 pass
uv run python -m pytest tests/unit/test_ops_cli.py::TestInboxBulkAck -v  # 5 pass (no regression)
make check-gated                                                   # green
uv run python scripts/internal/ops.py inbox ack-all --help         # shows --include-types / --exclude-types
```

## Verification Performed

- **Surface: unit tests** — `tests/unit/test_ops_inbox.py::TestAckAllExcludesBlockers` (6/6 pass):
  - `test_ack_all_excludes_blockers_by_default` — blocker stays unacked
  - `test_ack_all_excludes_escalations_by_default` — escalation stays unacked
  - `test_ack_all_include_types_blocker_opts_in` — `--include-types blocker` acks it
  - `test_ack_all_include_types_both_opts_in` — `--include-types blocker,escalation` acks both
  - `test_ack_all_exclude_types_overrides_default` — `--exclude-types progress` overrides default
  - `test_ack_all_help_mentions_exclusion` — help output contains `blocker` + `escalation`
- **Surface: regression** — existing `TestInboxBulkAck` (5/5 pass)
- **Surface: Tier 2** — `make check-gated` → "All checks passed"

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-d`
- Branch: `fix/ack-all-exclude-blocker-2792` (1 commit ahead of origin/main)

## Test plan

- [x] Default ack-all does NOT ack blocker or escalation
- [x] `--include-types blocker,escalation` opts them back in
- [x] `--exclude-types progress` overrides the default exclusion list
- [x] Help text mentions the default exclusion
- [x] Existing bulk-ack tests still pass
- [x] `make check-gated` green

Fixes #2792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)