### PR TITLE
fix(steward-platform): drop X3 commented-out blocks from B.9b wiring

### DIFF
--- a/.claude/tmux/steward-session.sh
+++ b/.claude/tmux/steward-session.sh
@@ -182,25 +182,15 @@ except Exception:
     esac
 }
 
-# Emit the `--system-prompt-file .claude/system_prompts/<archetype>.md` flag
-# for a lane, based on the hardcoded 19-lane → 8-archetype mapping from
+# Emit `--system-prompt-file .claude/system_prompts/<archetype>.md` flag
+# for a lane, using the hardcoded 19-lane → 8-archetype map from
 # plans/steward_platform/0_hardening/sub/g13_archetype_mapping.md §2.1
 # (Primitive B-exec.γ / B.9b — shaping.md §6).
-#
-# Fallback: if the resolved archetype prompt file does NOT yet exist under
-# .claude/system_prompts/ (pre-B.9a fan-out: only analyst.md is authored
-# today), emit nothing. The Claude Code default system prompt applies for
-# that lane. This prevents a "--system-prompt-file <missing-file>" launch
-# failure while B.9a fan-out is in flight. Once all 8 archetype files land,
-# every launch line gets the flag automatically with no further edits.
-#
-# Output is intended to be spliced unquoted into a tmux command line so
-# word splitting either emits two tokens
-# (`--system-prompt-file .claude/system_prompts/<archetype>.md`) or nothing.
-#
-# This function must stay behaviorally consistent with
-# scripts/internal/review_lane_runner.py's inline resolution in
-# invoke_review() (matching 19-lane hardcoded mapping).
+
+# Fallback: if the archetype prompt file does NOT exist (pre-B.9a fan-out),
+# emit nothing so Claude Code's default system prompt applies.
+# Output is spliced unquoted into tmux command lines (word-splitting). Must
+# stay behaviorally consistent with review_lane_runner.py invoke_review().
 # Args: lane_id
 system_prompt_flag_for_lane() {
     local lane="$1"

--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -552,17 +552,6 @@ def invoke_review(pr_number: int, branch: str, head_sha: str) -> dict[str, Any]:
         f"reason (string), findings (list of dicts with severity, file, message)."
     )
 
-    # Model-tier-aware permission-mode selection (#2767).
-    # Opus → ["--permission-mode", "auto"] (classifier-gated).
-    # Sonnet / Haiku → ["--dangerously-skip-permissions"] (explicit reduced
-    # safety envelope; --permission-mode auto silently falls back for
-    # non-Opus models and hides enforcement legibility).
-    #
-    # Archetype-aware system-prompt override (Primitive B-exec.γ / B.9b).
-    # Opus review lane → ["--system-prompt-file", ".claude/system_prompts/review.md"]
-    # when the archetype prompt file exists on disk. Fallback: if the
-    # file is not yet authored (pre-B.9a fan-out), the helper returns []
-    # and the subprocess falls back to the Claude Code default prompt.
     argv = [
         "claude",
         "--agent",

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -1491,3 +1491,39 @@ class TestSystemPromptArgsForLane:
                 f"Lane {lane!r} maps to invalid archetype {archetype!r}; "
                 f"valid set is {valid_archetypes}"
             )
+
+    def test_invoke_review_argv_assembly_has_no_x3_comment_block(self) -> None:
+        """Regression guard: the argv-assembly block inside ``invoke_review``
+        must not accumulate an 11+ line commented-out explanation.
+
+        Rationale: the initial B.9b landing (PR #2796) wedged an 11-line
+        comment block (model-tier + archetype-aware rationale) immediately
+        above the ``argv = [...]`` assignment in ``invoke_review``. That
+        tripped deterministic-precheck X3 (``Large commented-out block``).
+        The cleanup removes the duplicated prose — the helpers are
+        already self-documenting. This test prevents a future regression
+        that re-introduces a comment block thick enough to trip X3.
+        """
+        import re
+
+        runner_path = (
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "internal"
+            / "review_lane_runner.py"
+        )
+        content = runner_path.read_text()
+        # Locate invoke_review and grab the function body.
+        fn_idx = content.index("def invoke_review(")
+        # Extract up to the next top-level def / class.
+        tail = content[fn_idx:]
+        next_def = re.search(r"\n(?:def |class )", tail)
+        body = tail[: next_def.start()] if next_def else tail
+        comment_block_re = re.compile(r"((?:^[ \t]*#[^\n]*\n){11,})", re.MULTILINE)
+        findings = comment_block_re.findall(body)
+        assert not findings, (
+            "invoke_review has an 11+ line commented-out block — this "
+            "trips deterministic-precheck X3. Let the helpers "
+            "(permission_mode_args_for_lane, system_prompt_args_for_lane) "
+            "carry their own documentation at the definition site."
+        )

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,6 +15,35 @@ import pytest
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "internal"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_review_lane_runner() -> str:
+    """Read review_lane_runner.py, preferring the git-committed version in CI.
+
+    In CI, the ``setup-uv`` cache restoration can overwrite the working tree
+    after checkout, reverting files to the base branch. When ``GITHUB_SHA``
+    is set (GitHub Actions), we read from the merge-commit blob to get the
+    correct PR content. Locally we just read the file.
+    """
+    github_sha = os.environ.get("GITHUB_SHA")
+    if github_sha:
+        try:
+            return subprocess.check_output(
+                [
+                    "git",
+                    "show",
+                    f"{github_sha}:scripts/internal/review_lane_runner.py",
+                ],
+                cwd=str(_REPO_ROOT),
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            pass  # fall through to filesystem read
+    return (_REPO_ROOT / "scripts" / "internal" / "review_lane_runner.py").read_text()
+
 
 # Import the runner under test (after path setup)
 from review_lane_runner import (
@@ -1503,16 +1534,14 @@ class TestSystemPromptArgsForLane:
         The cleanup removes the duplicated prose — the helpers are
         already self-documenting. This test prevents a future regression
         that re-introduces a comment block thick enough to trip X3.
+
+        Uses ``_read_review_lane_runner()`` to read from the git-committed
+        blob in CI (setup-uv cache restoration can overwrite the working
+        tree; see the helper's docstring).
         """
         import re
 
-        runner_path = (
-            Path(__file__).resolve().parents[2]
-            / "scripts"
-            / "internal"
-            / "review_lane_runner.py"
-        )
-        content = runner_path.read_text()
+        content = _read_review_lane_runner()
         # Locate invoke_review and grab the function body.
         fn_idx = content.index("def invoke_review(")
         # Extract up to the next top-level def / class.

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -2140,6 +2140,47 @@ system_prompt_flag_for_lane analyst-b
             f"flag. stdout={result.stdout!r}"
         )
 
+    def test_helper_docstring_under_x3_threshold(self) -> None:
+        """Regression guard: the ``system_prompt_flag_for_lane`` docstring
+        must not exceed the deterministic-precheck X3 threshold
+        (11+ consecutive ``#`` comment lines).
+
+        Rationale: the initial B.9b landing (PR #2796) shipped a 20-line
+        docstring that tripped X3 in the follow-up review. The cleanup
+        (PR succeeding #2796) condenses it. This test prevents regression
+        if someone re-expands the comment without noticing the X3 gate.
+
+        Scope: this test only inspects the comment block *immediately above*
+        ``system_prompt_flag_for_lane`` (contiguous ``#`` lines bounded by a
+        blank line or non-comment line above). Pre-existing large blocks
+        elsewhere in the file (file header, other helpers) are out of scope
+        and tracked in backlog follow-ups.
+        """
+        content = STEWARD_SCRIPT.read_text()
+        lines = content.split("\n")
+        # Find the helper definition line.
+        helper_line_idx = next(
+            i
+            for i, ln in enumerate(lines)
+            if ln.startswith("system_prompt_flag_for_lane() {")
+        )
+        # Walk backward, collecting contiguous ``#`` comment lines until
+        # we hit a blank line or a non-comment line.
+        contiguous = 0
+        for i in range(helper_line_idx - 1, -1, -1):
+            stripped = lines[i].lstrip()
+            if stripped.startswith("#"):
+                contiguous += 1
+            else:
+                break
+        assert contiguous < 11, (
+            f"system_prompt_flag_for_lane helper has {contiguous} "
+            "contiguous # comment lines immediately above it — this "
+            "trips deterministic-precheck X3 (≥11 lines). Split the "
+            "docstring into blocks of ≤10 consecutive # lines separated "
+            "by blank lines."
+        )
+
 
 class TestLaunchdTemplate:
     """Validate the launchd plist template."""

--- a/tests/unit/test_steward_session.py
+++ b/tests/unit/test_steward_session.py
@@ -2155,8 +2155,12 @@ system_prompt_flag_for_lane analyst-b
         blank line or non-comment line above). Pre-existing large blocks
         elsewhere in the file (file header, other helpers) are out of scope
         and tracked in backlog follow-ups.
+
+        Uses ``_read_steward_script()`` to read from the git-committed blob
+        in CI (setup-uv cache restoration can overwrite the working tree;
+        see the helper's docstring).
         """
-        content = STEWARD_SCRIPT.read_text()
+        content = _read_steward_script()
         lines = content.split("\n")
         # Find the helper definition line.
         helper_line_idx = next(


### PR DESCRIPTION
## Summary

Post-merge follow-up to [PR #2796](https://github.com/Questuart/Bid-Euchre/pull/2796) (B.9b launch-script + system-prompt-file wiring). The merged commit introduced two large commented-out blocks that trip deterministic-precheck X3 (`Large commented-out block`, ≥11 consecutive `#` lines):

- `scripts/internal/review_lane_runner.py:555` — 11-line block explaining model-tier + archetype-aware argv selection. The explanation duplicates what the helpers (`permission_mode_args_for_lane`, `system_prompt_args_for_lane`) already document at their definitions. Dropped entirely.
- `.claude/tmux/steward-session.sh:185` — 20-line docstring above `system_prompt_flag_for_lane()`. Condensed to two small blocks (4 + 5 lines, separated by a blank) that preserve the fallback rationale + consistency note but stay under the X3 11-line threshold.

Adds two narrow regression guards so a future edit cannot reintroduce an 11+ line commented-out block in these surfaces without tripping Tier-1 CI:

- `test_steward_session.py::test_helper_docstring_under_x3_threshold` — walks backward from `system_prompt_flag_for_lane() {` and asserts the contiguous `#` block immediately above it is ≤10 lines.
- `test_review_lane_runner.py::test_invoke_review_argv_assembly_has_no_x3_comment_block` — extracts the `invoke_review` function body and asserts no 11+ line commented-out block inside.

No behavioral change. Helpers, tests, and wiring all unchanged.

## Why

Orchestrator recovery directive on PR #2796: `"PR #2796 precheck X3 BLOCK at scripts/internal/review_lane_runner.py:555 — 11-line commented-out block. Delete the commented block and push follow-up commit."` Auto-merge completed before the follow-up landed, so this ships as a post-merge cleanup PR instead.

## Repro / Validation

```bash
# Confirm X3 cleared in working tree
uv run python -c "
import sys; sys.path.insert(0, 'scripts/internal')
from deterministic_prechecks import check_file
from pathlib import Path
for p in ['scripts/internal/review_lane_runner.py', '.claude/tmux/steward-session.sh']:
    findings = [f for f in check_file(p, Path(p).read_text()) if f.check_id == 'X3']
    print(f'{p}: {len(findings)} X3 findings introduced by this PR (pre-existing blocks are out of scope)')
"

# Tier 1: run affected tests
uv run python -m pytest tests/unit/test_steward_session.py tests/unit/test_review_lane_runner.py -q
# → 222 passed (adds 2 new regression tests)
```

## Tests

- `pytest tests/unit/test_steward_session.py tests/unit/test_review_lane_runner.py -q` → 222 passed
- `pytest tests/unit/test_steward_session.py::TestSystemPromptFileFlag::test_helper_docstring_under_x3_threshold` → passed
- `pytest tests/unit/test_review_lane_runner.py::TestSystemPromptArgsForLane::test_invoke_review_argv_assembly_has_no_x3_comment_block` → passed

## Worktree proof

```
$ pwd
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
$ git rev-parse --show-toplevel
/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-flex-b
$ git branch --show-current
ops/b9b-x3-cleanup
```

## Verification Performed

Per author prompt policy (verification-surface-at-slice-close, Pattern 10 §10.9):

- **Surface:** Tier-1 pytest (`tests/unit/test_steward_session.py` + `tests/unit/test_review_lane_runner.py`)
- **Expected signal:** 222 passed (+2 from previous 220 — matches the two new regression tests)
- **Observed:** 222 passed in 5.40s (see Tests section above for full invocation)

Scope: strict (4 files, all declared in the B.9b packet). Pre-existing large comment blocks elsewhere (file header, other helpers) are out of scope and tracked in backlog follow-ups.

Refs #5-B
Refs PR #2796

🤖 Generated with [Claude Code](https://claude.com/claude-code)