### PR TITLE
feat(steward-platform): wire --system-prompt-file into fleet lane launches (B.9b)

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -182,6 +182,54 @@ except Exception:
     esac
 }
 
+# Emit the `--system-prompt-file .claude/system_prompts/<archetype>.md` flag
+# for a lane, based on the hardcoded 19-lane → 8-archetype mapping from
+# plans/steward_platform/0_hardening/sub/g13_archetype_mapping.md §2.1
+# (Primitive B-exec.γ / B.9b — shaping.md §6).
+#
+# Fallback: if the resolved archetype prompt file does NOT yet exist under
+# .claude/system_prompts/ (pre-B.9a fan-out: only analyst.md is authored
+# today), emit nothing. The Claude Code default system prompt applies for
+# that lane. This prevents a "--system-prompt-file <missing-file>" launch
+# failure while B.9a fan-out is in flight. Once all 8 archetype files land,
+# every launch line gets the flag automatically with no further edits.
+#
+# Output is intended to be spliced unquoted into a tmux command line so
+# word splitting either emits two tokens
+# (`--system-prompt-file .claude/system_prompts/<archetype>.md`) or nothing.
+#
+# This function must stay behaviorally consistent with
+# scripts/internal/review_lane_runner.py's inline resolution in
+# invoke_review() (matching 19-lane hardcoded mapping).
+# Args: lane_id
+system_prompt_flag_for_lane() {
+    local lane="$1"
+    local archetype=""
+    case "$lane" in
+        orchestrator)                              archetype="orchestrator" ;;
+        ops)                                       archetype="ops" ;;
+        review)                                    archetype="review" ;;
+        analyst-a|analyst-b|analyst-c|analyst-d)   archetype="analyst" ;;
+        author-a|author-b|author-c|author-d)       archetype="author" ;;
+        brws-author-a|brws-author-b|brws-author-c|brws-author-d)
+                                                   archetype="brws-author" ;;
+        flex-a|flex-b|flex-c|flex-d)               archetype="flex" ;;
+        *)
+            # Unknown lane → no flag (fall back to Claude Code default).
+            return 0
+            ;;
+    esac
+    local prompts_file="${MAIN_DIR}/.claude/system_prompts/${archetype}.md"
+    if [ -f "$prompts_file" ]; then
+        # Emit repo-relative path; the claude CLI resolves relative to CWD,
+        # which is the worktree at launch time. Tests and operators reading
+        # the launch command see the same path shape.
+        printf '%s\n' "--system-prompt-file .claude/system_prompts/${archetype}.md"
+    fi
+    # else: prompt file not yet authored (B.9a fan-out pending) — emit
+    # nothing so the launch falls back to the Claude Code default prompt.
+}
+
 validate_worktree_path() {
     local path="$1"
     local resolved
@@ -477,7 +525,7 @@ fi
 
 # --- Window 1: central-ops (3 panes, main-vertical) ---
 tmux new-session -d -s "$SESSION" -n central-ops -c "$MAIN_DIR" \
-    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $(permission_mode_flag_for_lane orchestrator) $ORCH_CHANNEL_FLAGS
+    "$CLAUDE_BIN" --name orchestrator --agent steward-orchestrator $(permission_mode_flag_for_lane orchestrator) $(system_prompt_flag_for_lane orchestrator) $ORCH_CHANNEL_FLAGS
 
 # ---------------------------------------------------------------------------
 # Auto-compact window for non-orchestrator lanes (token economy optimization).
@@ -535,53 +583,53 @@ if [ "$STEWARD_TELEGRAM_ENABLED" = "1" ]; then
 fi
 
 tmux split-window -t "${SESSION}:central-ops" -c "$OPS" \
-    "$CLAUDE_BIN" --name ops --agent steward-ops $(permission_mode_flag_for_lane ops)
+    "$CLAUDE_BIN" --name ops --agent steward-ops $(permission_mode_flag_for_lane ops) $(system_prompt_flag_for_lane ops)
 tmux split-window -t "${SESSION}:central-ops" -c "$REVIEW" \
-    "$CLAUDE_BIN" --name review --agent steward-review $(permission_mode_flag_for_lane review)
+    "$CLAUDE_BIN" --name review --agent steward-review $(permission_mode_flag_for_lane review) $(system_prompt_flag_for_lane review)
 tmux select-layout -t "${SESSION}:central-ops" main-vertical
 
 # --- Window 2: analyst (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n analyst -c "$ANALYST_A" \
-    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst $(permission_mode_flag_for_lane analyst-a)
+    "$CLAUDE_BIN" --name analyst-a --agent steward-analyst $(permission_mode_flag_for_lane analyst-a) $(system_prompt_flag_for_lane analyst-a)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_B" \
-    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst $(permission_mode_flag_for_lane analyst-b)
+    "$CLAUDE_BIN" --name analyst-b --agent steward-analyst $(permission_mode_flag_for_lane analyst-b) $(system_prompt_flag_for_lane analyst-b)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_C" \
-    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst $(permission_mode_flag_for_lane analyst-c)
+    "$CLAUDE_BIN" --name analyst-c --agent steward-analyst $(permission_mode_flag_for_lane analyst-c) $(system_prompt_flag_for_lane analyst-c)
 tmux split-window -t "${SESSION}:analyst" -c "$ANALYST_D" \
-    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst $(permission_mode_flag_for_lane analyst-d)
+    "$CLAUDE_BIN" --name analyst-d --agent steward-analyst $(permission_mode_flag_for_lane analyst-d) $(system_prompt_flag_for_lane analyst-d)
 tmux select-layout -t "${SESSION}:analyst" tiled
 
 # --- Window 3: platform ---
 tmux new-window -t "$SESSION" -n platform -c "$AUTHOR_A" \
-    "$CLAUDE_BIN" --name author-a --agent steward-author-a $(permission_mode_flag_for_lane author-a)
+    "$CLAUDE_BIN" --name author-a --agent steward-author-a $(permission_mode_flag_for_lane author-a) $(system_prompt_flag_for_lane author-a)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_B" \
-    "$CLAUDE_BIN" --name author-b --agent steward-author-b $(permission_mode_flag_for_lane author-b)
+    "$CLAUDE_BIN" --name author-b --agent steward-author-b $(permission_mode_flag_for_lane author-b) $(system_prompt_flag_for_lane author-b)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_C" \
-    "$CLAUDE_BIN" --name author-c --agent steward-author-c $(permission_mode_flag_for_lane author-c)
+    "$CLAUDE_BIN" --name author-c --agent steward-author-c $(permission_mode_flag_for_lane author-c) $(system_prompt_flag_for_lane author-c)
 tmux split-window -t "${SESSION}:platform" -c "$AUTHOR_D" \
-    "$CLAUDE_BIN" --name author-d --agent steward-author-d $(permission_mode_flag_for_lane author-d)
+    "$CLAUDE_BIN" --name author-d --agent steward-author-d $(permission_mode_flag_for_lane author-d) $(system_prompt_flag_for_lane author-d)
 tmux select-layout -t "${SESSION}:platform" tiled
 
 # --- Window 4: browser ---
 tmux new-window -t "$SESSION" -n browser -c "$BRWS_A" \
-    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a $(permission_mode_flag_for_lane brws-author-a)
+    "$CLAUDE_BIN" --name brws-author-a --agent steward-brws-author-a $(permission_mode_flag_for_lane brws-author-a) $(system_prompt_flag_for_lane brws-author-a)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_B" \
-    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b $(permission_mode_flag_for_lane brws-author-b)
+    "$CLAUDE_BIN" --name brws-author-b --agent steward-brws-author-b $(permission_mode_flag_for_lane brws-author-b) $(system_prompt_flag_for_lane brws-author-b)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_C" \
-    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c $(permission_mode_flag_for_lane brws-author-c)
+    "$CLAUDE_BIN" --name brws-author-c --agent steward-brws-author-c $(permission_mode_flag_for_lane brws-author-c) $(system_prompt_flag_for_lane brws-author-c)
 tmux split-window -t "${SESSION}:browser" -c "$BRWS_D" \
-    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d $(permission_mode_flag_for_lane brws-author-d)
+    "$CLAUDE_BIN" --name brws-author-d --agent steward-brws-author-d $(permission_mode_flag_for_lane brws-author-d) $(system_prompt_flag_for_lane brws-author-d)
 tmux select-layout -t "${SESSION}:browser" tiled
 
 # --- Window 5: flex (4 panes, tiled) ---
 tmux new-window -t "$SESSION" -n flex -c "$FLEX_A" \
-    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a $(permission_mode_flag_for_lane flex-a)
+    "$CLAUDE_BIN" --name flex-a --agent steward-flex-a $(permission_mode_flag_for_lane flex-a) $(system_prompt_flag_for_lane flex-a)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_B" \
-    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b $(permission_mode_flag_for_lane flex-b)
+    "$CLAUDE_BIN" --name flex-b --agent steward-flex-b $(permission_mode_flag_for_lane flex-b) $(system_prompt_flag_for_lane flex-b)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_C" \
-    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c $(permission_mode_flag_for_lane flex-c)
+    "$CLAUDE_BIN" --name flex-c --agent steward-flex-c $(permission_mode_flag_for_lane flex-c) $(system_prompt_flag_for_lane flex-c)
 tmux split-window -t "${SESSION}:flex" -c "$FLEX_D" \
-    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d $(permission_mode_flag_for_lane flex-d)
+    "$CLAUDE_BIN" --name flex-d --agent steward-flex-d $(permission_mode_flag_for_lane flex-d) $(system_prompt_flag_for_lane flex-d)
 tmux select-layout -t "${SESSION}:flex" tiled
 
 # Auto-launch ops monitoring loop (SP-3-08).

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -62,6 +62,36 @@ GH_TIMEOUT_SECONDS = 30
 POLL_INTERVAL_SECONDS = 30
 MAX_POLL_CYCLES = 30  # 30 * 30s = 15 min max runtime
 
+# Hardcoded 19-lane → 8-archetype mapping per G13 §2.1
+# (plans/steward_platform/0_hardening/sub/g13_archetype_mapping.md). This
+# is a temporary in-module hardcode per Primitive B-exec.γ / B.9b scope
+# lock; a future Primitive-G extraction will fold it into
+# .claude/lane_models.json as an `archetype` field consumed by both this
+# runner and the shell loader. Until then, the shell helper
+# `system_prompt_flag_for_lane` in .claude/tmux/steward-session.sh and
+# this dict must stay behaviorally consistent.
+_LANE_ARCHETYPE_MAP: dict[str, str] = {
+    "orchestrator": "orchestrator",
+    "ops": "ops",
+    "review": "review",
+    "analyst-a": "analyst",
+    "analyst-b": "analyst",
+    "analyst-c": "analyst",
+    "analyst-d": "analyst",
+    "author-a": "author",
+    "author-b": "author",
+    "author-c": "author",
+    "author-d": "author",
+    "brws-author-a": "brws-author",
+    "brws-author-b": "brws-author",
+    "brws-author-c": "brws-author",
+    "brws-author-d": "brws-author",
+    "flex-a": "flex",
+    "flex-b": "flex",
+    "flex-c": "flex",
+    "flex-d": "flex",
+}
+
 # Stale lock files to clean up before processing.
 # These are left behind by crashed scheduled tasks and block clean operation.
 _STALE_LOCK_PATTERNS = [
@@ -455,6 +485,52 @@ def find_pending_requests(queue_dir: Path | None = None) -> list[ReviewRequest]:
 # ---------------------------------------------------------------------------
 
 
+def system_prompt_args_for_lane(lane_id: str) -> list[str]:
+    """Return ``['--system-prompt-file', '<path>']`` for a lane, or ``[]``.
+
+    Resolves the lane to its archetype via :data:`_LANE_ARCHETYPE_MAP`
+    (Primitive B-exec.γ / B.9b — shaping.md §6) and returns the
+    ``--system-prompt-file`` argv fragment pointing at the archetype's
+    prompt file under ``.claude/system_prompts/``.
+
+    Fallback: if the resolved archetype prompt file does not yet exist
+    on disk (pre-B.9a fan-out; only ``analyst.md`` is authored today),
+    returns ``[]`` so the caller splices nothing into argv and the
+    ``claude`` subprocess falls back to the Claude Code default system
+    prompt. This prevents a ``--system-prompt-file <missing-file>``
+    launch failure while B.9a fan-out is in flight. Once all 8
+    archetype files land, every caller gets the flag automatically
+    with no further edits.
+
+    Consistency invariant: this helper's resolution must match
+    ``system_prompt_flag_for_lane`` in ``.claude/tmux/steward-session.sh``
+    for the same ``lane_id``. The shell helper and this function both
+    read the same hardcoded 19-lane map (G13 §2.1) and the same
+    filesystem presence of ``<archetype>.md``.
+
+    Args:
+        lane_id: The lane identifier (e.g., ``"review"``).
+
+    Returns:
+        A list of CLI tokens: either
+        ``["--system-prompt-file", ".claude/system_prompts/<archetype>.md"]``
+        (two elements) or ``[]`` (empty — fallback to default prompt).
+    """
+    archetype = _LANE_ARCHETYPE_MAP.get(lane_id)
+    if archetype is None:
+        return []
+    prompt_rel = Path(".claude") / "system_prompts" / f"{archetype}.md"
+    prompt_abs = _REPO_ROOT / prompt_rel
+    if not prompt_abs.is_file():
+        # File not yet authored (B.9a fan-out pending). Fall back to the
+        # Claude Code default system prompt by emitting nothing. Callers
+        # use ``list.extend([])`` which is a no-op.
+        return []
+    # Emit the repo-relative path; ``claude`` resolves relative to the
+    # subprocess cwd, which ``invoke_review`` sets to ``_REPO_ROOT``.
+    return ["--system-prompt-file", str(prompt_rel)]
+
+
 def invoke_review(pr_number: int, branch: str, head_sha: str) -> dict[str, Any]:
     """Invoke the steward-review agent for a PR.
 
@@ -481,11 +557,18 @@ def invoke_review(pr_number: int, branch: str, head_sha: str) -> dict[str, Any]:
     # Sonnet / Haiku → ["--dangerously-skip-permissions"] (explicit reduced
     # safety envelope; --permission-mode auto silently falls back for
     # non-Opus models and hides enforcement legibility).
+    #
+    # Archetype-aware system-prompt override (Primitive B-exec.γ / B.9b).
+    # Opus review lane → ["--system-prompt-file", ".claude/system_prompts/review.md"]
+    # when the archetype prompt file exists on disk. Fallback: if the
+    # file is not yet authored (pre-B.9a fan-out), the helper returns []
+    # and the subprocess falls back to the Claude Code default prompt.
     argv = [
         "claude",
         "--agent",
         "steward-review",
         *permission_mode_args_for_lane(LANE_ID),
+        *system_prompt_args_for_lane(LANE_ID),
         "--print",
         "--output-format",
         "json",

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -1175,3 +1175,319 @@ class TestInvokeReviewPermissionModeByModelTier:
             "Real loader + sonnet config must NOT cross-wire '--permission-mode' "
             f"(silent-fallback footgun): {argv}"
         )
+
+
+class TestInvokeReviewSystemPromptFile:
+    """Tests for archetype-aware ``--system-prompt-file`` wiring on ``invoke_review``.
+
+    Primitive B-exec.γ / B.9b (shaping.md §6) adds per-archetype system-prompt
+    file overrides to every lane launch. ``invoke_review`` runs the review
+    lane as a subprocess; its argv must include
+    ``--system-prompt-file .claude/system_prompts/review.md`` when the
+    archetype prompt file exists on disk, and must omit the flag entirely
+    when the file is missing (fallback to the Claude Code default prompt
+    so the subprocess does not fail on a missing-file argument).
+
+    The review lane is pinned to archetype ``review`` in the hardcoded
+    ``_LANE_ARCHETYPE_MAP`` table in ``review_lane_runner.py``. These tests
+    mock ``subprocess.run`` to inspect the argv, and monkeypatch
+    ``_REPO_ROOT`` onto a tmp-path so we can control whether the archetype
+    prompt file is staged or missing without perturbing the real
+    ``.claude/system_prompts/`` tree.
+
+    Existing flag preservation — ``--agent steward-review``, ``--print``,
+    ``-p``, ``--output-format json``, ``--permission-mode auto`` /
+    ``--dangerously-skip-permissions`` — must not regress when the new
+    ``--system-prompt-file`` fragment is spliced in.
+    """
+
+    @staticmethod
+    def _mock_subprocess_ok(mock_run: MagicMock) -> None:
+        """Make subprocess.run return a successful JSON payload."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"status": "passed", "reason": "clean", "findings": []}),
+            stderr="",
+        )
+
+    @staticmethod
+    def _stage_prompt_files(
+        tmp_root: Path, archetypes: list[str] | None = None
+    ) -> None:
+        """Stage ``.claude/system_prompts/<archetype>.md`` stubs under ``tmp_root``.
+
+        Defaults to staging only ``review.md`` (matching the review lane's
+        archetype). Pass an empty list to simulate the pre-B.9a state with
+        no archetype prompts authored yet.
+        """
+        if archetypes is None:
+            archetypes = ["review"]
+        prompts_dir = tmp_root / ".claude" / "system_prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        for archetype in archetypes:
+            (prompts_dir / f"{archetype}.md").write_text(
+                f"# Stub system prompt for archetype: {archetype}\n"
+            )
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_argv_contains_system_prompt_file_when_archetype_file_exists(
+        self,
+        mock_run: MagicMock,
+        mock_perm: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """review archetype + review.md staged → argv has ``--system-prompt-file``."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
+        # Stage the review archetype prompt file under tmp_root.
+        self._stage_prompt_files(tmp_path, archetypes=["review"])
+
+        # Redirect _REPO_ROOT to tmp_path so the helper's file-presence
+        # check consults our staged tree, not the real repo.
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        assert mock_run.called, "invoke_review must call subprocess.run"
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert isinstance(argv, list), "subprocess.run must be called with an argv list"
+
+        assert "--system-prompt-file" in argv, (
+            "When the review archetype prompt file exists, argv must include "
+            f"'--system-prompt-file' (got {argv})"
+        )
+        idx = argv.index("--system-prompt-file")
+        assert idx + 1 < len(
+            argv
+        ), "--system-prompt-file must be followed by a path value"
+        # The helper emits a repo-relative path string.
+        expected_path = str(Path(".claude") / "system_prompts" / "review.md")
+        assert argv[idx + 1] == expected_path, (
+            f"--system-prompt-file must point at '{expected_path}', "
+            f"got {argv[idx + 1]!r}"
+        )
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_argv_omits_system_prompt_file_when_archetype_file_missing(
+        self,
+        mock_run: MagicMock,
+        mock_perm: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """review archetype + review.md missing → argv omits ``--system-prompt-file``.
+
+        Guards the fallback invariant: if the archetype prompt file is not
+        yet authored (pre-B.9a fan-out), the helper must emit ``[]`` so the
+        subprocess falls back to the Claude Code default system prompt
+        rather than failing with a ``--system-prompt-file <missing>``
+        launch error.
+        """
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
+        # Stage NO archetype prompt files.
+        self._stage_prompt_files(tmp_path, archetypes=[])
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert "--system-prompt-file" not in argv, (
+            "When the archetype prompt file is missing, argv must NOT include "
+            f"'--system-prompt-file' (fallback to default prompt): {argv}"
+        )
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_existing_flags_preserved_with_system_prompt_file(
+        self,
+        mock_run: MagicMock,
+        mock_perm: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Splicing ``--system-prompt-file`` must not drop other flags."""
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
+        self._stage_prompt_files(tmp_path, archetypes=["review"])
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        call_args, _ = mock_run.call_args
+        argv = call_args[0]
+        assert argv[0] == "claude", f"First arg must be 'claude', got {argv[0]!r}"
+        assert (
+            "--agent" in argv and "steward-review" in argv
+        ), f"--agent steward-review must be preserved: {argv}"
+        assert "--print" in argv, f"--print must be preserved: {argv}"
+        assert "-p" in argv, f"-p prompt flag must be preserved: {argv}"
+        assert (
+            "--output-format" in argv and "json" in argv
+        ), f"--output-format json must be preserved: {argv}"
+        assert "--permission-mode" in argv and "auto" in argv, (
+            "--permission-mode auto must be preserved alongside "
+            f"--system-prompt-file: {argv}"
+        )
+        assert (
+            "--system-prompt-file" in argv
+        ), f"--system-prompt-file must be present when file exists: {argv}"
+
+    @patch("review_lane_runner.permission_mode_args_for_lane")
+    @patch("review_lane_runner.subprocess.run")
+    def test_system_prompt_helper_called_with_review_lane_id(
+        self,
+        mock_run: MagicMock,
+        mock_perm: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The helper must receive ``LANE_ID`` (i.e., the review lane id).
+
+        Wraps the real helper in a spy so we can assert the call args
+        without losing the file-presence semantics.
+        """
+        import review_lane_runner
+
+        self._mock_subprocess_ok(mock_run)
+        mock_perm.return_value = ["--permission-mode", "auto"]
+
+        self._stage_prompt_files(tmp_path, archetypes=["review"])
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        spy = MagicMock(wraps=review_lane_runner.system_prompt_args_for_lane)
+        monkeypatch.setattr(review_lane_runner, "system_prompt_args_for_lane", spy)
+
+        review_lane_runner.invoke_review(
+            pr_number=42, branch="feat/foo", head_sha="abc123"
+        )
+
+        assert spy.called, "invoke_review must call system_prompt_args_for_lane"
+        call_args, _ = spy.call_args
+        assert call_args[0] == review_lane_runner.LANE_ID, (
+            f"system_prompt_args_for_lane must be called with LANE_ID="
+            f"{review_lane_runner.LANE_ID!r}, got {call_args[0]!r}"
+        )
+
+
+class TestSystemPromptArgsForLane:
+    """Unit tests for the ``system_prompt_args_for_lane`` helper.
+
+    Narrower scope than ``TestInvokeReviewSystemPromptFile`` — these tests
+    exercise the helper directly across lane / archetype / file-presence
+    permutations, independent of the ``invoke_review`` subprocess harness.
+    """
+
+    def test_returns_empty_for_unknown_lane(self, tmp_path: Path) -> None:
+        """Unknown lane IDs → ``[]`` (fallback, no flag emitted)."""
+        import review_lane_runner
+
+        result = review_lane_runner.system_prompt_args_for_lane("not-a-real-lane-xyz")
+        assert (
+            result == []
+        ), f"Unknown lane must return empty list (fallback), got {result!r}"
+
+    def test_returns_empty_when_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Known lane + missing archetype file → ``[]`` (fallback)."""
+        import review_lane_runner
+
+        # Stage tmp repo root with no .claude/system_prompts/*.md files.
+        (tmp_path / ".claude" / "system_prompts").mkdir(parents=True)
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        result = review_lane_runner.system_prompt_args_for_lane("review")
+        assert (
+            result == []
+        ), f"Missing archetype file must return empty list (fallback), got {result!r}"
+
+    def test_returns_flag_when_file_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Known lane + present archetype file → ``['--system-prompt-file', '<path>']``."""
+        import review_lane_runner
+
+        prompts_dir = tmp_path / ".claude" / "system_prompts"
+        prompts_dir.mkdir(parents=True)
+        (prompts_dir / "review.md").write_text("# review\n")
+        monkeypatch.setattr(review_lane_runner, "_REPO_ROOT", tmp_path)
+
+        result = review_lane_runner.system_prompt_args_for_lane("review")
+        expected_path = str(Path(".claude") / "system_prompts" / "review.md")
+        assert result == ["--system-prompt-file", expected_path], (
+            f"Present archetype file must return ['--system-prompt-file', "
+            f"'{expected_path}'], got {result!r}"
+        )
+
+    def test_map_covers_19_lanes(self) -> None:
+        """Hardcoded map must cover all 19 active fleet lanes (G13 §2.1)."""
+        import review_lane_runner
+
+        expected_lanes = {
+            "orchestrator",
+            "ops",
+            "review",
+            "analyst-a",
+            "analyst-b",
+            "analyst-c",
+            "analyst-d",
+            "author-a",
+            "author-b",
+            "author-c",
+            "author-d",
+            "brws-author-a",
+            "brws-author-b",
+            "brws-author-c",
+            "brws-author-d",
+            "flex-a",
+            "flex-b",
+            "flex-c",
+            "flex-d",
+        }
+        actual_lanes = set(review_lane_runner._LANE_ARCHETYPE_MAP.keys())
+        assert actual_lanes == expected_lanes, (
+            f"Archetype map must cover exactly the 19 active lanes. "
+            f"Missing: {expected_lanes - actual_lanes}. "
+            f"Extra: {actual_lanes - expected_lanes}."
+        )
+
+    def test_map_values_are_valid_archetypes(self) -> None:
+        """Every mapped archetype must be one of the 8 canonical archetypes."""
+        import review_lane_runner
+
+        valid_archetypes = {
+            "orchestrator",
+            "ops",
+            "review",
+            "analyst",
+            "author",
+            "brws-author",
+            "flex",
+            "scratch",
+        }
+        for lane, archetype in review_lane_runner._LANE_ARCHETYPE_MAP.items():
+            assert archetype in valid_archetypes, (
+                f"Lane {lane!r} maps to invalid archetype {archetype!r}; "
+                f"valid set is {valid_archetypes}"
+            )

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -1797,6 +1797,350 @@ permission_mode_flag_for_lane {lane}
             ), f"Python loader and shell helper diverge for lane={lane!r}"
 
 
+class TestSystemPromptFileFlag:
+    """Tests for archetype-aware ``--system-prompt-file`` wiring (B.9b / §2767-γ).
+
+    Per ``plans/steward_platform/2_primitive_B/shaping.md`` §6 (B.9b Fleet
+    launch adoption of ``--system-prompt-file``) and G13 §2.1 (19-lane →
+    8-archetype mapping at
+    ``plans/steward_platform/0_hardening/sub/g13_archetype_mapping.md``):
+
+    * Every ``$CLAUDE_BIN`` launch line in steward-session.sh routes through
+      ``system_prompt_flag_for_lane <lane-id>``.
+    * The helper resolves ``<lane-id>`` to its archetype via a hardcoded
+      19-lane case (matching G13 §2.1) and emits
+      ``--system-prompt-file .claude/system_prompts/<archetype>.md`` iff
+      the archetype prompt file exists on disk.
+    * Missing prompt file ⇒ helper emits nothing; the lane falls back to
+      the Claude Code default system prompt (pre-B.9a fan-out safety).
+    """
+
+    EXPECTED_LANES = (
+        "orchestrator",
+        "ops",
+        "review",
+        "analyst-a",
+        "analyst-b",
+        "analyst-c",
+        "analyst-d",
+        "author-a",
+        "author-b",
+        "author-c",
+        "author-d",
+        "brws-author-a",
+        "brws-author-b",
+        "brws-author-c",
+        "brws-author-d",
+        "flex-a",
+        "flex-b",
+        "flex-c",
+        "flex-d",
+    )
+
+    # G13 §2.1 — 19-lane → 8-archetype mapping.
+    LANE_TO_ARCHETYPE = {
+        "orchestrator": "orchestrator",
+        "ops": "ops",
+        "review": "review",
+        "analyst-a": "analyst",
+        "analyst-b": "analyst",
+        "analyst-c": "analyst",
+        "analyst-d": "analyst",
+        "author-a": "author",
+        "author-b": "author",
+        "author-c": "author",
+        "author-d": "author",
+        "brws-author-a": "brws-author",
+        "brws-author-b": "brws-author",
+        "brws-author-c": "brws-author",
+        "brws-author-d": "brws-author",
+        "flex-a": "flex",
+        "flex-b": "flex",
+        "flex-c": "flex",
+        "flex-d": "flex",
+    }
+
+    EXPECTED_ARCHETYPES = frozenset(
+        {
+            "orchestrator",
+            "ops",
+            "review",
+            "analyst",
+            "author",
+            "brws-author",
+            "flex",
+        }
+    )
+
+    @staticmethod
+    def _claude_launch_lines(content: str) -> list[str]:
+        return [
+            line
+            for line in content.split("\n")
+            if "$CLAUDE_BIN" in line and "--agent" in line
+        ]
+
+    @staticmethod
+    def _extract_helper(content: str) -> str:
+        """Extract the ``system_prompt_flag_for_lane`` function body.
+
+        Mirrors ``TestPermissionModeByModelTier._extract_helper`` brace-
+        depth tracking so the embedded ``case`` block with ``;;`` doesn't
+        confuse a naive regex.
+        """
+        lines = content.split("\n")
+        out: list[str] = []
+        in_func = False
+        depth = 0
+        for line in lines:
+            if line.startswith("system_prompt_flag_for_lane()"):
+                in_func = True
+            if in_func:
+                out.append(line)
+                depth += line.count("{") - line.count("}")
+                if depth == 0 and "}" in line and len(out) > 1:
+                    break
+        return "\n".join(out)
+
+    # -- Structural checks on steward-session.sh ------------------------
+
+    def test_helper_function_defined(self) -> None:
+        """steward-session.sh must define ``system_prompt_flag_for_lane``."""
+        content = _read_steward_script()
+        assert "system_prompt_flag_for_lane()" in content, (
+            "system_prompt_flag_for_lane function must be defined (B.9b / "
+            "shaping.md §6)"
+        )
+
+    def test_every_launch_line_calls_system_prompt_helper(self) -> None:
+        """Every ``$CLAUDE_BIN --agent`` line must invoke the helper.
+
+        Missing the call on any launch line would leave that lane using
+        the Claude Code default system prompt permanently, regressing the
+        B.9b fleet-wide adoption.
+        """
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
+        assert launch_lines, "Expected at least one claude launch line in script"
+        missing = [
+            line.strip()
+            for line in launch_lines
+            if "system_prompt_flag_for_lane" not in line
+        ]
+        assert not missing, (
+            "Every claude launch must route through `system_prompt_flag_for_lane "
+            "<lane-id>` so the archetype system prompt is applied at launch "
+            "time (B.9b). Missing on "
+            f"{len(missing)} line(s):\n" + "\n".join(f"  {line}" for line in missing)
+        )
+
+    def test_system_prompt_invocation_count_matches_launch_count(self) -> None:
+        """One ``$(system_prompt_flag_for_lane ...)`` per launch line."""
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
+        invocation_count = content.count("$(system_prompt_flag_for_lane ")
+        assert invocation_count == len(launch_lines), (
+            f"Expected one $(system_prompt_flag_for_lane ...) call per "
+            f"launch line. Launch lines: {len(launch_lines)}; "
+            f"invocations: {invocation_count}"
+        )
+
+    def test_system_prompt_helper_covers_all_lanes(self) -> None:
+        """Each lane-id must appear exactly once as a helper argument.
+
+        Catches copy-paste errors where one lane's launch passes another
+        lane's id to the helper.
+        """
+        content = _read_steward_script()
+        for lane in self.EXPECTED_LANES:
+            token = f"$(system_prompt_flag_for_lane {lane})"
+            assert content.count(token) == 1, (
+                f"Expected exactly one invocation of `{token}` in "
+                f"steward-session.sh; found {content.count(token)}"
+            )
+
+    def test_system_prompt_call_before_channel_flags_on_orchestrator(self) -> None:
+        """Orchestrator: system-prompt helper must precede ``$ORCH_CHANNEL_FLAGS``.
+
+        The ``$ORCH_CHANNEL_FLAGS`` expansion is either empty or expands
+        to ``--channels plugin:...``. Placing the helper call before it
+        keeps the argv order deterministic whether channel flags are
+        empty or populated — matches the invariant enforced for the
+        permission-mode helper (#2767 follow-on).
+        """
+        content = _read_steward_script()
+        launch_lines = self._claude_launch_lines(content)
+        orch_lines = [line for line in launch_lines if "steward-orchestrator" in line]
+        assert len(orch_lines) == 1, "Expected exactly one orchestrator launch line"
+        line = orch_lines[0]
+        helper_pos = line.find("system_prompt_flag_for_lane")
+        channel_pos = line.find("$ORCH_CHANNEL_FLAGS")
+        assert (
+            helper_pos > 0
+        ), "Orchestrator launch must route through system_prompt_flag_for_lane"
+        assert channel_pos > 0, "Orchestrator launch must expand $ORCH_CHANNEL_FLAGS"
+        assert helper_pos < channel_pos, (
+            "system_prompt_flag_for_lane call must appear BEFORE "
+            "$ORCH_CHANNEL_FLAGS so the expansion is safe whether channel "
+            "flags are empty or populated"
+        )
+
+    def test_helper_references_system_prompts_directory(self) -> None:
+        """Helper body must reference ``.claude/system_prompts/``."""
+        content = _read_steward_script()
+        helper = self._extract_helper(content)
+        assert helper, "system_prompt_flag_for_lane body must be extractable"
+        assert ".claude/system_prompts/" in helper, (
+            "Helper must reference the canonical .claude/system_prompts/ "
+            "directory (per B.9a file layout)"
+        )
+
+    def test_helper_covers_all_8_archetypes(self) -> None:
+        """Helper body must contain all 8 archetype identifiers.
+
+        The archetype set is enumerated by G13 §2.1. A missing archetype
+        in the shell ``case`` statement would silently drop system-prompt
+        adoption for its lanes.
+        """
+        content = _read_steward_script()
+        helper = self._extract_helper(content)
+        missing = [a for a in self.EXPECTED_ARCHETYPES if a not in helper]
+        assert not missing, (
+            f"system_prompt_flag_for_lane must cover all 8 archetypes; "
+            f"missing: {sorted(missing)}"
+        )
+
+    # -- Functional checks on the helper --------------------------------
+
+    def _run_helper(
+        self,
+        tmp_path: Path,
+        lane: str,
+        *,
+        present_archetypes: list[str] | None = None,
+    ) -> str:
+        """Invoke the helper in a bash subshell with a staged prompts dir.
+
+        Staging: create ``<tmp_path>/.claude/system_prompts/<archetype>.md``
+        for each archetype in ``present_archetypes``. If the list is
+        omitted, no files exist (tests the fallback path).
+        """
+        prompts_dir = tmp_path / ".claude" / "system_prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        for archetype in present_archetypes or []:
+            (prompts_dir / f"{archetype}.md").write_text("# archetype prompt stub\n")
+        helper_body = self._extract_helper(_read_steward_script())
+        script = f"""
+MAIN_DIR="{tmp_path}"
+{helper_body}
+system_prompt_flag_for_lane {lane}
+"""
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, f"helper exited non-zero: {result.stderr}"
+        return result.stdout.strip()
+
+    def test_helper_emits_flag_when_archetype_file_exists(self, tmp_path: Path) -> None:
+        """With ``analyst.md`` present, an analyst lane gets the flag."""
+        out = self._run_helper(tmp_path, "analyst-a", present_archetypes=["analyst"])
+        assert (
+            out == "--system-prompt-file .claude/system_prompts/analyst.md"
+        ), f"Expected analyst.md flag, got {out!r}"
+
+    def test_helper_emits_nothing_when_archetype_file_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """With no prompt files staged, every lane gets empty output."""
+        out = self._run_helper(tmp_path, "author-a", present_archetypes=[])
+        assert out == "", (
+            f"Expected fallback (empty output) when archetype file missing, "
+            f"got {out!r}"
+        )
+
+    def test_helper_emits_empty_for_unknown_lane(self, tmp_path: Path) -> None:
+        """Unknown lane-id falls back to empty (no flag)."""
+        out = self._run_helper(
+            tmp_path,
+            "bogus-lane-42",
+            present_archetypes=["analyst", "author", "flex"],
+        )
+        assert out == "", f"Expected empty output for unknown lane, got {out!r}"
+
+    def test_helper_maps_every_known_lane_to_its_archetype(
+        self, tmp_path: Path
+    ) -> None:
+        """Every known lane resolves to the archetype per G13 §2.1."""
+        # Stage all 8 archetype prompt files so the helper always emits
+        # the flag — we're checking the case-statement mapping, not the
+        # fallback path.
+        present = list(self.EXPECTED_ARCHETYPES)
+        for lane, expected_archetype in self.LANE_TO_ARCHETYPE.items():
+            out = self._run_helper(tmp_path, lane, present_archetypes=present)
+            expected = (
+                f"--system-prompt-file .claude/system_prompts/"
+                f"{expected_archetype}.md"
+            )
+            assert out == expected, (
+                f"Lane {lane!r} must resolve to archetype "
+                f"{expected_archetype!r}; got {out!r}"
+            )
+
+    def test_helper_handles_per_archetype_partial_rollout(self, tmp_path: Path) -> None:
+        """With only ``analyst.md`` present, non-analyst lanes get empty.
+
+        This is the current (pre-B.9a fan-out) state: only analyst.md
+        lives in ``.claude/system_prompts/`` and other archetypes are
+        still pending. The helper must return the flag for analyst
+        lanes and empty for everyone else.
+        """
+        out_analyst = self._run_helper(
+            tmp_path, "analyst-a", present_archetypes=["analyst"]
+        )
+        out_author = self._run_helper(
+            tmp_path, "author-a", present_archetypes=["analyst"]
+        )
+        out_orchestrator = self._run_helper(
+            tmp_path, "orchestrator", present_archetypes=["analyst"]
+        )
+        assert (
+            out_analyst == "--system-prompt-file .claude/system_prompts/analyst.md"
+        ), f"analyst-a with analyst.md present must emit flag, got {out_analyst!r}"
+        assert out_author == "", (
+            f"author-a without author.md must emit empty (fallback), "
+            f"got {out_author!r}"
+        )
+        assert out_orchestrator == "", (
+            f"orchestrator without orchestrator.md must emit empty (fallback), "
+            f"got {out_orchestrator!r}"
+        )
+
+    def test_committed_analyst_prompt_is_wired(self) -> None:
+        """Live check: the committed ``.claude/system_prompts/analyst.md``
+        is picked up by the helper for each analyst lane when running
+        against the real repo (not a tmp-path mock).
+
+        This is a thin smoke test guarding against accidental drift
+        between the B.9a authoring surface and the B.9b launch surface.
+        """
+        analyst_prompt = REPO_ROOT / ".claude" / "system_prompts" / "analyst.md"
+        if not analyst_prompt.exists():
+            pytest.skip("analyst.md not present; B.9a landing still pending")
+        helper_body = self._extract_helper(_read_steward_script())
+        script = f"""
+MAIN_DIR="{REPO_ROOT}"
+{helper_body}
+system_prompt_flag_for_lane analyst-b
+"""
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        assert (
+            result.stdout.strip()
+            == "--system-prompt-file .claude/system_prompts/analyst.md"
+        ), (
+            "Real-repo check failed: analyst-b did not emit the analyst.md "
+            f"flag. stdout={result.stdout!r}"
+        )
+
+
 class TestLaunchdTemplate:
     """Validate the launchd plist template."""
 


### PR DESCRIPTION
## Summary

Primitive B-exec.γ / B.9b — Fleet launch adoption of per-archetype
system-prompt files. Every tmux pane and the review-lane subprocess now
emit `--system-prompt-file .claude/system_prompts/<archetype>.md` at
launch when the archetype's prompt file exists on disk.

Scope (4 files — all inline hardcodes, no `lane_models.{json,py}` changes):

- `.claude/tmux/steward-session.sh` — new `system_prompt_flag_for_lane`
  helper (19-lane → 8-archetype map per G13 §2.1); spliced into all 19
  `$CLAUDE_BIN` launch lines (orchestrator + 3 control + 16 pool).
  Placed before `$ORCH_CHANNEL_FLAGS` on orchestrator so the
  word-splitting expansion order stays deterministic.
- `scripts/internal/review_lane_runner.py` — new module-level
  `_LANE_ARCHETYPE_MAP` + `system_prompt_args_for_lane()` helper;
  spliced into `invoke_review()` argv after `permission_mode_args_for_lane`.
- `tests/unit/test_steward_session.py` — new `TestSystemPromptFileFlag`
  class (structural + functional tests).
- `tests/unit/test_review_lane_runner.py` — new
  `TestInvokeReviewSystemPromptFile` + `TestSystemPromptArgsForLane`
  classes.

## Why

B.9b — shaping.md §6 (`plans/steward_platform/2_primitive_B/shaping.md`)
calls for every lane launch (tmux + subprocess) to carry the
`--system-prompt-file` flag pointing at its archetype's prompt file.
This is the fleet-wide adoption step that makes B.9a's authored
archetype prompts (analyst.md pilot, PR #2779) actually load at
launch time instead of only being readable on disk.

Pattern 11 (shape-is-authoritative) applied: scope + verification
surfaces are enumerated in the packet; this PR implements exactly the
shaped surface with no in-line re-design.

## Fallback invariant

If the resolved archetype's `<archetype>.md` file does not yet exist
on disk (pre-B.9a fan-out; only `analyst.md` is authored today), both
helpers return empty and callers splice nothing. The subprocess falls
back to the Claude Code default system prompt rather than failing with
a `--system-prompt-file <missing-file>` launch error. Once the remaining
7 archetype prompt files land, every lane picks up the flag
automatically with no further code edits.

## Repro / Validation

```bash
# Tier 1 — targeted tests
uv run python -m pytest tests/unit/test_steward_session.py \
  tests/unit/test_review_lane_runner.py -q
# → 220 passed in 3.39s

# Tier 2 — full validation (pending; see Verification Performed below)
make check-gated
```

## Verification Performed

Per author prompt-policy clause — verification surfaces that ran:

- `tests/unit/test_steward_session.py::TestSystemPromptFileFlag` —
  structural + functional tests: helper defined, every launch line
  invokes helper, map covers 19 lanes + 8 archetypes, orchestrator
  ordering invariant, file-presence branches, partial-rollout
  behavior, committed-analyst-prompt wiring.
- `tests/unit/test_review_lane_runner.py::TestInvokeReviewSystemPromptFile` —
  argv contains `--system-prompt-file .claude/system_prompts/review.md`
  when archetype file staged; argv omits the flag entirely when
  missing; existing flags (`--agent steward-review`, `--print`, `-p`,
  `--output-format json`, `--permission-mode auto`) preserved
  alongside the new flag; helper called with `LANE_ID='review'`.
- `tests/unit/test_review_lane_runner.py::TestSystemPromptArgsForLane` —
  helper-direct unit tests for unknown lane → `[]`, missing file →
  `[]`, present file → `['--system-prompt-file', '<path>']`, 19-lane
  map coverage, 8-archetype value validity.

All 220 tests in the two touched files pass.

## Test plan

- [x] Unit tests added for shell helper (`system_prompt_flag_for_lane`)
- [x] Unit tests added for Python helper (`system_prompt_args_for_lane`)
- [x] Unit tests added for `invoke_review` argv splicing
- [x] Tier 1 passes locally (220/220)
- [ ] Tier 2 (`make check-gated`) passes — in progress; session-sync-worktree.sh
      was resetting the branch during Tier 2 runs, which required pushing
      the branch + opening this PR first so the hook detects OPEN and
      skips the reset. Tier 2 will re-run cleanly now.
- [ ] CI green

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b`
- `git worktree list` reports this worktree as `Bid-Euchre-steward-flex-b`
- Branch: `ops/b9b-system-prompt-wiring`
- Packet: `9bb050ffe712`

Refs #5-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)