### PR TITLE
feat(ops): land Primitive A event schema v1.0 + ops/events.py dispatcher (Packet 3)

### DIFF
--- a/.claude/hooks/event_emit.sh
+++ b/.claude/hooks/event_emit.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Primitive A v1.0 — native lifecycle hook absorber.
+#
+# Forwards a native Claude Code lifecycle event through the
+# ``bid_euchre.ops.events.emit`` dispatcher, which writes to the
+# v1.0 JSONL pipeline under ``data/events/events-YYYY-MM-DD-NNN.jsonl``.
+#
+# Invocation:
+#   event_emit.sh <event_type>
+#
+# Where <event_type> matches a registered v1.0 event type:
+#   pre_tool_use | post_tool_use | post_tool_use_failure |
+#   permission_request | permission_denied | notification |
+#   user_prompt_submit | stop | stop_failure |
+#   subagent_start | subagent_stop |
+#   pre_compact | session_start | session_end | teammate_idle
+#
+# Stdin: the native hook JSON payload.
+# Stderr: absorbed (never-raises contract; nothing must block the caller).
+# Exit code: always 0 (hook must never fail the hosting tool call).
+#
+# Design notes:
+#
+# - This hook is fire-and-forget. If ``uv run`` is slow to warm up,
+#   the cost is absorbed here once per hook fire. ``emit()`` itself is
+#   non-blocking in-process (O(ms) JSONL append + lock).
+# - Event payloads with enormous ``tool_response`` strings still flow
+#   through; summary-tier truncation is the dispatcher's job, not this
+#   script's.
+# - Resolves lane_id via the canonical helper when available so events
+#   carry the right lane even on hook-only dispatch paths.
+
+set -u  # Treat unset vars as error (do NOT set -e; we swallow failures)
+
+# Exit silently on any unhandled failure — never block the tool call.
+trap 'exit 0' ERR
+
+EVENT_TYPE="${1:-}"
+if [ -z "$EVENT_TYPE" ]; then
+    exit 0
+fi
+
+# Read the native hook JSON payload from stdin (may be empty for some
+# hook types like SessionStart).
+INPUT="$(cat || true)"
+
+# Resolve lane_id via the canonical helper (shared with other hooks).
+LANE_ID="${CLAUDE_AGENT_NAME:-unknown}"
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && \
+   [ -r "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh" ]; then
+    # shellcheck disable=SC1091
+    . "${CLAUDE_PROJECT_DIR}/.claude/hooks/lib/resolve-lane-id.sh"
+    RESOLVED="$(resolve_lane_id 2>/dev/null || true)"
+    [ -n "$RESOLVED" ] && LANE_ID="$RESOLVED"
+fi
+
+# Fire the emission as a detached process so even a slow interpreter
+# warmup never stalls the tool call. All output discarded; exit 0
+# regardless.
+INPUT="$INPUT" EVENT_TYPE="$EVENT_TYPE" LANE_ID="$LANE_ID" \
+uv run --no-sync python -c "
+import json
+import os
+import sys
+
+try:
+    from bid_euchre.ops.events import emit
+except Exception:  # pragma: no cover — import guard
+    sys.exit(0)
+
+event_type = os.environ.get('EVENT_TYPE', '')
+raw = os.environ.get('INPUT', '') or '{}'
+try:
+    payload = json.loads(raw)
+except Exception:
+    payload = {}
+
+# The native Claude Code payload schema keys are mostly compatible with
+# the v1.0 registry. Pass them through verbatim; dispatcher partitions
+# registered slots vs. extra_fields automatically.
+kwargs = {}
+if isinstance(payload, dict):
+    kwargs.update({k: v for k, v in payload.items() if k not in (
+        'event_type',
+    )})
+
+lane_id = os.environ.get('LANE_ID')
+if lane_id and 'lane_id' not in kwargs:
+    kwargs['lane_id'] = lane_id
+
+try:
+    emit(event_type, **kwargs)
+except Exception:
+    # emit() is never-raises; this is a defensive redundancy.
+    pass
+" >/dev/null 2>&1 &
+
+# Detach and exit immediately
+disown 2>/dev/null || true
+exit 0

--- a/.claude/rules/feature_flags.md
+++ b/.claude/rules/feature_flags.md
@@ -1,0 +1,79 @@
+# Feature Flags Registry
+
+> Registry of runtime feature flags used to gate platform behavior
+> changes and provide Pattern 7 (forward-then-reverse) rollback paths.
+
+## Registry
+
+### `STEWARD_EVENTS_POLLING_FALLBACK`
+
+| Property | Value |
+|----------|-------|
+| **Type** | Environment variable |
+| **Default** | `0` (disabled — event-driven path active) |
+| **Owning primitive** | A (event schema v1.0 dispatcher) + E (active-triage consumer) |
+| **Trigger** | Event-driven routing regresses (lost events, dispatcher crash, consumer backlog) |
+| **Expected effect** | Downstream active-triage consumers re-enter polling mode; event-driven path remains in place but is bypassed |
+| **Rollback SLO** | Operator flip → consumer re-entry to polling mode within **1 minute** |
+
+**Setting the flag:**
+
+```bash
+# Flip the flag in the lane's shell (or systemwide under a supervisor env).
+export STEWARD_EVENTS_POLLING_FALLBACK=1
+
+# To restore event-driven routing:
+unset STEWARD_EVENTS_POLLING_FALLBACK
+# or:
+export STEWARD_EVENTS_POLLING_FALLBACK=0
+```
+
+**Validation surface:** `tests/integration/test_polling_fallback.py`.
+The test flips the flag, waits for the consumer to re-enter polling,
+and asserts polling restart latency is ≤60 s. Re-run the test in the
+CI pipeline whenever either Primitive A's dispatcher or Primitive E's
+consumer changes.
+
+**Why this exists:** Primitive A migrates active-triage routing from a
+polling loop to the event-driven `events.emit()` path. If the
+dispatcher regresses mid-rollout (file lock starvation, hook
+registration drift, schema validation bug), the rollback must be
+**instant and safe**, not "revert the PR." This flag is the Pattern 7
+reversibility obligation discharged for Primitive A's Phase 0 landing
+— see `plans/steward_platform/1_primitive_A/shaping.md` §8.1 and
+`verification_contract/map.md` row **A.5**.
+
+**Cross-references:**
+
+- `docs/01_core/event_schema_v1.md` §11 (rollback path)
+- `plans/steward_platform/governing_plan.md` §10.9 Pattern 7
+  (forward-then-reverse reversibility)
+- `.claude/rules/80_permission_model.md` for related env-var-driven
+  behavior toggles.
+
+---
+
+## Conventions for adding a new entry
+
+When adding a new feature flag to this registry:
+
+1. **Name** — prefix with `STEWARD_` for platform-scoped flags;
+   `BIDEU_` for Bid-Euchre domain flags. Use uppercase with underscores.
+2. **Default** — prefer `0`/`off` so that "no env var set" is the
+   safe, forward path.
+3. **Rollback SLO** — must be concrete (e.g., "1 minute", not "fast").
+   Pattern 7 obligations require a measurable rollback.
+4. **Validation surface** — every flag carries a named pytest or
+   integration test that flips the flag and asserts the rollback
+   effect.
+5. **Owner** — primitive or module responsible for honoring the flag.
+6. **Deprecation** — flags have a lifecycle. When the forward path is
+   proven stable, file a follow-up to retire the flag and the fallback
+   path together. Expired flags move to an `## Archive` section below.
+
+---
+
+## Archive
+
+_(No archived flags yet. Expired flags move here with the retirement
+PR number and the date the fallback code was removed.)_

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,16 @@
             "timeout": 20
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh pre_tool_use",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -66,6 +76,15 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/attention-broker-autostart.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh session_start",
             "timeout": 5
           }
         ]
@@ -131,6 +150,28 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh post_tool_use",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh post_tool_use_failure",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PermissionDenied": [
@@ -150,6 +191,114 @@
             "type": "command",
             "command": "bash -lc '\"$CLAUDE_PROJECT_DIR\"/scripts/internal/hooks/permission_denied_alert.sh'",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh permission_denied",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh permission_request",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh notification",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh stop_failure",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh subagent_start",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh subagent_stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh pre_compact",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh session_end",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh teammate_idle",
+            "timeout": 5
           }
         ]
       }
@@ -179,6 +328,15 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/inbox-completion-inject.sh",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh user_prompt_submit",
+            "timeout": 5
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ data/hand_logs/
 data/training/
 data/data/models/
 data/local_smoke/
+# Event Schema v1.0 raw JSONL (Primitive A — runtime-only; retention enforced
+# via STEWARD_EVENTS_RETENTION_DAYS). Promoted artifacts derived from events
+# live under knowledge/ and are committed separately.
+data/events/
 
 # Experiment outputs (keep experiment scripts tracked)
 experiments/output/

--- a/docs/01_core/ARCHITECTURE.md
+++ b/docs/01_core/ARCHITECTURE.md
@@ -256,6 +256,7 @@ Every experiment run creates a standardized directory under `data/runs/<run_id>/
 | `scripts/internal/archivist.py` | Primitive C archivist stub (interface contract + CLI skeleton for KB promotion flow; Phase 0 scaffold) |
 | `scripts/internal/archivist_candidates.py` | Primitive D archivist candidate-generator CLI (lessons / GC / postmortem modes; writes `knowledge/_candidates/<date>_{lessons,gc}.md`) |
 | `scripts/internal/audit_analysis.py` | Review pipeline audit (follow-up rates, corrective PRs) |
+| `scripts/internal/audit_event_emission.py` | Primitive A event-emission audit — scans ops/ for emit() call sites across the 7 STEWARD_OPERATIONAL_CLASSES and reports green/yellow/red coverage |
 | `scripts/internal/audit_portability.py` | Ops package portability audit (coupling pattern scanner, severity counts, threshold enforcement) |
 | `scripts/internal/blind_strategy_comparison.py` | Blind strategy comparison for Arc D evaluation (anonymize, rubric, unblind) |
 | `scripts/internal/capture_steward_baseline.py` | Phase 0 steward platform baseline snapshot (§4.3) — composes fleet / token / PR / issue / event / plan sections into a diffable markdown artifact |

--- a/docs/01_core/event_schema_v1.md
+++ b/docs/01_core/event_schema_v1.md
@@ -1,0 +1,230 @@
+# Event Schema v1.0 — Operator Catalog
+
+> Operator-readable catalog of the steward platform's Event Schema v1.0,
+> emitted by `src/bid_euchre/ops/events.py` into JSONL files under
+> `data/events/`. Authored under Primitive A, Phase 0 Readiness.
+
+**Schema version:** `"1.0"` (constant `SCHEMA_VERSION` in
+`src/bid_euchre/ops/event_schema.py`).
+
+**Authoritative source:**
+`src/bid_euchre/ops/event_schema.py` (`EVENT_FIELD_REGISTRY`) —
+this document is the human-readable projection. When the two disagree,
+the registry wins.
+
+**Parent plan:** `plans/steward_platform/1_primitive_A/shaping.md`.
+
+---
+
+## §1. Scope
+
+The Event Schema v1.0 is the single emission contract for every steward
+telemetry writer. Every call-site uses the shared dispatcher:
+
+```python
+from bid_euchre.ops.events import emit
+
+emit(
+    event_type="task_started",
+    packet_id=packet_id,
+    dispatched_by="orchestrator",
+    priority="high",
+    domain="platform",
+    lane_id=lane_id,
+)
+```
+
+`emit()` is **non-blocking and never-raises** — exceptions in the
+emission path are caught and swallowed so a misbehaving emitter cannot
+crash a tool call, hook, or CLI invocation.
+
+## §2. File layout
+
+| Path | Purpose |
+|------|---------|
+| `data/events/events-*.jsonl` | Daily-rotated event log (gitignored; filename pattern `events-YYYY-MM-DD-NNN.jsonl`) |
+| `data/events/events-*.meta.json` | Paired sidecar (filename pattern `events-YYYY-MM-DD-NNN.meta.json`) with `first_seq`, `last_seq`, `first_timestamp_ns`, `last_timestamp_ns`, `event_count`, `schema_version`, `event_types` |
+| `data/events/.seq` | Monotonic sequence counter (file-locked) |
+| `data/events/` + `.turn` | Per-session turn counter (gitignored; created on first event emission) |
+| `data/events/.event_writer.lock` | Cross-process write lock |
+
+Rotation: when the active file exceeds `STEWARD_EVENTS_MAX_FILE_BYTES`
+(default 50 MB), a new file opens with `NNN+1`. The counter resets
+daily.
+
+Retention: raw JSONL files are retained
+`STEWARD_EVENTS_RETENTION_DAYS` days (default 30), then swept by a
+separate ops task. Promoted artifacts derived from events (KB entries,
+ADRs, dashboards) are committed; the raw events are not.
+
+## §3. §9.7 First-class IDs (top-level fields)
+
+Every event record carries these nine IDs as top-level fields. Routing
+a first-class ID through `extra_fields` is a Pattern 8 bug marker and
+is flagged by `agent_readability_lint.py check verification-contract`.
+
+| Field | Type | Source / population |
+|-------|------|---------------------|
+| `project_id` | string | Constant `"bid-euchre"` |
+| `cell_id` | string | Same as `project_id` (reserved for multi-cell future) |
+| `session_id` | string | `CLAUDE_SESSION_ID` env, fallback to UUID4 |
+| `task_id` | string \| null | Steward task packet ID when task-scoped |
+| `lane_id` | string | `CLAUDE_AGENT_NAME` env (e.g., `author-a`) |
+| `trace_id` | string | UUID4 generated at task creation; propagated across lifecycle |
+| `incident_fingerprint` | string \| null | Populated for incident-scoped events only |
+| `prompt_policy_version` | string | From `.claude/rules/prompt_policy/<lane>.md`; falls back to `"unset"` |
+| `schema_version` | string | `"1.0"` in Phase 0 |
+
+## §4. Correlation fields (top-level)
+
+| Field | Type | Population |
+|-------|------|------------|
+| `seq` | int | Monotonic counter per log directory (locked `.seq` file) |
+| `pid` | int | `os.getpid()` at emission |
+| `timestamp_ns` | int | `time.time_ns()` at emission |
+| `turn_id` | int | Per-session counter; increments on `user_prompt_submit` |
+
+## §5. Event types (v1.0 catalog — 35 registered)
+
+### §5.1 Native lifecycle hook events (15)
+
+Absorbed via `.claude/hooks/event_emit.sh` shim; registered against
+Claude Code's lifecycle hooks by `.claude/settings.json`.
+
+| Event type | Required fields (beyond §3 / §4 baseline) | Optional |
+|------------|-------------------------------------------|----------|
+| `pre_tool_use` | `tool_name`, `tool_input` | `tool_use_id` |
+| `post_tool_use` | `tool_name`, `tool_input`, `tool_response` | `tool_use_id`, `duration_ms` |
+| `post_tool_use_failure` | `tool_name`, `tool_input`, `error`, `error_category` | `tool_use_id`, `is_interrupt` |
+| `permission_request` | `tool_name`, `tool_input`, `permission_suggestions` | — |
+| `permission_denied` | `tool_name`, `tool_input`, `denial_reason` | — |
+| `notification` | `message` | `severity` |
+| `user_prompt_submit` | `prompt` | — |
+| `stop` | `stop_hook_active` | `last_assistant_message` |
+| `stop_failure` | `stop_hook_active` | `last_assistant_message` |
+| `subagent_start` | `agent_id`, `agent_type` | `parent_agent_id` |
+| `subagent_stop` | `agent_id`, `agent_type` | `parent_agent_id`, `agent_transcript_path` |
+| `pre_compact` | `trigger` | `custom_instructions` |
+| `session_start` | `source`, `model`, `archetype` | `agent_type` |
+| `session_end` | `reason` | `last_assistant_message` |
+| `teammate_idle` | `teammate_name`, `idle_seconds` | `team_name` |
+
+### §5.2 Steward operational events (task / worktree — 4)
+
+| Event type | Required | Optional |
+|------------|----------|----------|
+| `task_started` | `packet_id`, `dispatched_by`, `priority`, `domain` | `effort_hint`, `model_hint`, `task_type`, `complexity_estimate` |
+| `task_completed` | `packet_id`, `outcome` | `pr_number`, `source`, `title`, `summary`, `completed_by`, `actual_lane`, `recommended_lane`, `token_spend`, `elapsed_seconds`, `review_rounds`, `shipped_outcome` |
+| `worktree_create` | `worktree_path`, `branch`, `protected` | — |
+| `worktree_remove` | `worktree_path`, `branch`, `protected` | — |
+
+### §5.3 Steward-additive deferred classes (15 — registered v1.0, emitters per primitive)
+
+These event types are **registered** in `EVENT_FIELD_REGISTRY` so the
+dispatcher routes them correctly, but their **emitters** ship per their
+owning primitive.
+
+| Class | Event types | Owning primitive |
+|-------|-------------|-------------------|
+| Canary lifecycle | `canary_run_start`, `canary_run_complete`, `canary_run_fail`, `canary_rollback_complete` | H.0 |
+| Archivist lifecycle | `archivist_candidate_proposed`, `archivist_candidate_promoted`, `archivist_candidate_rejected`, `archivist_gc_proposed` | D |
+| Promotion lifecycle | `promotion_evaluated`, `promotion_passed`, `promotion_failed`, `promotion_rolled_back` | F + B |
+| Rollback lifecycle | `rollback_initiated`, `rollback_completed`, `rollback_validated` | G + per-primitive |
+
+### §5.4 Latency measurements (2 — self-instrumentation)
+
+Emitted by Primitive A itself; drive §5-A latency targets
+(≤5 min p95 event-to-signal, ≤30s p95 bus delivery). Rendered on the
+ops dashboard `Latencies` panel (see `format_dashboard_text`).
+
+| Event type | Required | Optional |
+|------------|----------|----------|
+| `event_to_signal_latency` | `source_event_id`, `signal_type`, `latency_ms` | — |
+| `bus_delivery_latency` | `message_id`, `delivery_ms` | — |
+
+## §6. Verbosity tiers
+
+Per-event size is controlled by the verbosity tier:
+
+| Tier | Per-event size | Contents |
+|------|----------------|----------|
+| `minimal` | ~200 B | Baseline + `event_type` + success flag |
+| `summary` | ~500 B | minimal + required fields + `extra_fields` (summarized) |
+| `full` | 1–50 KB | summary + optional fields + raw tool_input/tool_response |
+
+**Selection:**
+
+1. Per-call override: `emit(..., _verbosity="full")` (rare).
+2. Per-process override: `STEWARD_EVENTS_VERBOSITY` env var.
+3. Default: `EventTypeSpec.verbosity_default` from the registry.
+
+## §7. Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `STEWARD_EVENTS_LOG_DIR` | `data/events` | Log directory root |
+| `STEWARD_EVENTS_VERBOSITY` | (per-type default) | Override verbosity tier for this process |
+| `STEWARD_EVENTS_MAX_FILE_BYTES` | `52428800` (50 MB) | File rotation threshold |
+| `STEWARD_EVENTS_RETENTION_DAYS` | `30` | Raw-JSONL retention window |
+| `STEWARD_PROMPT_POLICY_VERSION` | `"unset"` | Populates `prompt_policy_version` top-level field |
+| `STEWARD_EVENTS_POLLING_FALLBACK` | `0` | If `1`, re-enables polling-based consumers (see `.claude/rules/feature_flags.md`) |
+
+## §8. `extra_fields` — bug marker pattern
+
+`extra_fields: dict[str, Any]` exists for **future-proofing unknown
+fields** (e.g., a new lifecycle hook ships fields not yet in the
+registry).
+
+For **known emitters** (any steward call-site), routing a registered
+field through `extra_fields` is a Pattern 8 violation. The lint
+(`agent_readability_lint.py check verification-contract`) flags these
+in CI. Fix by either (a) moving the field to the registry as a
+first-class or optional slot, or (b) dropping it.
+
+Native-hook absorption is the only legitimate `extra_fields`
+population path — the dispatcher routes unknown native fields into
+`extra_fields` until the registry catches up.
+
+## §9. Versioning policy (summary)
+
+- **v1.N additive** (new types; new optional fields; new top-level
+  correlation fields with defaults) are replay-compatible. The replay
+  harness (Primitive H.1) asserts `v1.N → v1.M` compatibility for
+  `N ≤ M`.
+- **v2.0 breaking** (renames, removals, semantic reinterpretations)
+  requires a sub-plan + ADR + 1-week analyst review window.
+- The `schema_version` field on every event record records the writer's
+  version; consumers handle version skew during the compatibility
+  window.
+
+See `plans/steward_platform/1_primitive_A/shaping.md` §2.1 for the full
+policy.
+
+## §10. Related surfaces
+
+| Surface | Purpose |
+|---------|---------|
+| `scripts/internal/audit_event_emission.py` | Walks codebase + hook registry; reports green/yellow/red coverage |
+| `scripts/internal/agent_readability_lint.py check verification-contract` | Lints emission call-sites for schema / `extra_fields` violations |
+| `src/bid_euchre/ops/dashboard.py` `Latencies` panel | Reads `data/events/*.jsonl`; renders p50/p95 for each latency metric |
+| `docs/ops/phoenix.md` | Downstream Phoenix-consumer runbook (separate packet) |
+| `.claude/rules/feature_flags.md` — `STEWARD_EVENTS_POLLING_FALLBACK` | Rollback path if event-driven routing regresses |
+
+## §11. Rollback path
+
+Primitive A ships as a dual-write overlay during Phase 0 — the new
+`events.emit()` writes to `data/events/` alongside the legacy
+`append_event` writer at `.claude/runtime/events/`. If v1.0 emission
+regresses, downstream consumers fall back to the legacy writer or the
+polling path:
+
+1. Flip `STEWARD_EVENTS_POLLING_FALLBACK=1` (see
+   `.claude/rules/feature_flags.md`).
+2. Downstream active-triage consumers (Primitive E) re-enter polling
+   mode within one minute (validated by
+   `tests/integration/test_polling_fallback.py`).
+3. The legacy `append_event` writer remains operational across the
+   rollback window; no consumer loss.
+
+The rollback path is registered in `plans/steward_platform/verification_contract/map.md`
+row **A.5** and exercised during the Phase 0 proving run.

--- a/docs/ops/phoenix.md
+++ b/docs/ops/phoenix.md
@@ -1,0 +1,57 @@
+# Phoenix Deployment Runbook (stub)
+
+> Downstream Arize Phoenix consumer of the steward Event Schema v1.0
+> JSONL stream (per `docs/01_core/event_schema_v1.md`). Phoenix hosts
+> the trace-inspection UI for the proving-run workflow (§5-A of the
+> governing plan).
+
+**Status:** **Stub** — this runbook is a placeholder. The Phoenix
+container deployment lands under a separate packet
+(Primitive A / Packet 3.1 or later) per
+`plans/steward_platform/1_primitive_A/shaping.md` §8.1 *Files NOT
+modified by Packet 3*. This file exists so the stub is **discoverable**
+and the operator has a landing page while the deployment packet ships.
+
+**Expected landing-sections** (to be authored under the Phoenix
+deployment packet):
+
+1. **Prerequisites** — Docker runtime; `data/events/` bind mount; one
+   `STEWARD_EVENTS_RETENTION_DAYS` coordination note.
+2. **Deploy** — `docker compose up phoenix` or equivalent; first-boot
+   schema ingest from `data/events/events-*.jsonl`.
+3. **Named workflows** — at least two must be documented per
+   `plans/steward_platform/verification_contract/map.md` row **A.3**:
+   - Workflow 1: *trace lineage reconstruction* for a given
+     `trace_id` across primitives.
+   - Workflow 2: *latency drill-down* using the
+     `event_to_signal_latency` and `bus_delivery_latency` event
+     classes.
+4. **Retention coordination** — Phoenix indexes persist in its own
+   volume; raw JSONL is swept after
+   `STEWARD_EVENTS_RETENTION_DAYS`. The runbook documents how Phoenix's
+   retention window composes with the steward sweep so operators can
+   plan storage.
+5. **Rollback path** — disable via `docker compose down phoenix`;
+   event stream keeps writing to `data/events/` unchanged. Flip
+   `STEWARD_EVENTS_POLLING_FALLBACK=1`
+   (see `.claude/rules/feature_flags.md`) if downstream event-driven
+   consumers regress.
+6. **Pattern 7 rollback validation** — the Phoenix deployment
+   registers at verification_contract/map.md row **A.3** with the
+   acceptance condition *deployment reversible; 2 named workflows
+   documented*.
+
+**Cross-references:**
+
+- `docs/01_core/event_schema_v1.md` — upstream event catalog.
+- `plans/steward_platform/1_primitive_A/shaping.md` §5 proving-run
+  protocol (Phoenix as proving-time observation surface).
+- `.claude/rules/feature_flags.md` — `STEWARD_EVENTS_POLLING_FALLBACK`.
+- `plans/steward_platform/verification_contract/map.md` row **A.3**.
+
+**Why this stub exists:** Primitive A Phase 0 Readiness requires the
+downstream Phoenix runbook path to be named; the deployment artifact
+itself is deferred. Landing the stub keeps the verification contract
+grep-discoverable
+(`plans/steward_platform/verification_contract/map.md` cites `docs/ops/phoenix.md`) while the
+deployment lands under a scoped follow-up.

--- a/scripts/check_docs_freshness.py
+++ b/scripts/check_docs_freshness.py
@@ -78,8 +78,9 @@ def check_path_references(docs_dir: Path, repo_root: Path) -> list[str]:
             # Skip run-relative paths (not repo-root paths)
             if ref.startswith(run_relative_prefixes):
                 continue
-            # Skip data/runs/ and data/artifacts/ paths (gitignored generated outputs)
-            if ref.startswith(("data/runs/", "data/artifacts/")):
+            # Skip data/runs/, data/artifacts/, and data/events/ paths
+            # (gitignored generated outputs — runtime artifacts)
+            if ref.startswith(("data/runs/", "data/artifacts/", "data/events/")):
                 continue
             # Skip src/bid_euchre/ submodule-relative shorthand paths
             first_segment = ref.split("/")[0]

--- a/scripts/internal/agent_readability_lint.py
+++ b/scripts/internal/agent_readability_lint.py
@@ -382,7 +382,13 @@ def _load_global_map(repo_root: Path) -> set[str]:
 
 
 def check_verification_contract(roots: list[Path], repo_root: Path) -> list[Finding]:
-    """Return all Pattern 10 findings across the given plan roots."""
+    """Return all Pattern 10 findings across the given plan roots.
+
+    Also runs the events-emission sub-checks (VC4/VC5) introduced in
+    Primitive A §8.2 step 9: unknown event_type passed to ``emit()``
+    is BLOCK, §9.7 first-class IDs routed through ``extra_fields=`` is
+    WARN (Pattern 8 "extra_fields-as-bug-marker" signal).
+    """
     walk = walk_plans(roots)
     global_map = _load_global_map(repo_root)
     findings: list[Finding] = []
@@ -454,7 +460,202 @@ def check_verification_contract(roots: list[Path], repo_root: Path) -> list[Find
             )
         )
 
+    # Rules VC4/VC5 — events.emit() call-site audit. Scans the repo's Python
+    # surfaces for emit() calls and validates them against the Event Schema
+    # v1.0 registry.
+    findings.extend(_check_emit_call_sites(repo_root))
+
     return findings
+
+
+# ---------------------------------------------------------------------------
+# Event emission sub-checks (Primitive A §8.2 step 9)
+# ---------------------------------------------------------------------------
+
+
+#: Python source roots scanned for ``emit("<event_type>", ...)`` call-sites.
+#: Tests are intentionally excluded — they legitimately construct arbitrary
+#: event-type literals for fixtures.
+_EMIT_SCAN_ROOTS: tuple[str, ...] = ("src/bid_euchre", "scripts", "experiments")
+
+#: Python source files excluded from emit-call-site scanning because they
+#: are the definitions / helpers, not emission call-sites.
+_EMIT_SCAN_EXCLUDE: tuple[str, ...] = (
+    "src/bid_euchre/ops/events.py",
+    "src/bid_euchre/ops/event_schema.py",
+    "src/bid_euchre/ops/event_writer.py",
+    "src/bid_euchre/ops/event_taxonomy.py",
+    "scripts/internal/audit_event_emission.py",
+    "scripts/internal/agent_readability_lint.py",
+)
+
+
+#: Matches ``emit("<type>", ...)`` / ``events.emit("<type>", ...)`` /
+#: ``v1_emit("<type>", ...)``. Capture group 0 is the event type literal,
+#: capture group 1 is the tail of the call (up to a balanced-enough paren).
+_EMIT_CALL_RE = re.compile(
+    r"""
+    (?:\bevents\.emit|\bv1_emit|\bemit)    # callable spellings
+    \s*\(\s*
+    ["'](?P<event_type>[a-z_][a-z0-9_]*)["']
+    (?P<tail>[^)]*)           # remaining kwargs up to closing paren
+    \)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+#: Canonical §9.7 first-class IDs. Routing any of these through
+#: ``extra_fields=`` is a Pattern 8 bug marker — they must land at the
+#: top level of the record per ADR 007.
+_FIRST_CLASS_IDS: frozenset[str] = frozenset(
+    {
+        "project_id",
+        "cell_id",
+        "session_id",
+        "task_id",
+        "lane_id",
+        "trace_id",
+        "incident_fingerprint",
+        "prompt_policy_version",
+        "schema_version",
+    }
+)
+
+
+def _check_emit_call_sites(repo_root: Path) -> list[Finding]:
+    """Scan Python sources for emit() call-sites and produce VC4/VC5 findings.
+
+    VC4 (BLOCK): unknown event_type literal passed to emit(). Only literal
+    strings are checked — dynamic ``emit(type_var, ...)`` usages are
+    out of scope (audit_event_emission.py will catch those through the
+    no-emitter-for-class path instead).
+
+    VC5 (WARN): §9.7 first-class IDs routed through ``extra_fields=``.
+    These must land at the top level per ADR 007 "extra_fields is a bug
+    marker" (Pattern 8).
+    """
+    findings: list[Finding] = []
+    known_types = _load_known_event_types(repo_root)
+    if known_types is None:
+        # Schema module not importable — skip (not a lint failure).
+        return findings
+    for source_path in _iter_emit_scan_files(repo_root):
+        try:
+            text = source_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in _EMIT_CALL_RE.finditer(text):
+            event_type = m.group("event_type")
+            tail = m.group("tail") or ""
+            # Compute line number (1-indexed) for the matched literal.
+            line_no = text[: m.start()].count("\n") + 1
+            # VC4: unknown event_type.
+            if event_type not in known_types:
+                findings.append(
+                    Finding(
+                        severity=Severity.BLOCK,
+                        rule_id="VC4",
+                        path=source_path,
+                        line=line_no,
+                        message=(
+                            f"emit({event_type!r}) — event_type not registered in "
+                            f"EVENT_FIELD_REGISTRY. Either add a spec to "
+                            f"event_schema.py or fix the typo."
+                        ),
+                    )
+                )
+            # VC5: §9.7 ID routed through extra_fields.
+            leaked_ids = _extra_fields_leaked_ids(tail)
+            if leaked_ids:
+                findings.append(
+                    Finding(
+                        severity=Severity.WARN,
+                        rule_id="VC5",
+                        path=source_path,
+                        line=line_no,
+                        message=(
+                            f"emit({event_type!r}) routes §9.7 first-class ID(s) "
+                            f"{sorted(leaked_ids)!r} through extra_fields=; these "
+                            f"must be top-level kwargs (Pattern 8: "
+                            f"extra_fields-is-a-bug-marker)."
+                        ),
+                    )
+                )
+    return findings
+
+
+def _iter_emit_scan_files(repo_root: Path) -> list[Path]:
+    """Enumerate Python files to scan for emit() call-sites."""
+    paths: list[Path] = []
+    excludes = {(repo_root / rel).resolve() for rel in _EMIT_SCAN_EXCLUDE}
+    for rel in _EMIT_SCAN_ROOTS:
+        root = repo_root / rel
+        if not root.exists():
+            continue
+        for py in root.rglob("*.py"):
+            try:
+                resolved = py.resolve()
+            except OSError:
+                continue
+            if resolved in excludes:
+                continue
+            paths.append(py)
+    return paths
+
+
+def _load_known_event_types(repo_root: Path) -> set[str] | None:
+    """Load the set of registered event types from event_schema.py.
+
+    Loads the module directly from its file path at
+    ``<repo_root>/src/bid_euchre/ops/event_schema.py`` (bypassing
+    ``sys.modules`` caching) so lint behaviour is per-repo-root and does
+    not leak state between tmp_path-based tests and the live repo.
+
+    Returns None if the schema file is absent (not a lint failure — a
+    freshly cloned repo may legitimately lack it until Primitive A lands).
+    """
+    import importlib.util
+
+    schema_path = repo_root / "src" / "bid_euchre" / "ops" / "event_schema.py"
+    if not schema_path.exists():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"_arl_schema_{abs(hash(str(schema_path)))}", schema_path
+        )
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except Exception:
+        return None
+    registry = getattr(mod, "EVENT_FIELD_REGISTRY", None)
+    if not isinstance(registry, dict):
+        return None
+    return set(registry.keys())
+
+
+# ``extra_fields={"lane_id": x, ...}`` — pattern for finding §9.7 IDs.
+_EXTRA_FIELDS_BLOCK_RE = re.compile(
+    r"""extra_fields\s*=\s*(?P<block>\{[^{}]*\})""",
+    re.DOTALL,
+)
+
+_ID_KEY_RE = re.compile(r"""["'](?P<key>[a-z_][a-z0-9_]*)["']\s*:""")
+
+
+def _extra_fields_leaked_ids(call_tail: str) -> set[str]:
+    """Return the set of §9.7 IDs routed through ``extra_fields=`` literal
+    dict, if any. Best-effort string-scan (AST not required for lint)."""
+    leaked: set[str] = set()
+    for block_m in _EXTRA_FIELDS_BLOCK_RE.finditer(call_tail):
+        block = block_m.group("block")
+        for key_m in _ID_KEY_RE.finditer(block):
+            key = key_m.group("key")
+            if key in _FIRST_CLASS_IDS:
+                leaked.add(key)
+    return leaked
 
 
 def _bullet_covered(

--- a/scripts/internal/audit_event_emission.py
+++ b/scripts/internal/audit_event_emission.py
@@ -54,11 +54,10 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Ensure ``src/`` is on the import path so ``bid_euchre.ops.event_schema``
-# is resolvable when the script is invoked via ``python scripts/...``.
-sys.path.insert(0, str(REPO_ROOT / "src"))
-
-from bid_euchre.ops.event_schema import (  # noqa: E402
+# Invoke via ``uv run python scripts/internal/audit_event_emission.py`` so
+# ``bid_euchre`` resolves from the project venv (``uv sync`` installs it).
+# ``sys.path`` mutation is forbidden by repo-lint ``no-sys-path-mutation``.
+from bid_euchre.ops.event_schema import (
     EVENT_FIELD_REGISTRY,
     NATIVE_LIFECYCLE_EVENT_TYPES,
     STEWARD_OPERATIONAL_CLASSES,

--- a/scripts/internal/audit_event_emission.py
+++ b/scripts/internal/audit_event_emission.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Event-emission coverage audit (Primitive A Phase 0 Readiness #2).
+
+Walks the codebase + native hook registry and verifies that:
+
+1. All 15 native Claude Code lifecycle hook types (`NATIVE_LIFECYCLE_EVENT_TYPES`)
+   are registered in `.claude/settings.json` with a command that routes
+   through `event_emit.sh` (Tier S absorbed surface per ADR 007 §9.7).
+
+2. All steward operational classes (`STEWARD_OPERATIONAL_CLASSES`) have at
+   least one committed `events.emit(...)` call-site or are explicitly
+   deferred (marked `DEFERRED-TO-PRIMITIVE-<letter>` in a comment within
+   the owning class's block below).
+
+3. Every registered event type in `EVENT_FIELD_REGISTRY` is either
+   (a) the target of a committed `events.emit("<type>", ...)` call,
+   (b) covered transitively via a native hook registration (for the
+   native-lifecycle types), or
+   (c) documented as deferred to a later primitive.
+
+The script prints a ``green`` / ``yellow`` / ``red`` status and exits 0 for
+green (all classes covered), 1 for red (at least one class has zero
+coverage and is not deferred). Yellow (partial coverage; some types still
+deferred) exits 0 to keep Phase 0 kickoff unblocked; yellow is an
+expected intermediate state as Primitives B–G ship the rest of the
+emitters.
+
+Usage::
+
+    uv run python scripts/internal/audit_event_emission.py           # human-readable
+    uv run python scripts/internal/audit_event_emission.py --json    # machine-readable
+    uv run python scripts/internal/audit_event_emission.py --strict  # red on any yellow
+
+Exit codes
+----------
+0 — green or yellow (no hard failures)
+1 — red (at least one class has zero coverage and is not deferred), or
+    --strict was passed and there is at least one yellow class.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Repo + schema imports
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Ensure ``src/`` is on the import path so ``bid_euchre.ops.event_schema``
+# is resolvable when the script is invoked via ``python scripts/...``.
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from bid_euchre.ops.event_schema import (  # noqa: E402
+    EVENT_FIELD_REGISTRY,
+    NATIVE_LIFECYCLE_EVENT_TYPES,
+    STEWARD_OPERATIONAL_CLASSES,
+)
+
+# ---------------------------------------------------------------------------
+# Scan targets
+# ---------------------------------------------------------------------------
+
+#: Directory roots scanned for ``events.emit("...", ...)`` call-sites.
+EMIT_SCAN_ROOTS: tuple[Path, ...] = (
+    REPO_ROOT / "src" / "bid_euchre",
+    REPO_ROOT / "scripts",
+    REPO_ROOT / "experiments",
+    REPO_ROOT / "tests",
+)
+
+#: Native hook registration file.
+CLAUDE_SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+
+#: Hook script that must appear as the command for every native hook event
+#: registration.
+HOOK_DISPATCHER_NAME = "event_emit.sh"
+
+#: Mapping from native v1.0 event_type to the corresponding Claude Code
+#: top-level hook section key.  Required because the Claude Code hook
+#: schema uses CamelCase keys while the event_type strings use snake_case.
+NATIVE_EVENT_TO_HOOK_SECTION: dict[str, str] = {
+    "pre_tool_use": "PreToolUse",
+    "post_tool_use": "PostToolUse",
+    "post_tool_use_failure": "PostToolUseFailure",
+    "permission_request": "PermissionRequest",
+    "permission_denied": "PermissionDenied",
+    "notification": "Notification",
+    "user_prompt_submit": "UserPromptSubmit",
+    "stop": "Stop",
+    "stop_failure": "StopFailure",
+    "subagent_start": "SubagentStart",
+    "subagent_stop": "SubagentStop",
+    "pre_compact": "PreCompact",
+    "session_start": "SessionStart",
+    "session_end": "SessionEnd",
+    "teammate_idle": "TeammateIdle",
+}
+
+#: Event types whose emitter is deferred to a later primitive.  Keyed by
+#: the class name; value is the letter of the primitive that owns the
+#: emitter.  Audit reports these as "deferred" (yellow) rather than
+#: "missing" (red).
+DEFERRED_CLASSES: dict[str, str] = {
+    "canary_lifecycle": "E",  # Primitive E owns canary framework
+    "archivist_lifecycle": "F",  # Primitive F owns archivist
+    "promotion_lifecycle": "F",  # Primitive F owns promotion gate
+    "rollback_lifecycle": "F",  # Primitive F owns rollback orchestration
+    "latency_measurements": "A",  # Primitive A completion (this packet)
+    "worktree_lifecycle": "G",  # Primitive G owns worktree lifecycle
+}
+
+
+# ---------------------------------------------------------------------------
+# Emit call-site scanner
+# ---------------------------------------------------------------------------
+
+# Matches both ``events.emit("type", ...)`` and ``emit("type", ...)``
+# call-sites.  Keeps the pattern deliberately simple — complex parsing
+# (full AST walking) is overkill for a coverage audit and would couple the
+# script to module-import state.
+_EMIT_CALL_RE = re.compile(
+    r"""
+    (?:\bevents\.emit|\bemit|\bv1_emit)   # callable: events.emit | emit | v1_emit
+    \s*\(\s*                              # opening paren + optional whitespace
+    ["']                                  # opening quote
+    (?P<event_type>[a-z_][a-z0-9_]*)      # event_type literal
+    ["']                                  # closing quote
+    """,
+    re.VERBOSE,
+)
+
+
+def scan_emit_call_sites(roots: tuple[Path, ...]) -> dict[str, list[Path]]:
+    """Scan the repository for ``emit("<type>", ...)`` call-sites.
+
+    Returns a mapping ``event_type → [file_path, ...]`` of files containing
+    at least one committed call-site for that event type.  The audit
+    module itself is excluded to avoid self-registration.
+    """
+    found: dict[str, set[Path]] = {}
+    self_path = Path(__file__).resolve()
+    for root in roots:
+        if not root.exists():
+            continue
+        for py_file in root.rglob("*.py"):
+            try:
+                resolved = py_file.resolve()
+            except OSError:
+                continue
+            if resolved == self_path:
+                continue
+            try:
+                text = py_file.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for match in _EMIT_CALL_RE.finditer(text):
+                event_type = match.group("event_type")
+                found.setdefault(event_type, set()).add(py_file)
+    return {k: sorted(v) for k, v in found.items()}
+
+
+# ---------------------------------------------------------------------------
+# Native hook registration scanner
+# ---------------------------------------------------------------------------
+
+
+def scan_native_hook_registrations(
+    settings_path: Path,
+) -> dict[str, bool]:
+    """Return which native lifecycle event types have event_emit.sh wired.
+
+    For each entry in ``NATIVE_LIFECYCLE_EVENT_TYPES``, walks
+    ``settings.json`` -> ``hooks.<HookSection>`` and returns True iff any
+    registered hook command contains the HOOK_DISPATCHER_NAME constant.
+    """
+    result: dict[str, bool] = dict.fromkeys(NATIVE_LIFECYCLE_EVENT_TYPES, False)
+    if not settings_path.exists():
+        return result
+    try:
+        cfg = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return result
+    hooks = cfg.get("hooks") or {}
+    if not isinstance(hooks, dict):
+        return result
+    for event_type, section in NATIVE_EVENT_TO_HOOK_SECTION.items():
+        bucket = hooks.get(section) or []
+        found = False
+        for group in bucket:
+            if not isinstance(group, dict):
+                continue
+            for hook in group.get("hooks") or []:
+                if not isinstance(hook, dict):
+                    continue
+                cmd = hook.get("command") or ""
+                if HOOK_DISPATCHER_NAME in cmd:
+                    found = True
+                    break
+            if found:
+                break
+        result[event_type] = found
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Coverage roll-up
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CoverageResult:
+    """Per-class coverage summary."""
+
+    class_name: str
+    status: str  # "green" | "yellow" | "red"
+    covered_types: list[str] = field(default_factory=list)
+    missing_types: list[str] = field(default_factory=list)
+    deferred_to: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "class_name": self.class_name,
+            "status": self.status,
+            "covered_types": self.covered_types,
+            "missing_types": self.missing_types,
+            "deferred_to": self.deferred_to,
+        }
+
+
+@dataclass
+class AuditReport:
+    """Top-level audit output."""
+
+    overall: str  # "green" | "yellow" | "red"
+    native_hook_coverage_pct: float
+    native_hooks_missing: list[str]
+    classes: list[CoverageResult]
+    emit_call_site_count: int
+    registered_event_types: int
+    covered_event_types: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "overall": self.overall,
+            "native_hook_coverage_pct": self.native_hook_coverage_pct,
+            "native_hooks_missing": self.native_hooks_missing,
+            "classes": [c.to_dict() for c in self.classes],
+            "emit_call_site_count": self.emit_call_site_count,
+            "registered_event_types": self.registered_event_types,
+            "covered_event_types": self.covered_event_types,
+        }
+
+
+def _classify_class(
+    class_name: str,
+    members: tuple[str, ...],
+    emit_sites: dict[str, list[Path]],
+    native_hook_status: dict[str, bool],
+) -> CoverageResult:
+    covered: list[str] = []
+    missing: list[str] = []
+    for t in members:
+        if t in emit_sites and emit_sites[t]:
+            covered.append(t)
+        elif native_hook_status.get(t, False):
+            covered.append(t)
+        else:
+            missing.append(t)
+    if not missing:
+        status = "green"
+        deferred_to = None
+    elif class_name in DEFERRED_CLASSES:
+        status = "yellow"
+        deferred_to = DEFERRED_CLASSES[class_name]
+    elif covered:
+        status = "yellow"
+        deferred_to = None
+    else:
+        status = "red"
+        deferred_to = None
+    return CoverageResult(
+        class_name=class_name,
+        status=status,
+        covered_types=covered,
+        missing_types=missing,
+        deferred_to=deferred_to,
+    )
+
+
+def build_audit_report(
+    emit_sites: dict[str, list[Path]],
+    native_hook_status: dict[str, bool],
+) -> AuditReport:
+    """Compose the audit report from scanned inputs."""
+    classes = [
+        _classify_class(name, members, emit_sites, native_hook_status)
+        for name, members in STEWARD_OPERATIONAL_CLASSES.items()
+    ]
+    # Overall status: red if any class is red; yellow if any are yellow;
+    # green otherwise.
+    statuses = {c.status for c in classes}
+    if "red" in statuses:
+        overall = "red"
+    elif "yellow" in statuses:
+        overall = "yellow"
+    else:
+        overall = "green"
+
+    native_missing = [t for t, ok in native_hook_status.items() if not ok]
+    native_pct = (
+        100.0
+        * (len(NATIVE_LIFECYCLE_EVENT_TYPES) - len(native_missing))
+        / max(1, len(NATIVE_LIFECYCLE_EVENT_TYPES))
+    )
+    if native_missing and overall == "green":
+        overall = "yellow"
+
+    all_registered = set(EVENT_FIELD_REGISTRY.keys())
+    covered_types: set[str] = set()
+    for t in all_registered:
+        if t in emit_sites and emit_sites[t]:
+            covered_types.add(t)
+        if native_hook_status.get(t, False):
+            covered_types.add(t)
+
+    return AuditReport(
+        overall=overall,
+        native_hook_coverage_pct=native_pct,
+        native_hooks_missing=native_missing,
+        classes=classes,
+        emit_call_site_count=sum(len(v) for v in emit_sites.values()),
+        registered_event_types=len(all_registered),
+        covered_event_types=len(covered_types),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pretty-printing
+# ---------------------------------------------------------------------------
+
+
+def format_report(report: AuditReport) -> str:
+    """Return a human-readable summary string."""
+    symbol = {"green": "✓", "yellow": "◐", "red": "✗"}[report.overall]
+    lines: list[str] = [
+        f"Event-emission coverage audit  [{symbol} {report.overall.upper()}]",
+        "=" * 66,
+        (
+            f"Native lifecycle hooks: "
+            f"{len(NATIVE_LIFECYCLE_EVENT_TYPES) - len(report.native_hooks_missing)} "
+            f"of {len(NATIVE_LIFECYCLE_EVENT_TYPES)} subscribed "
+            f"({report.native_hook_coverage_pct:.1f}%)"
+        ),
+    ]
+    if report.native_hooks_missing:
+        lines.append("  missing: " + ", ".join(sorted(report.native_hooks_missing)))
+    lines.append("")
+    lines.append("Steward operational classes:")
+    for c in report.classes:
+        csym = {"green": "✓", "yellow": "◐", "red": "✗"}[c.status]
+        deferred = f" (deferred → Primitive {c.deferred_to})" if c.deferred_to else ""
+        lines.append(
+            f"  [{csym}] {c.class_name:24s} "
+            f"{len(c.covered_types)}/{len(c.covered_types) + len(c.missing_types)} "
+            f"covered{deferred}"
+        )
+        if c.missing_types:
+            lines.append("       missing: " + ", ".join(c.missing_types))
+    lines.append("")
+    lines.append(
+        f"Event-type coverage: "
+        f"{report.covered_event_types}/{report.registered_event_types} "
+        f"registered types have ≥1 emitter"
+    )
+    lines.append(f"Total committed emit() call-sites: {report.emit_call_site_count}")
+    lines.append("")
+    if report.overall == "green":
+        lines.append(
+            "all 15 native lifecycle hooks subscribed; "
+            f"all {len(STEWARD_OPERATIONAL_CLASSES)} steward operational "
+            "classes emit at least one call-site"
+        )
+    elif report.overall == "yellow":
+        lines.append(
+            "coverage partial — classes deferred to later primitives or "
+            "still ramping up emission. Not blocking Phase 0 kickoff."
+        )
+    else:
+        lines.append(
+            "coverage RED — at least one class has no committed emitter "
+            "and is not marked as deferred. Fix before Phase 0 kickoff."
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Event-emission coverage audit (Primitive A Phase 0)."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a human summary.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on yellow (any missing coverage, not just red).",
+    )
+    parser.add_argument(
+        "--settings",
+        type=Path,
+        default=CLAUDE_SETTINGS,
+        help="Path to .claude/settings.json (default: repo default).",
+    )
+    parser.add_argument(
+        "--scan-root",
+        type=Path,
+        action="append",
+        default=None,
+        help=(
+            "Directory root to scan for emit() call-sites (repeatable). "
+            "Defaults to src/, scripts/, experiments/, tests/."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    roots = tuple(args.scan_root) if args.scan_root else EMIT_SCAN_ROOTS
+    emit_sites = scan_emit_call_sites(roots)
+    native_status = scan_native_hook_registrations(args.settings)
+    report = build_audit_report(emit_sites, native_status)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(format_report(report), end="")
+
+    if report.overall == "red":
+        return 1
+    if args.strict and report.overall == "yellow":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1884,8 +1884,13 @@ def cmd_task(args: argparse.Namespace) -> int:
         # detail provided on the CLI so downstream consumers (outcome-join
         # reporting, adaptive dispatch scorer) can compare recommendation vs
         # actual routing without re-reading archived packets.
+        #
+        # Phase 0 dual-write (Primitive A §8.2 step 7): call the new
+        # `events.emit()` v1.0 dispatcher AND the legacy `append_event`.
+        # Both are best-effort; failures never block completion.
         try:
             from bid_euchre.ops.events import append_event
+            from bid_euchre.ops.events import emit as v1_emit
             from bid_euchre.ops.task_queue import (
                 get_complexity,
                 get_effort_hint,
@@ -1916,6 +1921,35 @@ def cmd_task(args: argparse.Namespace) -> int:
                 "shipped_outcome": shipped_outcome,
             }
 
+            # v1.0 dispatcher (new path, writes to data/events/).
+            try:
+                v1_emit(
+                    "task_completed",
+                    packet_id=packet_id,
+                    outcome=(shipped_outcome or "completed"),
+                    pr_number=pr_number,
+                    source="steward",
+                    title=pkt.title,
+                    summary=summary,
+                    completed_by=payload["completed_by"],
+                    task_type=payload["task_type"],
+                    complexity_estimate=payload["complexity_estimate"],
+                    model_hint=payload["model_hint"],
+                    effort_hint=payload["effort_hint"],
+                    actual_lane=actual_lane,
+                    recommended_lane=recommended_lane,
+                    token_spend=token_spend,
+                    elapsed_seconds=elapsed_seconds,
+                    review_rounds=review_rounds,
+                    shipped_outcome=shipped_outcome,
+                    lane_id=actual_lane,
+                )
+            except Exception:
+                # emit() is never-raises per contract; defensive guard.
+                pass
+
+            # Legacy pipeline (existing path, writes to
+            # .claude/runtime/events/). Kept until legacy consumers migrate.
             append_event(
                 event_type="task_completed",
                 source="ops.task_complete",
@@ -2075,7 +2109,33 @@ def _cmd_task_accept(args: argparse.Namespace) -> int:
         # Duplicate message_id — already sent
         steps_done.append("ack already sent to orchestrator")
 
-    # 4. Emit task_started event (always — events are append-only)
+    # 4. Emit task_started event (always — events are append-only).
+    #
+    # Phase 0 dual-write (Primitive A §8.2 step 7): call the new
+    # `events.emit()` v1.0 dispatcher AND the legacy `append_event`
+    # so legacy consumers (~25 files under scripts/internal/ and
+    # src/bid_euchre/ops/) continue to read from the legacy pipeline
+    # while the v1.0 event stream bootstraps under data/events/.
+    # Both calls are best-effort; failures do not block task accept.
+    try:
+        from bid_euchre.ops.events import emit as v1_emit
+
+        v1_emit(
+            "task_started",
+            packet_id=packet_id,
+            dispatched_by=pkt.created_by,
+            priority=pkt.priority,
+            domain=pkt.domain,
+            task_type=(pkt.metadata or {}).get("task_type"),
+            complexity_estimate=(pkt.metadata or {}).get("complexity_estimate"),
+            model_hint=(pkt.metadata or {}).get("model_hint"),
+            effort_hint=(pkt.metadata or {}).get("effort_hint"),
+            lane_id=lane_id,
+        )
+    except Exception:
+        # emit() is never-raises per contract; defensive guard.
+        pass
+
     try:
         append_event(
             event_type="task_started",

--- a/src/bid_euchre/ops/dashboard.py
+++ b/src/bid_euchre/ops/dashboard.py
@@ -282,6 +282,11 @@ class DashboardView:
     warning_count: int = 0
     token_economy: dict[str, Any] = field(default_factory=dict)
     canary: CanarySummary = field(default_factory=lambda: CanarySummary())
+    #: Latency-panel summary (Primitive A, per shaping §8.2 step 10).
+    #: Shape: ``{<metric_key>: {"count": N, "p50_ms": X, "p95_ms": Y}}``
+    #: where metric_key is ``event_to_signal`` or ``bus_delivery``. Empty
+    #: when ``data/events/`` has no latency events or does not exist.
+    latencies: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +468,123 @@ def _derive_inbox_highlights(
     return highlights
 
 
+# ---------------------------------------------------------------------------
+# Latencies panel (Primitive A, per shaping §8.2 step 10)
+# ---------------------------------------------------------------------------
+
+
+#: Event types that carry latency measurements (registered in Primitive A).
+#: Maps the dashboard metric key to ``(event_type, field_name)``.
+_LATENCY_EVENT_FIELDS: dict[str, tuple[str, str]] = {
+    "event_to_signal": ("event_to_signal_latency", "latency_ms"),
+    "bus_delivery": ("bus_delivery_latency", "delivery_ms"),
+}
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Return the ``pct``-th percentile of ``values`` (linear interpolation).
+
+    ``pct`` is in [0, 100]. The input list must be non-empty; callers are
+    responsible for guarding on that. Values are sorted internally.
+    """
+    if not values:
+        raise ValueError("_percentile called on empty list")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    frac = rank - low
+    return float(ordered[low] + (ordered[high] - ordered[low]) * frac)
+
+
+def _load_latency_summary(
+    events_dir: Path | None = None,
+    *,
+    max_files: int = 5,
+) -> dict[str, Any]:
+    """Scan recent event JSONL files and return per-metric latency stats.
+
+    Reads up to the most recent ``max_files`` JSONL files in ``events_dir``
+    (sorted by filename, which sorts date-then-counter ascending), skimming
+    each line for records whose ``event_type`` matches a registered latency
+    event. Computes count / p50 / p95 per metric.
+
+    Args:
+        events_dir: Log directory. Defaults to ``STEWARD_EVENTS_LOG_DIR``
+            env var or ``data/events/``.
+        max_files: Upper bound on JSONL files scanned (most recent first).
+            Guards against unbounded work on large historical archives.
+
+    Returns:
+        Dict shaped ``{metric_key: {"count": N, "p50_ms": X, "p95_ms": Y}}``.
+        Empty dict if the directory is missing, has no JSONL files, or
+        contains no latency events. Never raises — any parse failure on a
+        single line is skipped silently (best-effort read path).
+    """
+    if events_dir is None:
+        override = os.environ.get("STEWARD_EVENTS_LOG_DIR")
+        events_dir = Path(override) if override else Path("data/events")
+
+    if not events_dir.exists() or not events_dir.is_dir():
+        return {}
+
+    # Sorted ascending by filename (events-YYYY-MM-DD-NNN.jsonl); take the
+    # last ``max_files`` which are the most recent by date+counter.
+    try:
+        jsonl_files = sorted(events_dir.glob("events-*.jsonl"))
+    except OSError:
+        return {}
+    if not jsonl_files:
+        return {}
+    recent = jsonl_files[-max_files:]
+
+    # Collect raw values per metric key.
+    buckets: dict[str, list[float]] = {key: [] for key in _LATENCY_EVENT_FIELDS}
+    type_to_key = {
+        event_type: (key, field_name)
+        for key, (event_type, field_name) in _LATENCY_EVENT_FIELDS.items()
+    }
+
+    for path in recent:
+        try:
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    event_type = record.get("event_type")
+                    if event_type not in type_to_key:
+                        continue
+                    key, field_name = type_to_key[event_type]
+                    value = record.get(field_name)
+                    if value is None:
+                        continue
+                    try:
+                        buckets[key].append(float(value))
+                    except (TypeError, ValueError):
+                        continue
+        except OSError:
+            continue
+
+    # Summarize (skip metrics with zero samples to keep the panel terse).
+    summary: dict[str, Any] = {}
+    for key, values in buckets.items():
+        if not values:
+            continue
+        summary[key] = {
+            "count": len(values),
+            "p50_ms": round(_percentile(values, 50.0), 2),
+            "p95_ms": round(_percentile(values, 95.0), 2),
+        }
+    return summary
+
+
 def build_dashboard_view(
     runtime_dir: Path | None = None,
     *,
@@ -529,6 +651,15 @@ def build_dashboard_view(
         canary_runtime_root / "canary_state" / "dogfood_v1.json"
     )
 
+    # Latencies panel (Primitive A, per shaping §8.2 step 10).
+    # Best-effort: a missing or unreadable events dir yields an empty
+    # panel — never fail dashboard render on telemetry-store state.
+    latencies: dict[str, Any] = {}
+    try:
+        latencies = _load_latency_summary()
+    except Exception:  # pragma: no cover — defensive
+        logger.debug("latency summary load failed", exc_info=True)
+
     return DashboardView(
         generated_at=now.isoformat(),
         foreground=DashboardSection(
@@ -547,6 +678,7 @@ def build_dashboard_view(
         warning_count=len(report.warnings),
         token_economy=token_economy,
         canary=canary,
+        latencies=latencies,
     )
 
 
@@ -943,6 +1075,23 @@ def format_dashboard_text(
                 sev = ap.get("severity", "?")
                 lines.append(f"    [{sev}] {ap.get('name', '?')}")
 
+    # Latencies panel (Primitive A). Hidden when no samples are present —
+    # an empty telemetry store is the steady state before emission is
+    # widespread, so rendering an empty panel would just add noise.
+    lat = view.latencies
+    if lat:
+        lines.append("")
+        lines.append("Latencies")
+        for key, stats in sorted(lat.items()):
+            count = stats.get("count", 0)
+            p50 = stats.get("p50_ms")
+            p95 = stats.get("p95_ms")
+            p50_str = f"{p50:.1f}ms" if isinstance(p50, (int, float)) else "—"
+            p95_str = f"{p95:.1f}ms" if isinstance(p95, (int, float)) else "—"
+            lines.append(
+                f"  {key:<18s} p50={p50_str:<8s}  p95={p95_str:<8s}  n={count}"
+            )
+
     return "\n".join(lines)
 
 
@@ -979,4 +1128,5 @@ def format_dashboard_json(view: DashboardView) -> dict[str, Any]:
         "task_queue": view.task_queue_summary,
         "token_economy": view.token_economy or None,
         "canary": asdict(view.canary),
+        "latencies": view.latencies or None,
     }

--- a/src/bid_euchre/ops/event_schema.py
+++ b/src/bid_euchre/ops/event_schema.py
@@ -1,0 +1,398 @@
+"""Event Schema v1.0 for steward observability (Primitive A).
+
+This module is the canonical source of truth for the v1.0 event catalog,
+the per-event-type field contract, and the §9.7 first-class IDs that
+every event record carries as top-level fields.
+
+See ``plans/steward_platform/1_primitive_A/shaping.md`` §2 for the
+design, and ADR 007 (observability dispatcher pattern) for the
+underlying decision.
+
+**Version policy:**
+
+- ``SCHEMA_VERSION = "1.0"`` is the Phase 0 Readiness target.
+- Additive evolutions (new event types; new fields on existing types;
+  new top-level correlation fields with default values) are ``v1.N`` and
+  remain replay-compatible. Bump ``SCHEMA_VERSION`` when adding.
+- Breaking changes require ``v2.0`` + migration plan + ADR.
+
+**Top-level §9.7 IDs (§2.3 of shaping):** every event record carries
+nine first-class identity fields (``project_id``, ``cell_id``,
+``session_id``, ``task_id``, ``lane_id``, ``trace_id``,
+``incident_fingerprint``, ``prompt_policy_version``, ``schema_version``)
+regardless of event type. ``extra_fields`` is a **bug marker**, not a
+fallback: known emitters must populate fields into the registry's
+declared slots.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Version constant
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION: str = "1.0"
+"""Current schema version. Bumped additively for v1.N; bumped to v2.0 on
+breaking change (requires migration adapter in Primitive H.1)."""
+
+
+# ---------------------------------------------------------------------------
+# Verbosity tiers (ADR 007 adopted pattern; §3.3 of shaping)
+# ---------------------------------------------------------------------------
+
+VerbosityTier = Literal["minimal", "summary", "full"]
+
+VERBOSITY_TIERS: tuple[VerbosityTier, ...] = ("minimal", "summary", "full")
+"""Allowed verbosity levels: ``minimal`` (~200 B), ``summary`` (~500 B),
+``full`` (1-50 KB). Selection per §3.3 of shaping."""
+
+
+# ---------------------------------------------------------------------------
+# §9.7 first-class IDs (§2.3 of shaping)
+# ---------------------------------------------------------------------------
+
+FIRST_CLASS_ID_FIELDS: tuple[str, ...] = (
+    "project_id",
+    "cell_id",
+    "session_id",
+    "task_id",
+    "lane_id",
+    "trace_id",
+    "incident_fingerprint",
+    "prompt_policy_version",
+    "schema_version",
+)
+"""Nine §9.7 identity fields that must be present (may be ``null``) on
+every event record. Emissions that route a §9.7 ID through
+``extra_fields`` are a Pattern 8 bug-marker violation.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Correlation fields (ADR 007 adopted; §2.4 of shaping)
+# ---------------------------------------------------------------------------
+
+CORRELATION_FIELDS: tuple[str, ...] = ("seq", "pid", "timestamp_ns", "turn_id")
+"""Four correlation fields set by the dispatcher; drive event ordering
+and per-session turn bounding."""
+
+
+# ---------------------------------------------------------------------------
+# EventTypeSpec dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EventTypeSpec:
+    """Per-event-type contract row.
+
+    ``required_fields`` and ``optional_fields`` are *beyond* the baseline
+    ``FIRST_CLASS_ID_FIELDS + CORRELATION_FIELDS + ("event_type",)``, which
+    every event carries. A field listed in ``required_fields`` must be
+    passed to ``events.emit()`` by the caller (or dispatcher rejects the
+    emission).
+    """
+
+    required_fields: tuple[str, ...] = field(default_factory=tuple)
+    optional_fields: tuple[str, ...] = field(default_factory=tuple)
+    verbosity_default: VerbosityTier = "summary"
+    schema_version_added: str = "1.0"
+    replay_compat_window: str = "v1.x"
+
+    def known_field(self, name: str) -> bool:
+        """Return True if ``name`` is a registered known field for this type."""
+        return name in self.required_fields or name in self.optional_fields
+
+
+# ---------------------------------------------------------------------------
+# EVENT_FIELD_REGISTRY — 35 event types in v1.0
+# ---------------------------------------------------------------------------
+
+# Baseline fields every event carries (populated by the dispatcher itself).
+BASELINE_FIELDS: frozenset[str] = frozenset(
+    FIRST_CLASS_ID_FIELDS + CORRELATION_FIELDS + ("event_type",)
+)
+
+EVENT_FIELD_REGISTRY: dict[str, EventTypeSpec] = {
+    # -----------------------------------------------------------------------
+    # Native Claude Code lifecycle hook events (§2.2 rows 1-15)
+    # -----------------------------------------------------------------------
+    "pre_tool_use": EventTypeSpec(
+        required_fields=("tool_name", "tool_input"),
+        optional_fields=("tool_use_id",),
+        verbosity_default="minimal",
+    ),
+    "post_tool_use": EventTypeSpec(
+        required_fields=("tool_name", "tool_input", "tool_response"),
+        optional_fields=("tool_use_id", "duration_ms"),
+        verbosity_default="minimal",
+    ),
+    "post_tool_use_failure": EventTypeSpec(
+        required_fields=("tool_name", "tool_input", "error", "error_category"),
+        optional_fields=("tool_use_id", "is_interrupt"),
+        verbosity_default="summary",
+    ),
+    "permission_request": EventTypeSpec(
+        required_fields=("tool_name", "tool_input", "permission_suggestions"),
+    ),
+    "permission_denied": EventTypeSpec(
+        required_fields=("tool_name", "tool_input", "denial_reason"),
+    ),
+    "notification": EventTypeSpec(
+        required_fields=("message",),
+        optional_fields=("notification_id",),
+    ),
+    "user_prompt_submit": EventTypeSpec(
+        required_fields=("prompt",),
+        verbosity_default="full",
+    ),
+    "stop": EventTypeSpec(
+        required_fields=("stop_hook_active",),
+        optional_fields=("last_assistant_message",),
+    ),
+    "stop_failure": EventTypeSpec(
+        required_fields=("stop_hook_active", "failure_category"),
+        optional_fields=("last_assistant_message",),
+    ),
+    "subagent_start": EventTypeSpec(
+        required_fields=("agent_id", "agent_type"),
+        optional_fields=("parent_agent_id", "agent_transcript_path"),
+    ),
+    "subagent_stop": EventTypeSpec(
+        required_fields=("agent_id", "agent_type"),
+        optional_fields=("parent_agent_id", "agent_transcript_path"),
+    ),
+    "pre_compact": EventTypeSpec(
+        required_fields=("trigger",),
+        optional_fields=("custom_instructions",),
+    ),
+    "session_start": EventTypeSpec(
+        required_fields=("source", "model", "archetype"),
+        optional_fields=("agent_type",),
+    ),
+    "session_end": EventTypeSpec(
+        required_fields=("reason",),
+        optional_fields=("last_assistant_message",),
+    ),
+    "teammate_idle": EventTypeSpec(
+        required_fields=("teammate_name", "idle_seconds"),
+        optional_fields=("team_name",),
+    ),
+    # -----------------------------------------------------------------------
+    # Steward task-lifecycle events (§2.2 rows 16-17)
+    # -----------------------------------------------------------------------
+    "task_started": EventTypeSpec(
+        required_fields=("packet_id", "dispatched_by", "priority", "domain"),
+        optional_fields=(
+            "effort_hint",
+            "model_hint",
+            "task_type",
+            "complexity_estimate",
+        ),
+    ),
+    "task_completed": EventTypeSpec(
+        required_fields=("packet_id", "outcome"),
+        optional_fields=(
+            "pr_number",
+            "merged_at",
+            "source",  # "steward" | "native" — native+steward merged per §2.2
+            "title",
+            "summary",
+            "completed_by",
+            "task_type",
+            "complexity_estimate",
+            "model_hint",
+            "effort_hint",
+            "actual_lane",
+            "recommended_lane",
+            "token_spend",
+            "elapsed_seconds",
+            "review_rounds",
+            "shipped_outcome",
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    # Worktree events (§2.2 row 18; emitters land in Primitive G)
+    # -----------------------------------------------------------------------
+    "worktree_create": EventTypeSpec(
+        required_fields=("worktree_path", "branch", "protected"),
+    ),
+    "worktree_remove": EventTypeSpec(
+        required_fields=("worktree_path", "branch", "protected"),
+    ),
+    # -----------------------------------------------------------------------
+    # Canary lifecycle (4 types; owning primitive H.0)
+    # -----------------------------------------------------------------------
+    "canary_run_start": EventTypeSpec(
+        required_fields=("canary_id", "trigger", "canary_version"),
+    ),
+    "canary_run_complete": EventTypeSpec(
+        required_fields=(
+            "canary_id",
+            "success",
+            "elapsed_seconds",
+            "pass_metrics",
+            "event_type_hash",
+        ),
+    ),
+    "canary_run_fail": EventTypeSpec(
+        required_fields=("canary_id", "failed_assertions", "elapsed_seconds"),
+    ),
+    "canary_rollback_complete": EventTypeSpec(
+        required_fields=("canary_id", "rollback_pr"),
+    ),
+    # -----------------------------------------------------------------------
+    # Archivist lifecycle (4 types; owning primitive D)
+    # -----------------------------------------------------------------------
+    "archivist_candidate_proposed": EventTypeSpec(
+        required_fields=("candidate_path", "candidate_class"),
+        optional_fields=("source_event_ids",),
+    ),
+    "archivist_candidate_promoted": EventTypeSpec(
+        required_fields=("candidate_path", "promoted_path"),
+        optional_fields=("operator",),
+    ),
+    "archivist_candidate_rejected": EventTypeSpec(
+        required_fields=("candidate_path", "rejection_reason"),
+        optional_fields=("operator",),
+    ),
+    "archivist_gc_proposed": EventTypeSpec(
+        required_fields=("candidate_path", "gc_class"),
+        optional_fields=("target_paths",),
+    ),
+    # -----------------------------------------------------------------------
+    # Promotion lifecycle (4 types; owning primitives F + B)
+    # -----------------------------------------------------------------------
+    "promotion_evaluated": EventTypeSpec(
+        required_fields=("candidate_id", "gates", "verdict"),
+        optional_fields=("evidence_paths",),
+    ),
+    "promotion_passed": EventTypeSpec(
+        required_fields=("candidate_id", "verdict_ids"),
+    ),
+    "promotion_failed": EventTypeSpec(
+        required_fields=("candidate_id", "verdict_ids"),
+    ),
+    "promotion_rolled_back": EventTypeSpec(
+        required_fields=("candidate_id", "rollback_pr", "reason"),
+    ),
+    # -----------------------------------------------------------------------
+    # Rollback lifecycle (3 types; owning primitive G + per-primitive)
+    # -----------------------------------------------------------------------
+    "rollback_initiated": EventTypeSpec(
+        required_fields=("change_id", "rollback_class"),
+    ),
+    "rollback_completed": EventTypeSpec(
+        required_fields=("change_id", "rollback_pr"),
+        optional_fields=("forward_event_ids", "reverse_event_ids"),
+    ),
+    "rollback_validated": EventTypeSpec(
+        required_fields=("change_id", "validation_method"),
+    ),
+    # -----------------------------------------------------------------------
+    # Latency measurements (2 types; self-instrumentation by Primitive A)
+    # -----------------------------------------------------------------------
+    "event_to_signal_latency": EventTypeSpec(
+        required_fields=("source_event_id", "signal_type", "latency_ms"),
+        verbosity_default="minimal",
+    ),
+    "bus_delivery_latency": EventTypeSpec(
+        required_fields=("message_id", "delivery_ms"),
+        verbosity_default="minimal",
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Registry introspection helpers
+# ---------------------------------------------------------------------------
+
+
+def is_known_event_type(event_type: str) -> bool:
+    """Return True if ``event_type`` is registered in v1.0."""
+    return event_type in EVENT_FIELD_REGISTRY
+
+
+def get_spec(event_type: str) -> EventTypeSpec | None:
+    """Return the :class:`EventTypeSpec` for ``event_type`` or None."""
+    return EVENT_FIELD_REGISTRY.get(event_type)
+
+
+def registered_types() -> tuple[str, ...]:
+    """Return a sorted tuple of all registered event types."""
+    return tuple(sorted(EVENT_FIELD_REGISTRY))
+
+
+def baseline_fields() -> frozenset[str]:
+    """Return the baseline fields populated on every event record."""
+    return BASELINE_FIELDS
+
+
+def known_field_for_event(event_type: str, field_name: str) -> bool:
+    """Return True if ``field_name`` is a registered slot for ``event_type``.
+
+    This check excludes baseline fields (see :func:`baseline_fields`);
+    the registry is scanned for per-event-type required/optional slots.
+    """
+    spec = get_spec(event_type)
+    if spec is None:
+        return False
+    return spec.known_field(field_name)
+
+
+# Coverage classes (§2.2 of shaping): used by audit_event_emission.py
+# to verify the ≥4 steward operational classes expected at Phase 0.
+STEWARD_OPERATIONAL_CLASSES: dict[str, tuple[str, ...]] = {
+    "task_lifecycle": ("task_started", "task_completed"),
+    "canary_lifecycle": (
+        "canary_run_start",
+        "canary_run_complete",
+        "canary_run_fail",
+        "canary_rollback_complete",
+    ),
+    "archivist_lifecycle": (
+        "archivist_candidate_proposed",
+        "archivist_candidate_promoted",
+        "archivist_candidate_rejected",
+        "archivist_gc_proposed",
+    ),
+    "promotion_lifecycle": (
+        "promotion_evaluated",
+        "promotion_passed",
+        "promotion_failed",
+        "promotion_rolled_back",
+    ),
+    "rollback_lifecycle": (
+        "rollback_initiated",
+        "rollback_completed",
+        "rollback_validated",
+    ),
+    "latency_measurements": (
+        "event_to_signal_latency",
+        "bus_delivery_latency",
+    ),
+    "worktree_lifecycle": ("worktree_create", "worktree_remove"),
+}
+
+# Native Claude Code lifecycle hook event types — the 15 absorbed at v1.0
+# per shaping §4.1 (the `task_completed` row is merged with steward, so
+# it's counted under `task_lifecycle` above and not duplicated here).
+NATIVE_LIFECYCLE_EVENT_TYPES: tuple[str, ...] = (
+    "pre_tool_use",
+    "post_tool_use",
+    "post_tool_use_failure",
+    "permission_request",
+    "permission_denied",
+    "notification",
+    "user_prompt_submit",
+    "stop",
+    "stop_failure",
+    "subagent_start",
+    "subagent_stop",
+    "pre_compact",
+    "session_start",
+    "session_end",
+    "teammate_idle",
+)

--- a/src/bid_euchre/ops/event_taxonomy.py
+++ b/src/bid_euchre/ops/event_taxonomy.py
@@ -1,0 +1,332 @@
+"""Event taxonomy helpers (Primitive A).
+
+Per shaping §3.6-§3.7 (ADR 007 adopted pattern):
+
+- :func:`categorize_error` — stable taxonomy for mapping a free-form
+  error string to one of five buckets. Used by
+  ``post_tool_use_failure.error_category``,
+  ``stop_failure.failure_category``, ``task_completed.outcome`` (when
+  outcome=failed), and incident-fingerprint generation.
+
+- :func:`build_status_message` — one-line human-readable summary for
+  ``notification`` events, the ``triaging-issues`` skill, the
+  dashboard's recent-events panel, and archivist candidate-lesson
+  templating.
+
+- :func:`incident_fingerprint` — deterministic hash of the incident
+  signature, used by the ``triaging-issues`` skill to dedupe repeat
+  incidents across time. Null/empty inputs produce ``None``.
+
+These helpers are pure: no I/O, no environment reads, no side effects.
+Callers in ``events.emit`` and downstream consumers receive pure string
+outputs, which keeps the taxonomy testable in isolation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Category taxonomy (shaping §3.6)
+# ---------------------------------------------------------------------------
+
+#: Canonical error-category labels. Order reflects triage priority:
+#: interrupted (user-initiated) first, then timeout / permission denial /
+#: execution error, with ``other`` as the catch-all.
+ERROR_CATEGORIES: tuple[str, ...] = (
+    "interrupted",
+    "timeout",
+    "permission_denied",
+    "execution_error",
+    "other",
+)
+
+#: Regex patterns → category. Evaluated in order; first match wins.
+#: Patterns intentionally broad to align with steward's existing
+#: ``triaging-issues`` taxonomy (see `.claude/rules/` for the review
+#: side; taxonomy is load-bearing across both).
+_CATEGORY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"\b(?:keyboard ?interrupt|sigint|user ?cancel|aborted by user|ctrl[- ]?c)\b",
+            re.I,
+        ),
+        "interrupted",
+    ),
+    (
+        re.compile(
+            r"\b(?:timeout|timed?[- ]?out|deadline exceeded|operation took too long)\b",
+            re.I,
+        ),
+        "timeout",
+    ),
+    (
+        re.compile(
+            r"\b(?:permission ?denied|not ?permitted|not ?authorized|unauthorized|"
+            r"forbidden|access ?denied|eacces|eperm|permissiondenied)\b",
+            re.I,
+        ),
+        "permission_denied",
+    ),
+    (
+        re.compile(
+            r"\b(?:traceback|exception|error|failed|failure|exited with|"
+            r"exit ?code|non[- ]?zero|oserror|ioerror|runtimeerror|valueerror)\b",
+            re.I,
+        ),
+        "execution_error",
+    ),
+)
+
+
+def categorize_error(error_str: str | None) -> str:
+    """Return one of ``ERROR_CATEGORIES`` for a free-form error string.
+
+    Per shaping §3.6: bucket free-form errors into a stable taxonomy so
+    downstream consumers (incident fingerprinting, dashboard, triage)
+    have a small closed vocabulary to join on.
+
+    Args:
+        error_str: Free-form error message (stderr, exception repr,
+            log line). ``None`` or empty → ``"other"``.
+
+    Returns:
+        One of ``interrupted | timeout | permission_denied |
+        execution_error | other``.
+
+    Examples:
+        >>> categorize_error("KeyboardInterrupt")
+        'interrupted'
+        >>> categorize_error("Operation timed out after 30s")
+        'timeout'
+        >>> categorize_error("Permission denied: /etc/passwd")
+        'permission_denied'
+        >>> categorize_error("Traceback ... ValueError: x")
+        'execution_error'
+        >>> categorize_error("")
+        'other'
+    """
+    if not error_str:
+        return "other"
+    for pattern, category in _CATEGORY_PATTERNS:
+        if pattern.search(error_str):
+            return category
+    return "other"
+
+
+# Internal alias for shaping §3.6 exact-name parity with the ADR 007
+# reference plugin. External callers should use the public
+# ``categorize_error``; internal modules (``events.py``) may call either.
+_categorize_error = categorize_error
+
+
+# ---------------------------------------------------------------------------
+# Status message pattern (shaping §3.7)
+# ---------------------------------------------------------------------------
+
+# Event types routed through specialized formatters. Any type not listed
+# falls through to ``_generic_status_message``.
+_STATUS_FORMATTERS: dict[str, Any] = {}
+
+
+def _register(event_type: str):
+    def decorator(func):
+        _STATUS_FORMATTERS[event_type] = func
+        return func
+
+    return decorator
+
+
+def _short(value: Any, limit: int = 80) -> str:
+    """Clamp a value to ``limit`` chars with ellipsis, as a string."""
+    s = str(value)
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "…"
+
+
+@_register("task_started")
+def _fmt_task_started(rec: dict) -> str:
+    pid = _short(rec.get("packet_id") or rec.get("task_id") or "?")
+    title = _short(rec.get("title", "(untitled)"))
+    by = rec.get("dispatched_by") or "orchestrator"
+    return f"Task {pid} started by {by}: {title}"
+
+
+@_register("task_completed")
+def _fmt_task_completed(rec: dict) -> str:
+    pid = _short(rec.get("packet_id") or rec.get("task_id") or "?")
+    outcome = rec.get("outcome", "unknown")
+    pr_number = rec.get("pr_number")
+    if pr_number:
+        return f"Task {pid} {outcome} (PR #{pr_number})"
+    return f"Task {pid} {outcome}"
+
+
+@_register("post_tool_use_failure")
+def _fmt_post_tool_use_failure(rec: dict) -> str:
+    tool = rec.get("tool_name", "?")
+    cat = rec.get("error_category", "other")
+    return f"Tool failed: {tool} ({cat})"
+
+
+@_register("stop_failure")
+def _fmt_stop_failure(rec: dict) -> str:
+    cat = rec.get("failure_category", "other")
+    return f"Session stop failed: {cat}"
+
+
+@_register("canary_run_complete")
+def _fmt_canary_run_complete(rec: dict) -> str:
+    run_id = _short(rec.get("canary_run_id", "?"))
+    passed = rec.get("scenarios_passed", 0)
+    total = rec.get("scenarios_total", 0)
+    return f"Canary run {run_id} complete: {passed}/{total} scenarios passed"
+
+
+@_register("canary_run_fail")
+def _fmt_canary_run_fail(rec: dict) -> str:
+    run_id = _short(rec.get("canary_run_id", "?"))
+    failed = rec.get("scenarios_failed", "?")
+    return f"Canary run {run_id} FAILED: {failed} scenarios failed"
+
+
+@_register("notification")
+def _fmt_notification(rec: dict) -> str:
+    severity = rec.get("severity", "info")
+    msg = _short(rec.get("message", ""), limit=120)
+    return f"[{severity}] {msg}"
+
+
+@_register("promotion_start")
+def _fmt_promotion_start(rec: dict) -> str:
+    surface = _short(rec.get("surface_id") or rec.get("target", "?"))
+    return f"Promotion started: {surface}"
+
+
+@_register("promotion_complete")
+def _fmt_promotion_complete(rec: dict) -> str:
+    surface = _short(rec.get("surface_id") or rec.get("target", "?"))
+    return f"Promotion complete: {surface}"
+
+
+@_register("rollback_triggered")
+def _fmt_rollback_triggered(rec: dict) -> str:
+    surface = _short(rec.get("surface_id") or rec.get("target", "?"))
+    reason = _short(rec.get("reason", "unspecified"))
+    return f"Rollback triggered on {surface}: {reason}"
+
+
+def _generic_status_message(rec: dict) -> str:
+    """Fallback formatter for event types without a specialized message."""
+    et = rec.get("event_type", "event")
+    lane = rec.get("lane_id", "?")
+    return f"{et} ({lane})"
+
+
+def build_status_message(event_record: dict) -> str:
+    """Return a one-line human-readable summary of an event record.
+
+    Per shaping §3.7: centralizes event-to-human translation in one
+    function so the notification body, triaging-issues title, dashboard
+    recent-events panel, and archivist candidate-lesson template all
+    stay in sync.
+
+    Args:
+        event_record: Event dict with at least ``event_type``.
+
+    Returns:
+        A single-line summary (no embedded newlines).
+    """
+    event_type = event_record.get("event_type")
+    formatter = _STATUS_FORMATTERS.get(event_type) if event_type else None
+    try:
+        if formatter is not None:
+            msg = formatter(event_record)
+        else:
+            msg = _generic_status_message(event_record)
+    except Exception:  # pragma: no cover — defensive; never-raises
+        msg = _generic_status_message(event_record)
+    # Strip embedded newlines defensively.
+    return msg.replace("\n", " ").strip()
+
+
+# Internal alias for shaping §3.7 exact-name parity with the ADR 007
+# reference plugin.
+_build_status_message = build_status_message
+
+
+# ---------------------------------------------------------------------------
+# Incident fingerprint (§9.7 first-class ID)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_for_fingerprint(value: Any) -> str:
+    """Normalize a fingerprint input: trim, collapse whitespace, drop paths."""
+    s = str(value).strip()
+    # Collapse runs of whitespace to single spaces.
+    s = re.sub(r"\s+", " ", s)
+    # Drop absolute paths up to the last path component to improve
+    # dedup stability across workers / worktrees (e.g., temp dirs).
+    s = re.sub(r"/[^\s:]+/", "/…/", s)
+    return s
+
+
+def incident_fingerprint(
+    *,
+    event_type: str | None = None,
+    error_category: str | None = None,
+    signature: str | None = None,
+    **extra: Any,
+) -> str | None:
+    """Return a deterministic fingerprint for an incident, or ``None``.
+
+    Fingerprints are used by the ``triaging-issues`` skill to dedupe
+    repeat incidents across time. Two incidents with the same
+    ``(event_type, error_category, normalized signature)`` tuple produce
+    the same fingerprint.
+
+    Args:
+        event_type: The emitting event type (e.g., ``stop_failure``).
+        error_category: A category label from :data:`ERROR_CATEGORIES`.
+        signature: The stable incident signature (e.g., the first line
+            of a traceback, the command that failed, the failing
+            assertion). Leading / trailing whitespace is stripped and
+            run-of-whitespace collapsed before hashing.
+        **extra: Additional stable tokens to include in the hash
+            (e.g., ``tool_name=...``). Order-independent.
+
+    Returns:
+        A 16-character hex fingerprint, or ``None`` if all three
+        principal inputs are absent/empty (no incident to fingerprint).
+
+    Examples:
+        >>> fp1 = incident_fingerprint(
+        ...     event_type="stop_failure",
+        ...     error_category="timeout",
+        ...     signature="Operation timed out after 30s",
+        ... )
+        >>> fp2 = incident_fingerprint(
+        ...     event_type="stop_failure",
+        ...     error_category="timeout",
+        ...     signature="  Operation   timed out after 30s  ",
+        ... )
+        >>> fp1 == fp2
+        True
+        >>> incident_fingerprint() is None
+        True
+    """
+    if not any((event_type, error_category, signature)) and not extra:
+        return None
+    parts = [
+        ("event_type", event_type or ""),
+        ("error_category", error_category or ""),
+        ("signature", _normalize_for_fingerprint(signature) if signature else ""),
+    ]
+    for key in sorted(extra.keys()):
+        parts.append((key, _normalize_for_fingerprint(extra[key])))
+    token = "|".join(f"{k}={v}" for k, v in parts)
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return digest[:16]

--- a/src/bid_euchre/ops/event_writer.py
+++ b/src/bid_euchre/ops/event_writer.py
@@ -1,0 +1,388 @@
+"""JSONL event writer with daily rotation + sidecar metadata (Primitive A).
+
+Per shaping §3.2 (ADR 007 adopted pattern):
+
+- Log home: ``data/events/`` (gitignored).
+- File naming: ``events-{YYYY-MM-DD}-{NNN}.jsonl`` where ``NNN`` is a
+  3-digit rotation counter.
+- Rotation: when active file exceeds ``STEWARD_EVENTS_MAX_FILE_BYTES``
+  (default 50 MB), open new file with ``NNN+1``. Counter resets daily.
+- Metadata sidecar: paired ``.meta.json`` per file records
+  ``first_seq`` / ``last_seq`` / ``first_timestamp_ns`` /
+  ``last_timestamp_ns`` / ``event_count`` / ``schema_version``.
+- Retention: ``STEWARD_EVENTS_RETENTION_DAYS`` (default 30) before
+  age-out deletion (enforced by a separate ops task; this module writes
+  and rotates, does not delete).
+- Locking: cross-platform (``fcntl.flock`` on POSIX, ``msvcrt.locking``
+  on Windows). Per-line atomic: writers acquire lock, append one whole
+  line, release.
+
+This module is intentionally narrow: it accepts already-built event
+records (dicts) and writes them. All schema validation, field
+population, and error categorization happen in ``events.py`` /
+``event_schema.py`` / ``event_taxonomy.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from bid_euchre.ops.event_schema import SCHEMA_VERSION
+
+logger = logging.getLogger("ops.event_writer")
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via env vars)
+# ---------------------------------------------------------------------------
+
+DEFAULT_LOG_DIR = Path("data/events")
+"""Per shaping §3.2 default log home. Steward-namespaced per ADR 007 §4.6."""
+
+DEFAULT_MAX_FILE_BYTES = 50 * 1024 * 1024
+"""50 MB default rotation threshold. Override via
+``STEWARD_EVENTS_MAX_FILE_BYTES`` env var."""
+
+LOCK_FILE_NAME = ".event_writer.lock"
+SEQ_FILE_NAME = ".seq"
+TURN_FILE_NAME = ".turn"
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform file locking
+# ---------------------------------------------------------------------------
+
+
+class _FileLock:
+    """Context manager holding a cross-platform exclusive file lock.
+
+    POSIX: ``fcntl.flock(LOCK_EX)``.
+    Windows: ``msvcrt.locking(LK_LOCK)`` on the full file region.
+
+    The lock is held for the duration of the ``with`` block. All
+    write-path operations in this module acquire it briefly and release
+    — per-line atomic, not cross-line transactional.
+    """
+
+    def __init__(self, lock_path: Path) -> None:
+        self.lock_path = lock_path
+        self._fh: Any = None
+
+    def __enter__(self) -> "_FileLock":
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.lock_path, "a+")
+        _platform_lock(self._fh)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        try:
+            _platform_unlock(self._fh)
+        finally:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+            self._fh = None
+
+
+def _platform_lock(fh: Any) -> None:
+    if sys.platform == "win32":  # pragma: no cover — POSIX CI
+        import msvcrt
+
+        # Lock one byte at position 0; fine-grained locks aren't needed.
+        msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+
+
+def _platform_unlock(fh: Any) -> None:
+    if sys.platform == "win32":  # pragma: no cover — POSIX CI
+        import msvcrt
+
+        try:
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        import fcntl
+
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Environment knobs
+# ---------------------------------------------------------------------------
+
+
+def _env_log_dir() -> Path:
+    override = os.environ.get("STEWARD_EVENTS_LOG_DIR")
+    if override:
+        return Path(override)
+    return DEFAULT_LOG_DIR
+
+
+def _env_max_file_bytes() -> int:
+    override = os.environ.get("STEWARD_EVENTS_MAX_FILE_BYTES")
+    if not override:
+        return DEFAULT_MAX_FILE_BYTES
+    try:
+        value = int(override)
+    except ValueError:
+        logger.warning(
+            "Invalid STEWARD_EVENTS_MAX_FILE_BYTES=%r; using default", override
+        )
+        return DEFAULT_MAX_FILE_BYTES
+    return max(value, 1024)  # 1 KB floor to avoid pathological rotation
+
+
+def _today_utc() -> str:
+    """Return today's UTC date in YYYY-MM-DD form."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# Active-file resolution + rotation
+# ---------------------------------------------------------------------------
+
+
+def _active_file_path(log_dir: Path, today: str) -> tuple[Path, Path, int]:
+    """Return ``(jsonl_path, meta_path, rotation_counter)`` for today.
+
+    Selects the highest-numbered existing file for today whose size is
+    still under the max, or creates counter 001 if none exists. On a new
+    day, the counter resets to 001 regardless of yesterday's counter.
+    """
+    max_bytes = _env_max_file_bytes()
+
+    # Find all files for today, sorted by rotation counter.
+    prefix = f"events-{today}-"
+    existing = sorted(log_dir.glob(f"{prefix}*.jsonl"))
+    if existing:
+        latest = existing[-1]
+        try:
+            # Extract the NNN counter from the filename stem.
+            counter = int(latest.stem.rsplit("-", 1)[-1])
+        except ValueError:
+            counter = 1
+        if latest.stat().st_size < max_bytes:
+            return latest, _sidecar_path(latest), counter
+        # Rotate to next counter.
+        counter += 1
+    else:
+        counter = 1
+    new_path = log_dir / f"events-{today}-{counter:03d}.jsonl"
+    return new_path, _sidecar_path(new_path), counter
+
+
+def _sidecar_path(jsonl_path: Path) -> Path:
+    """Return the ``.meta.json`` sidecar path for a given JSONL file."""
+    return jsonl_path.with_suffix(".meta.json")
+
+
+# ---------------------------------------------------------------------------
+# Sequence counter (global per log_dir)
+# ---------------------------------------------------------------------------
+
+# Thread-local mutex for in-process coordination; the on-disk ``.seq``
+# file + file lock handles cross-process coordination.
+_seq_thread_lock = threading.Lock()
+
+
+def _next_seq(log_dir: Path) -> int:
+    """Return the next monotonic sequence number for this log_dir.
+
+    Reads and writes a ``.seq`` counter file, guarded by the same file
+    lock used by the writer (coarse but correct — the writer holds the
+    lock anyway during the write).
+    """
+    seq_path = log_dir / SEQ_FILE_NAME
+    with _seq_thread_lock:
+        try:
+            current = int(seq_path.read_text().strip())
+        except (OSError, ValueError):
+            current = 0
+        new_value = current + 1
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+            seq_path.write_text(str(new_value))
+        except OSError as exc:
+            logger.warning("Failed to persist .seq counter: %s", exc)
+        return new_value
+
+
+# ---------------------------------------------------------------------------
+# Sidecar metadata
+# ---------------------------------------------------------------------------
+
+
+def _update_sidecar(
+    meta_path: Path,
+    *,
+    seq: int,
+    timestamp_ns: int,
+    event_type: str,
+) -> None:
+    """Merge one event into the sidecar metadata. Best-effort."""
+    meta: dict[str, Any] = {}
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            meta = {}
+    if "first_seq" not in meta:
+        meta["first_seq"] = seq
+    meta["last_seq"] = seq
+    if "first_timestamp_ns" not in meta:
+        meta["first_timestamp_ns"] = timestamp_ns
+    meta["last_timestamp_ns"] = timestamp_ns
+    meta["event_count"] = int(meta.get("event_count", 0)) + 1
+    meta["schema_version"] = SCHEMA_VERSION
+    types = set(meta.get("event_types", []))
+    types.add(event_type)
+    meta["event_types"] = sorted(types)
+    try:
+        meta_path.write_text(json.dumps(meta, sort_keys=True))
+    except OSError as exc:
+        logger.warning("Failed to update sidecar %s: %s", meta_path, exc)
+
+
+def read_sidecar(meta_path: Path) -> dict[str, Any] | None:
+    """Return the sidecar dict for a JSONL file (None if absent/invalid)."""
+    if not meta_path.exists():
+        return None
+    try:
+        return json.loads(meta_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Write path
+# ---------------------------------------------------------------------------
+
+
+def write_event(
+    event_record: dict[str, Any],
+    *,
+    log_dir: Path | None = None,
+) -> Path:
+    """Append one fully-built event record to the active JSONL file.
+
+    Args:
+        event_record: A dict with at least ``event_type`` and the §9.7
+            first-class IDs + correlation fields populated. This writer
+            does **not** validate the record shape; validation is
+            ``events.py``'s responsibility.
+        log_dir: Override for the log directory. Defaults to
+            ``STEWARD_EVENTS_LOG_DIR`` env var or ``data/events/``.
+
+    Returns:
+        The path the event was written to.
+
+    Note:
+        This function is intentionally never-raises-in-practice: any
+        exception during the write path is logged to stderr and swallowed
+        so the caller (``events.emit``) remains non-blocking per ADR 007.
+        Truly unrecoverable errors still propagate.
+    """
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    effective_log_dir.mkdir(parents=True, exist_ok=True)
+
+    lock_path = effective_log_dir / LOCK_FILE_NAME
+    today = _today_utc()
+
+    with _FileLock(lock_path):
+        jsonl_path, meta_path, _counter = _active_file_path(effective_log_dir, today)
+        # Line-by-line atomic append.
+        line = json.dumps(event_record, sort_keys=True, default=str) + "\n"
+        with open(jsonl_path, "a") as f:
+            f.write(line)
+            f.flush()
+        # Best-effort sidecar update; keep inside the lock to preserve
+        # ordering between the JSONL line and its sidecar entry.
+        _update_sidecar(
+            meta_path,
+            seq=int(event_record.get("seq", 0) or 0),
+            timestamp_ns=int(event_record.get("timestamp_ns", 0) or 0),
+            event_type=str(event_record.get("event_type", "")),
+        )
+
+    return jsonl_path
+
+
+def next_seq(log_dir: Path | None = None) -> int:
+    """Public helper for callers that want to reserve a seq without writing."""
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    effective_log_dir.mkdir(parents=True, exist_ok=True)
+    return _next_seq(effective_log_dir)
+
+
+# ---------------------------------------------------------------------------
+# Turn counter (per-session)
+# ---------------------------------------------------------------------------
+
+
+def get_turn_id(log_dir: Path | None = None) -> int:
+    """Return the current turn_id from the ``.turn`` file (0 if absent)."""
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    turn_path = effective_log_dir / TURN_FILE_NAME
+    try:
+        return int(turn_path.read_text().strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def increment_turn_id(log_dir: Path | None = None) -> int:
+    """Bump the ``.turn`` counter and return the new value. Best-effort."""
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    effective_log_dir.mkdir(parents=True, exist_ok=True)
+    turn_path = effective_log_dir / TURN_FILE_NAME
+    with _seq_thread_lock:
+        try:
+            current = int(turn_path.read_text().strip())
+        except (OSError, ValueError):
+            current = 0
+        new_value = current + 1
+        try:
+            turn_path.write_text(str(new_value))
+        except OSError as exc:
+            logger.warning("Failed to persist .turn counter: %s", exc)
+        return new_value
+
+
+# ---------------------------------------------------------------------------
+# Introspection for audit / dashboard
+# ---------------------------------------------------------------------------
+
+
+def list_active_files(log_dir: Path | None = None) -> list[Path]:
+    """Return today's event files (sorted by rotation counter)."""
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    today = _today_utc()
+    if not effective_log_dir.exists():
+        return []
+    return sorted(effective_log_dir.glob(f"events-{today}-*.jsonl"))
+
+
+def iter_sidecars(log_dir: Path | None = None) -> list[dict[str, Any]]:
+    """Yield sidecar dicts for all JSONL files in the log dir (any date)."""
+    effective_log_dir = log_dir if log_dir is not None else _env_log_dir()
+    results: list[dict[str, Any]] = []
+    if not effective_log_dir.exists():
+        return results
+    for meta_path in sorted(effective_log_dir.glob("*.meta.json")):
+        meta = read_sidecar(meta_path)
+        if meta is not None:
+            results.append(meta)
+    return results

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -1,11 +1,26 @@
-"""Durable event log for operational signals.
+"""Durable event log + Primitive A emit() dispatcher.
 
-Events are appended to a JSONL file and can be queried or drained.
-The event log is the canonical bus for CI failures, heartbeat anomalies,
-task completions, and other hook-produced operational signals.
+This module exposes two surfaces:
 
-Storage: ``.claude/runtime/events/events.jsonl`` (append-only, gitignored)
-Archive: ``.claude/runtime/events/events.archive.jsonl`` (drained events)
+1. **Legacy API** (``append_event`` / ``read_events`` / ``drain_events``,
+   :data:`VALID_EVENT_TYPES`, :data:`DEFAULT_EVENTS_DIR`) — the
+   ``.claude/runtime/events/events.jsonl`` pipeline used by 25+ existing
+   consumers. Preserved as-is for backward compatibility during the
+   Phase 0 rollout; migration to :func:`emit` is incremental.
+
+2. **Primitive A v1.0 dispatcher** (:func:`emit`) — the single public
+   entry point for steward event emission per shaping §3.1. Writes to
+   ``data/events/events-{YYYY-MM-DD}-{NNN}.jsonl`` via
+   :mod:`bid_euchre.ops.event_writer`, validates against
+   :data:`~bid_euchre.ops.event_schema.EVENT_FIELD_REGISTRY`, fills the
+   §9.7 first-class IDs + §2.4 correlation fields on every record, and
+   is **non-blocking + never-raises** per ADR 007.
+
+New emitters MUST use :func:`emit`. Legacy emitters may migrate
+incrementally; the two pipelines coexist until Primitive A proves out.
+
+Storage (legacy): ``.claude/runtime/events/events.jsonl``
+Storage (v1.0):   ``data/events/events-{YYYY-MM-DD}-{NNN}.jsonl``
 """
 
 from __future__ import annotations
@@ -13,10 +28,24 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import os
+import sys
+import time
+import uuid
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from bid_euchre.ops import event_taxonomy, event_writer
+from bid_euchre.ops.event_schema import (
+    BASELINE_FIELDS,
+    EVENT_FIELD_REGISTRY,
+    SCHEMA_VERSION,
+    VERBOSITY_TIERS,
+    get_spec,
+    is_known_event_type,
+)
 
 logger = logging.getLogger("ops.events")
 
@@ -292,3 +321,368 @@ def drain_events(
 
     logger.info("Drained %d events to archive", len(to_drain))
     return len(to_drain)
+
+
+# ===========================================================================
+# Primitive A v1.0 — emit() dispatcher
+# ===========================================================================
+#
+# Per shaping §3.1-§3.4 + ADR 007:
+# - One public entry point: emit(event_type, **fields) -> None
+# - One internal dispatch function: _dispatch(event_record) -> None
+# - Non-blocking + never-raises (exceptions caught + logged to stderr)
+# - Registry-driven contract (unknown event_type logged, no JSONL write)
+# - Baseline fields (§9.7 IDs + §2.4 correlation) populated by dispatcher
+# - Pattern 8: unknown fields routed to extra_fields (bug marker)
+# - Verbosity tiers: minimal / summary / full
+#
+# ===========================================================================
+
+_PROJECT_ID = "bid-euchre"
+"""Constant per shaping §2.3 row 1 — identifies the cell; portable to
+future multi-cell pipelines."""
+
+_CELL_ID = "bid-euchre"
+"""Constant per shaping §2.3 row 2 — distinct field for adapter contract
+clarity, currently equal to ``_PROJECT_ID``."""
+
+# Cached per-session values. Populated lazily in ``_session_id()`` /
+# ``_prompt_policy_version()`` to avoid doing env lookups at import time.
+_CACHED_SESSION_ID: str | None = None
+_CACHED_PROMPT_POLICY_VERSION: str | None = None
+
+
+def _session_id() -> str:
+    """Return the cached session_id per §2.3 row 3.
+
+    Reads ``CLAUDE_SESSION_ID`` env var, falling back to a UUID4 when
+    unset (e.g., headless scripts). The value is cached for the process
+    lifetime so subsequent emissions in the same process share a stable
+    session_id.
+    """
+    global _CACHED_SESSION_ID
+    if _CACHED_SESSION_ID is None:
+        env_val = os.environ.get("CLAUDE_SESSION_ID")
+        _CACHED_SESSION_ID = env_val if env_val else str(uuid.uuid4())
+    return _CACHED_SESSION_ID
+
+
+def _lane_id() -> str | None:
+    """Return the lane_id per §2.3 row 5 (``CLAUDE_AGENT_NAME`` env var)."""
+    return os.environ.get("CLAUDE_AGENT_NAME")
+
+
+def _prompt_policy_version() -> str:
+    """Return the cached prompt_policy_version per §2.3 row 8.
+
+    Phase 0: returns ``"unset"`` since Primitive B.3 registry is a
+    separate deliverable. When B.3 lands, this helper will read the
+    registry version instead.
+    """
+    global _CACHED_PROMPT_POLICY_VERSION
+    if _CACHED_PROMPT_POLICY_VERSION is None:
+        _CACHED_PROMPT_POLICY_VERSION = os.environ.get(
+            "STEWARD_PROMPT_POLICY_VERSION", "unset"
+        )
+    return _CACHED_PROMPT_POLICY_VERSION
+
+
+def _resolve_verbosity(requested: str | None) -> str:
+    """Return the effective verbosity tier for this emission.
+
+    Resolution order per shaping §3.3:
+
+    1. Explicit ``_verbosity`` kwarg to :func:`emit`.
+    2. ``STEWARD_EVENTS_VERBOSITY`` env var.
+    3. ``EventTypeSpec.verbosity_default`` from the registry.
+    4. ``"summary"`` (ultimate fallback).
+    """
+    if requested and requested in VERBOSITY_TIERS:
+        return requested
+    env_val = os.environ.get("STEWARD_EVENTS_VERBOSITY")
+    if env_val and env_val in VERBOSITY_TIERS:
+        return env_val
+    return "summary"
+
+
+def _log_fallback(msg: str, *args: Any) -> None:
+    """Stderr fallback logger per shaping §2.7 never-raises contract.
+
+    Uses stderr directly (not :mod:`logging`) so a misconfigured logger
+    can't swallow the signal. The emit path must never propagate
+    exceptions to the caller, so this is the last-resort channel.
+    """
+    try:
+        formatted = msg % args if args else msg
+        print(f"[ops.events] {formatted}", file=sys.stderr)
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+
+def _validate_and_split_fields(
+    event_type: str,
+    caller_fields: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Split caller-supplied fields into (known, extra, missing_required).
+
+    Per shaping §3.4:
+
+    - Registry-declared required/optional fields land in ``known``.
+    - §9.7 first-class IDs + correlation baseline — not caller-owned;
+      the dispatcher populates these. If the caller passes them, we
+      honor the override but log a debug note.
+    - Anything else lands in ``extra_fields`` (Pattern 8 marker).
+
+    Returns a tuple of:
+        (known_fields_dict, extra_fields_dict, missing_required_list)
+
+    ``missing_required`` names fields the registry marks as required
+    but which the caller omitted. The dispatcher refuses to emit when
+    this list is non-empty (per shaping §3.4).
+    """
+    spec = get_spec(event_type)
+    known: dict[str, Any] = {}
+    extra: dict[str, Any] = {}
+    missing: list[str] = []
+
+    if spec is None:
+        # Unknown event type — caller should never reach here; guarded in emit.
+        return caller_fields, {}, []
+
+    # Partition caller fields into known-to-registry vs extra_fields.
+    registered_slots = set(spec.required_fields) | set(spec.optional_fields)
+    # Baseline fields (§9.7 IDs + correlation + event_type) are dispatcher-
+    # owned; caller overrides are honored but land in known.
+    for key, value in caller_fields.items():
+        if key in BASELINE_FIELDS or key in registered_slots:
+            known[key] = value
+        else:
+            extra[key] = value
+
+    # Missing-required check — baseline fields excluded (dispatcher fills).
+    for req in spec.required_fields:
+        if req in BASELINE_FIELDS:
+            continue
+        if req not in caller_fields:
+            missing.append(req)
+
+    return known, extra, missing
+
+
+def _populate_baseline(
+    event_type: str,
+    caller_fields: dict[str, Any],
+    log_dir: Path,
+) -> dict[str, Any]:
+    """Build the baseline field block for a new event record.
+
+    Per shaping §2.3 + §2.4 — every record carries the 9 §9.7 IDs + 4
+    correlation fields + ``event_type``. Caller-supplied values for
+    these fields override the dispatcher defaults (useful for
+    worktree-create events where the lane_id is the *target* lane,
+    not the emitting lane).
+    """
+    # §9.7 first-class IDs
+    baseline: dict[str, Any] = {
+        "event_type": event_type,
+        "project_id": caller_fields.get("project_id", _PROJECT_ID),
+        "cell_id": caller_fields.get("cell_id", _CELL_ID),
+        "session_id": caller_fields.get("session_id", _session_id()),
+        "task_id": caller_fields.get("task_id"),
+        "lane_id": caller_fields.get("lane_id", _lane_id()),
+        "trace_id": caller_fields.get("trace_id"),
+        "incident_fingerprint": caller_fields.get("incident_fingerprint"),
+        "prompt_policy_version": caller_fields.get(
+            "prompt_policy_version", _prompt_policy_version()
+        ),
+        "schema_version": caller_fields.get("schema_version", SCHEMA_VERSION),
+    }
+    # §2.4 correlation fields
+    baseline["seq"] = caller_fields.get("seq") or event_writer.next_seq(log_dir=log_dir)
+    baseline["pid"] = caller_fields.get("pid") or os.getpid()
+    baseline["timestamp_ns"] = caller_fields.get("timestamp_ns") or time.time_ns()
+    baseline["turn_id"] = caller_fields.get(
+        "turn_id", event_writer.get_turn_id(log_dir=log_dir)
+    )
+    return baseline
+
+
+def _apply_verbosity(event_record: dict[str, Any], tier: str) -> dict[str, Any]:
+    """Apply verbosity-tier truncation to the event record.
+
+    - ``minimal``: baseline only (IDs + correlation + event_type + a
+      tiny ``success``/``failure`` flag if derivable).
+    - ``summary``: baseline + required fields (large payloads truncated).
+    - ``full``: everything — including ``extra_fields``.
+    """
+    if tier == "full":
+        return event_record
+
+    baseline_keys = set(BASELINE_FIELDS)
+
+    if tier == "minimal":
+        kept = {k: v for k, v in event_record.items() if k in baseline_keys}
+        # Preserve a minimal success/failure hint if present.
+        for hint in ("success", "outcome", "error_category"):
+            if hint in event_record:
+                kept[hint] = event_record[hint]
+        return kept
+
+    # summary tier: baseline + required + truncated large strings
+    spec = get_spec(event_record.get("event_type", ""))
+    if spec is None:
+        return event_record
+
+    keep_keys = baseline_keys | set(spec.required_fields) | {"extra_fields"}
+    summary: dict[str, Any] = {}
+    for key, value in event_record.items():
+        if key in keep_keys:
+            summary[key] = _truncate_large(value)
+    return summary
+
+
+_SUMMARY_TRUNCATE_CHARS = 2000
+
+
+def _truncate_large(value: Any) -> Any:
+    """Truncate very large string values for the ``summary`` tier."""
+    if isinstance(value, str) and len(value) > _SUMMARY_TRUNCATE_CHARS:
+        return value[: _SUMMARY_TRUNCATE_CHARS - 1] + "…"
+    return value
+
+
+def _dispatch(event_record: dict[str, Any], log_dir: Path) -> None:
+    """Internal dispatch. Writes event_record to JSONL. Never-raises."""
+    try:
+        event_writer.write_event(event_record, log_dir=log_dir)
+    except (
+        Exception
+    ) as exc:  # pragma: no cover — defensive; writer is never-raises already
+        _log_fallback(
+            "write_event failed for %s: %s",
+            event_record.get("event_type", "?"),
+            exc,
+        )
+
+
+def _env_events_log_dir() -> Path:
+    """Resolve the v1.0 events log dir per shaping §3.2.
+
+    Defaults to ``data/events/``; overridable via
+    ``STEWARD_EVENTS_LOG_DIR``.
+    """
+    override = os.environ.get("STEWARD_EVENTS_LOG_DIR")
+    if override:
+        return Path(override)
+    return Path("data/events")
+
+
+def emit(
+    event_type: str,
+    *,
+    _verbosity: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit one event record to the Primitive A v1.0 JSONL pipeline.
+
+    This is the single public entry point per shaping §3.1. Callers
+    invoke it with the event type and event-type-specific fields; the
+    dispatcher fills the §9.7 first-class IDs + §2.4 correlation fields,
+    validates against :data:`EVENT_FIELD_REGISTRY`, applies verbosity,
+    and writes a JSONL line.
+
+    **Never raises.** Per ADR 007 adopted pattern, any exception during
+    the dispatch path is caught and logged to stderr — the calling hook
+    or tool must never crash because of a misbehaving emitter.
+
+    Args:
+        event_type: Must be a key of
+            :data:`~bid_euchre.ops.event_schema.EVENT_FIELD_REGISTRY`.
+        _verbosity: Optional per-call override: ``"minimal"`` |
+            ``"summary"`` | ``"full"``. Falls back to
+            ``STEWARD_EVENTS_VERBOSITY`` env var, then the registry
+            default, then ``"summary"``.
+        **fields: Event-type-specific fields. Caller-supplied §9.7 IDs
+            override dispatcher defaults. Fields outside the registry
+            are routed to ``extra_fields`` (Pattern 8 bug-marker).
+
+    Examples:
+        >>> emit(
+        ...     "task_started",
+        ...     packet_id="abc123",
+        ...     dispatched_by="orchestrator",
+        ...     priority="high",
+        ...     domain="platform",
+        ... )  # doctest: +SKIP
+    """
+    try:
+        log_dir = _env_events_log_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. Unknown-event-type gate (shaping §3.4).
+        if not is_known_event_type(event_type):
+            _log_fallback(
+                "rejected unknown event_type %r; no JSONL write. Registry "
+                "has %d known types.",
+                event_type,
+                len(EVENT_FIELD_REGISTRY),
+            )
+            return
+
+        # 2. Split caller fields into (known, extra, missing_required).
+        known, extra, missing = _validate_and_split_fields(event_type, fields)
+        if missing:
+            _log_fallback(
+                "rejected %s emission: missing required fields %s",
+                event_type,
+                sorted(missing),
+            )
+            return
+
+        # 3. Populate baseline §9.7 IDs + §2.4 correlation fields.
+        baseline = _populate_baseline(event_type, known, log_dir)
+
+        # 4. Build the full record. Baseline first (dispatcher-owned keys),
+        #    then caller-supplied known slots, then extra_fields if any.
+        record: dict[str, Any] = {}
+        record.update(baseline)
+        for key, value in known.items():
+            if key not in baseline:
+                record[key] = value
+        if extra:
+            # Merge with any caller-supplied extra_fields dict.
+            existing_extra = record.pop("extra_fields", None) or {}
+            if isinstance(existing_extra, dict):
+                merged_extra = {**existing_extra, **extra}
+            else:
+                merged_extra = dict(extra)
+            record["extra_fields"] = merged_extra
+
+        # 5. Apply verbosity tier.
+        tier = _resolve_verbosity(_verbosity)
+        record = _apply_verbosity(record, tier)
+
+        # 6. Dispatch to JSONL writer.
+        _dispatch(record, log_dir)
+    except Exception as exc:  # pragma: no cover — outer never-raises guard
+        _log_fallback("emit(%s) unexpected failure: %s", event_type, exc)
+
+
+def reset_cached_session() -> None:
+    """Test helper — clear cached session_id / prompt_policy_version.
+
+    Pure test surface: production code should never call this. Allows
+    test fixtures to exercise emit() across multiple "sessions" within a
+    single process.
+    """
+    global _CACHED_SESSION_ID, _CACHED_PROMPT_POLICY_VERSION
+    _CACHED_SESSION_ID = None
+    _CACHED_PROMPT_POLICY_VERSION = None
+
+
+# Re-export taxonomy helpers for downstream convenience (consumers that
+# emit fail/incident events typically want ``categorize_error`` +
+# ``incident_fingerprint`` available on the same import).
+categorize_error = event_taxonomy.categorize_error
+build_status_message = event_taxonomy.build_status_message
+incident_fingerprint = event_taxonomy.incident_fingerprint

--- a/src/bid_euchre/ops/events.py
+++ b/src/bid_euchre/ops/events.py
@@ -326,7 +326,7 @@ def drain_events(
 # ===========================================================================
 # Primitive A v1.0 — emit() dispatcher
 # ===========================================================================
-#
+
 # Per shaping §3.1-§3.4 + ADR 007:
 # - One public entry point: emit(event_type, **fields) -> None
 # - One internal dispatch function: _dispatch(event_record) -> None
@@ -335,7 +335,7 @@ def drain_events(
 # - Baseline fields (§9.7 IDs + §2.4 correlation) populated by dispatcher
 # - Pattern 8: unknown fields routed to extra_fields (bug marker)
 # - Verbosity tiers: minimal / summary / full
-#
+
 # ===========================================================================
 
 _PROJECT_ID = "bid-euchre"

--- a/tests/integration/test_event_to_signal.py
+++ b/tests/integration/test_event_to_signal.py
@@ -1,0 +1,121 @@
+"""Event-to-signal integration smoke (Primitive A / Primitive E handoff).
+
+Proves that an emission via ``events.emit()`` lands in the v1.0 JSONL
+stream, is discoverable via the audit script, and that the latency
+surface described in ``docs/01_core/event_schema_v1.md`` is wired end
+to end.
+
+The full event-to-signal latency test (flipping a lifecycle event ->
+operator signal within the ≤5 min p95 target) lands under Primitive E
+Phase 0. This smoke proves the upstream half of that handoff is live.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.event_writer import list_active_files
+from bid_euchre.ops.events import emit
+
+
+@pytest.fixture()
+def event_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    log_dir = tmp_path / "events"
+    monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(log_dir))
+    return log_dir
+
+
+class TestEventToSignalSmoke:
+    """Upstream half of the event-to-signal handoff (Primitive A)."""
+
+    def test_emit_lands_in_jsonl_stream(self, event_env: Path) -> None:
+        emit(
+            "task_started",
+            packet_id="smoke-1",
+            dispatched_by="orchestrator",
+            priority="high",
+            domain="platform",
+            lane_id="author-a",
+        )
+        files = list_active_files(event_env)
+        assert len(files) == 1
+        # File has exactly one line with our event.
+        lines = files[0].read_text().splitlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["event_type"] == "task_started"
+        assert record["packet_id"] == "smoke-1"
+
+    def test_latency_event_emission_visible_on_dashboard_pipeline(
+        self, event_env: Path
+    ) -> None:
+        """Emit a latency event; dashboard helper must see it.
+
+        Links Primitive A emission -> Primitive A dashboard surface (the
+        Latencies panel added in shaping §8.2 step 10).
+        """
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        emit(
+            "event_to_signal_latency",
+            source_event_id="evt-1",
+            signal_type="inbox",
+            latency_ms=42.0,
+            lane_id="author-a",
+        )
+        emit(
+            "event_to_signal_latency",
+            source_event_id="evt-2",
+            signal_type="inbox",
+            latency_ms=84.0,
+            lane_id="author-a",
+        )
+        summary = _load_latency_summary(event_env)
+        assert summary["event_to_signal"]["count"] == 2
+        assert summary["event_to_signal"]["p50_ms"] == 63.0
+
+    def test_audit_script_sees_live_emitters(self, event_env: Path) -> None:
+        """audit_event_emission.py locates live emitters via code scan.
+
+        This is an emission-call-site discovery check — it does **not**
+        require any live JSONL content. Proves the audit path is wired.
+        """
+        repo_root = Path(__file__).resolve().parents[2]
+        script = repo_root / "scripts" / "internal" / "audit_event_emission.py"
+        assert script.exists()
+        result = subprocess.run(
+            [sys.executable, str(script), "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # Script exits 0 for green/yellow; only red fails. Yellow is
+        # acceptable on a repo where deferred classes (canary/archivist/
+        # promotion/rollback/worktree) have no emitters yet.
+        assert result.returncode == 0, (
+            f"audit script exited {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        payload = json.loads(result.stdout)
+        assert "classes" in payload
+        # Find the task_lifecycle class entry (classes is a list of dicts).
+        task_class = next(
+            (c for c in payload["classes"] if c["class_name"] == "task_lifecycle"),
+            None,
+        )
+        assert task_class is not None, (
+            f"task_lifecycle class missing from audit payload:\n"
+            f"{json.dumps(payload, indent=2)}"
+        )
+        # task_lifecycle must be green (we just migrated ops/task_queue.py
+        # in Packet 3 step 7; emitters are committed).
+        assert task_class["status"] in {
+            "green",
+            "yellow",
+        }, f"task_lifecycle unexpectedly red:\n{json.dumps(task_class, indent=2)}"

--- a/tests/integration/test_polling_fallback.py
+++ b/tests/integration/test_polling_fallback.py
@@ -1,0 +1,126 @@
+"""Polling-fallback feature-flag smoke (Primitive A / Primitive E handoff).
+
+Exercises the ``STEWARD_EVENTS_POLLING_FALLBACK`` feature flag documented
+in ``.claude/rules/feature_flags.md``. Phase 0 scope is **flag-shape
+only** — the live polling consumer lives under Primitive E and ships in
+a later packet. This stub locks in:
+
+1. The flag is registered in the authoritative registry file.
+2. The flag honors ``"0"`` / ``"1"`` parsing conventions.
+3. Event-driven emission is **unaffected** by the flag (it gates
+   downstream consumers, not upstream emitters).
+
+When Primitive E lands the live consumer, this file grows a real
+rollback-latency assertion (flip flag → poll restarts within 60s).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.event_writer import list_active_files
+from bid_euchre.ops.events import emit
+
+_FLAG_NAME = "STEWARD_EVENTS_POLLING_FALLBACK"
+_REGISTRY_PATH = (
+    Path(__file__).resolve().parents[2] / ".claude" / "rules" / "feature_flags.md"
+)
+
+
+class TestPollingFallbackFlagShape:
+    """Lock the flag's registry contract (Phase 0 stub)."""
+
+    def test_flag_is_documented_in_registry(self) -> None:
+        """feature_flags.md must carry an entry for the flag."""
+        assert (
+            _REGISTRY_PATH.exists()
+        ), f"Expected feature-flag registry at {_REGISTRY_PATH}"
+        content = _REGISTRY_PATH.read_text()
+        assert (
+            f"`{_FLAG_NAME}`" in content
+        ), f"Flag {_FLAG_NAME} not documented in {_REGISTRY_PATH}"
+        # Operator-visible contract fields must all appear.
+        for required_section in ("Default", "Trigger", "Expected effect", "Rollback"):
+            assert (
+                required_section in content
+            ), f"Registry entry missing section: {required_section}"
+
+    def test_flag_parse_sanity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Standard shell-truthy conventions: ``"1"`` and ``"0"`` are both sane values."""
+        for value in ("0", "1"):
+            monkeypatch.setenv(_FLAG_NAME, value)
+            # Stand-in parse: the live consumer will use a helper. For now,
+            # lock the convention we've documented so tests catch divergence.
+            parsed = os.environ.get(_FLAG_NAME) == "1"
+            if value == "1":
+                assert parsed is True
+            else:
+                assert parsed is False
+
+
+class TestEmissionUnaffectedByFlag:
+    """Upstream emission is orthogonal to the downstream polling flag."""
+
+    @pytest.fixture()
+    def event_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        log_dir = tmp_path / "events"
+        monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(log_dir))
+        return log_dir
+
+    def test_emission_writes_jsonl_when_flag_off(
+        self, event_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_FLAG_NAME, "0")
+        emit(
+            "task_started",
+            packet_id="off",
+            dispatched_by="orchestrator",
+            priority="medium",
+            domain="platform",
+            lane_id="author-a",
+        )
+        files = list_active_files(event_env)
+        assert len(files) == 1
+        assert "off" in files[0].read_text()
+
+    def test_emission_writes_jsonl_when_flag_on(
+        self, event_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_FLAG_NAME, "1")
+        emit(
+            "task_started",
+            packet_id="on",
+            dispatched_by="orchestrator",
+            priority="medium",
+            domain="platform",
+            lane_id="author-a",
+        )
+        files = list_active_files(event_env)
+        assert len(files) == 1
+        record = json.loads(files[0].read_text().splitlines()[0])
+        assert record["packet_id"] == "on"
+        # Upstream emission path is unaffected — the flag gates downstream
+        # consumers only.
+
+
+# ---------------------------------------------------------------------------
+# Primitive E coordination point — expand when the live consumer lands.
+# ---------------------------------------------------------------------------
+#
+# When Primitive E migrates active-triage from polling to event-driven
+# routing (see plans/steward_platform/verification_contract/map.md row
+# A.5), add a TestPollingFallbackLiveConsumer class that:
+#
+#   1. Starts the event-driven consumer in a subprocess / thread.
+#   2. Emits a synthetic triage-triggering event.
+#   3. Asserts the consumer picks it up within event-driven latency target.
+#   4. Flips STEWARD_EVENTS_POLLING_FALLBACK=1.
+#   5. Asserts the polling fallback restarts within the 60s SLO.
+#   6. Flips it off and asserts the event-driven path resumes.
+#
+# The <1min wall-clock rollback SLO is the Pattern 7 obligation this
+# test will discharge — tracked in feature_flags.md.

--- a/tests/integration/test_polling_fallback.py
+++ b/tests/integration/test_polling_fallback.py
@@ -110,7 +110,7 @@ class TestEmissionUnaffectedByFlag:
 # ---------------------------------------------------------------------------
 # Primitive E coordination point — expand when the live consumer lands.
 # ---------------------------------------------------------------------------
-#
+
 # When Primitive E migrates active-triage from polling to event-driven
 # routing (see plans/steward_platform/verification_contract/map.md row
 # A.5), add a TestPollingFallbackLiveConsumer class that:
@@ -121,6 +121,6 @@ class TestEmissionUnaffectedByFlag:
 #   4. Flips STEWARD_EVENTS_POLLING_FALLBACK=1.
 #   5. Asserts the polling fallback restarts within the 60s SLO.
 #   6. Flips it off and asserts the event-driven path resumes.
-#
+
 # The <1min wall-clock rollback SLO is the Pattern 7 obligation this
 # test will discharge — tracked in feature_flags.md.

--- a/tests/reliability/__init__.py
+++ b/tests/reliability/__init__.py
@@ -6,4 +6,8 @@ Primitive H owns this subtree. See
 - H.0 (Phase 0 mini-canary) lives under ``tests/reliability/canaries/``.
 - H.1 (Phase 1 reliability lab) adds ``tests/reliability/replay.py`` and
   ``tests/reliability/failure_injection/`` in a follow-on packet.
+
+Primitive A Phase 0 (Packet 3) additionally lands the Event Schema v1.0
+replay-compat smoke suite under ``tests/reliability/`` as a precursor
+to the full H.1 replay harness.
 """

--- a/tests/reliability/test_replay_compat.py
+++ b/tests/reliability/test_replay_compat.py
@@ -1,0 +1,229 @@
+"""Replay-compat smoke — Event Schema v1.0 (Primitive A Packet 3).
+
+Proves that records emitted by ``bid_euchre.ops.events.emit()`` at
+schema v1.0 emit cleanly, carry the expected §9.7 first-class IDs and
+§2.4 correlation fields, and re-parse without loss.
+
+This is the **smoke** companion to the full replay harness (Primitive
+H.1, ``tests/reliability/replay.py``). The full harness lands in
+Phase 1; the smoke ensures the v1.0 emission path is not silently
+broken in the interim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops.event_schema import (
+    EVENT_FIELD_REGISTRY,
+    NATIVE_LIFECYCLE_EVENT_TYPES,
+    SCHEMA_VERSION,
+)
+from bid_euchre.ops.event_writer import list_active_files
+from bid_euchre.ops.events import emit
+
+# §9.7 first-class IDs that must appear on every record.
+_FIRST_CLASS_IDS = (
+    "project_id",
+    "cell_id",
+    "session_id",
+    "task_id",
+    "lane_id",
+    "trace_id",
+    "incident_fingerprint",
+    "prompt_policy_version",
+    "schema_version",
+)
+
+# §2.4 correlation fields that must appear on every record.
+_CORRELATION_FIELDS = ("seq", "pid", "timestamp_ns", "turn_id")
+
+
+@pytest.fixture()
+def isolated_events_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Give each test its own ``STEWARD_EVENTS_LOG_DIR``."""
+    log_dir = tmp_path / "events"
+    monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(log_dir))
+    # Keep verbosity deterministic so optional fields survive re-parse.
+    monkeypatch.setenv("STEWARD_EVENTS_VERBOSITY", "full")
+    return log_dir
+
+
+def _read_all_events(log_dir: Path) -> list[dict]:
+    records: list[dict] = []
+    for path in list_active_files(log_dir):
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                records.append(json.loads(line))
+    return records
+
+
+class TestReplayCompatV1:
+    """Smoke: v1.0 records round-trip through JSON encode → decode."""
+
+    def test_emit_task_started_is_replayable(self, isolated_events_dir: Path) -> None:
+        emit(
+            "task_started",
+            packet_id="abc123",
+            dispatched_by="orchestrator",
+            priority="high",
+            domain="platform",
+            lane_id="author-a",
+        )
+        records = _read_all_events(isolated_events_dir)
+        assert len(records) == 1
+
+        record = records[0]
+        # §9.7 IDs all present (null is acceptable for the three nullable ones).
+        for id_key in _FIRST_CLASS_IDS:
+            assert id_key in record, f"Missing first-class ID: {id_key!r}"
+        # Correlation fields present and well-typed.
+        for corr_key in _CORRELATION_FIELDS:
+            assert corr_key in record, f"Missing correlation field: {corr_key!r}"
+            assert isinstance(record[corr_key], int)
+        # Schema version is the v1.0 constant.
+        assert record["schema_version"] == SCHEMA_VERSION == "1.0"
+        # Event-type-specific fields landed at top level, not in extra_fields.
+        assert record["event_type"] == "task_started"
+        assert record["packet_id"] == "abc123"
+        assert record["dispatched_by"] == "orchestrator"
+        assert record["priority"] == "high"
+        assert record["domain"] == "platform"
+        assert record["lane_id"] == "author-a"
+        # project_id + cell_id are populated by the dispatcher.
+        assert record["project_id"] == "bid-euchre"
+        assert record["cell_id"] == "bid-euchre"
+
+    def test_emit_task_completed_is_replayable(self, isolated_events_dir: Path) -> None:
+        emit(
+            "task_completed",
+            packet_id="xyz789",
+            outcome="merged",
+            pr_number=1234,
+            lane_id="author-b",
+        )
+        records = _read_all_events(isolated_events_dir)
+        assert len(records) == 1
+        record = records[0]
+        assert record["event_type"] == "task_completed"
+        assert record["packet_id"] == "xyz789"
+        assert record["outcome"] == "merged"
+        assert record["pr_number"] == 1234
+        assert record["lane_id"] == "author-b"
+
+    def test_multi_event_seq_monotonic(self, isolated_events_dir: Path) -> None:
+        """seq is strictly monotonic across consecutive emissions."""
+        for i in range(5):
+            emit(
+                "task_started",
+                packet_id=f"p{i}",
+                dispatched_by="orchestrator",
+                priority="medium",
+                domain="platform",
+                lane_id="author-a",
+            )
+        records = _read_all_events(isolated_events_dir)
+        assert len(records) == 5
+        seqs = [r["seq"] for r in records]
+        assert seqs == sorted(seqs)
+        assert len(set(seqs)) == len(seqs)  # no duplicates
+
+    def test_unknown_event_type_does_not_write(self, isolated_events_dir: Path) -> None:
+        """Unknown event types are dropped silently (never-raises)."""
+        emit("not_a_real_event_type_xyz", foo="bar")
+        records = _read_all_events(isolated_events_dir)
+        assert records == []
+
+    def test_emit_never_raises_on_missing_required(
+        self, isolated_events_dir: Path
+    ) -> None:
+        """Missing required fields drop the emission but never raise."""
+        # ``task_started`` requires packet_id / dispatched_by / priority /
+        # domain; leaving them out must not raise.
+        emit("task_started")
+        records = _read_all_events(isolated_events_dir)
+        assert records == []
+
+    def test_extra_fields_routed_to_extra_fields_bucket(
+        self, isolated_events_dir: Path
+    ) -> None:
+        """Unknown kwargs land in ``extra_fields`` (Pattern 8 bug marker)."""
+        emit(
+            "task_started",
+            packet_id="abc",
+            dispatched_by="orchestrator",
+            priority="high",
+            domain="platform",
+            lane_id="author-a",
+            # Unknown field — must route to extra_fields, not a top-level slot.
+            experimental_flag="yes",
+        )
+        records = _read_all_events(isolated_events_dir)
+        assert len(records) == 1
+        record = records[0]
+        assert "experimental_flag" not in record
+        assert record.get("extra_fields", {}).get("experimental_flag") == "yes"
+
+    def test_record_round_trips_through_json(self, isolated_events_dir: Path) -> None:
+        """Serialize → deserialize → compare: no loss, no reshape."""
+        emit(
+            "task_started",
+            packet_id="abc",
+            dispatched_by="orchestrator",
+            priority="high",
+            domain="platform",
+            lane_id="author-a",
+        )
+        records = _read_all_events(isolated_events_dir)
+        assert len(records) == 1
+        original = records[0]
+        # Re-encode + decode; shape must survive.
+        reparsed = json.loads(json.dumps(original))
+        assert reparsed == original
+
+
+class TestRegistryInvariantsV1:
+    """Guards that lock the v1.0 registry shape for replay compatibility."""
+
+    def test_schema_version_is_v1(self) -> None:
+        assert SCHEMA_VERSION == "1.0"
+
+    def test_registry_includes_all_native_lifecycle_types(self) -> None:
+        """NATIVE_LIFECYCLE_EVENT_TYPES must all appear in the registry.
+
+        Primitive H.1 replay assumes every native lifecycle event type is
+        replayable — dropping one silently would break reconstruction of
+        sessions that include the missing type.
+        """
+        missing = [
+            t for t in NATIVE_LIFECYCLE_EVENT_TYPES if t not in EVENT_FIELD_REGISTRY
+        ]
+        assert missing == [], f"Missing native lifecycle types: {missing}"
+
+    def test_task_types_require_packet_id(self) -> None:
+        """``task_started`` / ``task_completed`` both require ``packet_id``.
+
+        Replay lifecycle reconstruction depends on packet_id as the join key.
+        """
+        for event_type in ("task_started", "task_completed"):
+            spec = EVENT_FIELD_REGISTRY[event_type]
+            assert (
+                "packet_id" in spec.required_fields
+            ), f"{event_type} must require packet_id for replay join"
+
+    def test_latency_events_register_latency_ms(self) -> None:
+        """Latency events carry a numeric latency field at top level."""
+        assert (
+            "latency_ms"
+            in EVENT_FIELD_REGISTRY["event_to_signal_latency"].required_fields
+        )
+        assert (
+            "delivery_ms"
+            in EVENT_FIELD_REGISTRY["bus_delivery_latency"].required_fields
+        )

--- a/tests/unit/test_agent_readability_lint.py
+++ b/tests/unit/test_agent_readability_lint.py
@@ -716,3 +716,181 @@ def test_live_steward_platform_tree_is_clean() -> None:
     findings = arl.check_verification_contract([target], repo_root=repo_root)
     blocks = [f for f in findings if f.severity == arl.Severity.BLOCK]
     assert not blocks, "BLOCK findings:\n" + "\n".join(f.format_line() for f in blocks)
+
+
+# ---------------------------------------------------------------------------
+# check verification-contract — rules VC4 (unknown event_type) and VC5
+# (§9.7 IDs routed through extra_fields) — Primitive A §8.2 step 9
+# ---------------------------------------------------------------------------
+
+
+def _setup_fake_repo_with_emitter(
+    tmp_path: Path,
+    emit_body: str,
+    *,
+    registered_types: tuple[str, ...] = ("task_started", "task_completed"),
+) -> Path:
+    """Build a minimal fake repo tree under ``tmp_path`` that the lint can
+    scan.  Writes a stub ``event_schema.py`` with the given registry so the
+    VC4 "unknown-type" check resolves.
+    """
+    # Stub event_schema.py so VC4 can resolve EVENT_FIELD_REGISTRY.
+    schema_dir = tmp_path / "src" / "bid_euchre" / "ops"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "__init__.py").write_text("")
+    (tmp_path / "src" / "bid_euchre" / "__init__.py").write_text("")
+    registry_repr = "{" + ", ".join(f"{t!r}: object()" for t in registered_types) + "}"
+    (schema_dir / "event_schema.py").write_text(
+        f"EVENT_FIELD_REGISTRY = {registry_repr}\n"
+    )
+    # Plant the emitter file under scripts/ so the scan picks it up.
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    emitter = scripts_dir / "emitter.py"
+    emitter.write_text(emit_body)
+    return emitter
+
+
+def test_vc4_blocks_unknown_event_type(tmp_path: Path) -> None:
+    emitter = _setup_fake_repo_with_emitter(
+        tmp_path,
+        emit_body='events.emit("not_a_real_event", packet_id="x")\n',
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    vc4 = [f for f in findings if f.rule_id == "VC4"]
+    assert vc4, "expected VC4 finding for unknown event_type"
+    assert all(f.severity == arl.Severity.BLOCK for f in vc4)
+    assert any(emitter.samefile(f.path) for f in vc4)
+
+
+def test_vc4_silent_for_registered_type(tmp_path: Path) -> None:
+    _setup_fake_repo_with_emitter(
+        tmp_path,
+        emit_body='events.emit("task_started", packet_id="x")\n',
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    assert not any(f.rule_id == "VC4" for f in findings)
+
+
+def test_vc4_recognises_all_spellings(tmp_path: Path) -> None:
+    """VC4 fires on each of events.emit / emit / v1_emit call spellings."""
+    _setup_fake_repo_with_emitter(
+        tmp_path,
+        emit_body=(
+            'events.emit("bad_one", x=1)\n'
+            'emit("bad_two", x=1)\n'
+            'v1_emit("bad_three", x=1)\n'
+        ),
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    vc4_types = [
+        f.message.split("(")[1].split(",")[0].strip().strip("'\"")
+        for f in findings
+        if f.rule_id == "VC4"
+    ]
+    # We captured something; assertion on content:
+    assert len([f for f in findings if f.rule_id == "VC4"]) == 3
+    assert any("bad_" in t or "not" in t for t in vc4_types)
+
+
+def test_vc5_warns_when_session_id_in_extra_fields(tmp_path: Path) -> None:
+    _setup_fake_repo_with_emitter(
+        tmp_path,
+        emit_body=(
+            'events.emit("task_started", packet_id="x",\n'
+            '            extra_fields={"session_id": "s1", "note": "ok"})\n'
+        ),
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    vc5 = [f for f in findings if f.rule_id == "VC5"]
+    assert vc5, "expected VC5 for §9.7 id leaked through extra_fields"
+    assert all(f.severity == arl.Severity.WARN for f in vc5)
+    assert "session_id" in vc5[0].message
+
+
+def test_vc5_warns_on_any_first_class_id(tmp_path: Path) -> None:
+    """VC5 fires for each of the 9 §9.7 first-class IDs."""
+    ids_to_test = [
+        "project_id",
+        "cell_id",
+        "session_id",
+        "task_id",
+        "lane_id",
+        "trace_id",
+        "incident_fingerprint",
+        "prompt_policy_version",
+        "schema_version",
+    ]
+    for idk in ids_to_test:
+        sub = tmp_path / idk
+        sub.mkdir()
+        _setup_fake_repo_with_emitter(
+            sub,
+            emit_body=(
+                f'events.emit("task_started", packet_id="x",\n'
+                f'            extra_fields={{"{idk}": "v"}})\n'
+            ),
+        )
+        findings = arl.check_verification_contract([sub / "plans"], repo_root=sub)
+        vc5 = [f for f in findings if f.rule_id == "VC5"]
+        assert vc5, f"expected VC5 finding for {idk}"
+        assert idk in vc5[0].message
+
+
+def test_vc5_silent_when_extra_fields_holds_non_first_class(
+    tmp_path: Path,
+) -> None:
+    """Non-§9.7 keys routed through extra_fields do NOT trigger VC5."""
+    _setup_fake_repo_with_emitter(
+        tmp_path,
+        emit_body=(
+            'events.emit("task_started", packet_id="x",\n'
+            '            extra_fields={"custom_note": "ok"})\n'
+        ),
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    assert not any(f.rule_id == "VC5" for f in findings)
+
+
+def test_vc4_vc5_skip_when_schema_unavailable(tmp_path: Path) -> None:
+    """If event_schema.py is absent, VC4/VC5 silently no-op (best-effort)."""
+    # Only scripts/ exists; no src/bid_euchre/ops/event_schema.py.
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "x.py").write_text('events.emit("totally_bogus", x=1)\n')
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    # No finding because schema could not be loaded.
+    assert not any(f.rule_id in {"VC4", "VC5"} for f in findings)
+
+
+def test_vc4_vc5_exclude_library_modules(tmp_path: Path) -> None:
+    """emit() calls inside events.py/event_schema.py itself are not flagged."""
+    schema_dir = tmp_path / "src" / "bid_euchre" / "ops"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "__init__.py").write_text("")
+    (tmp_path / "src" / "bid_euchre" / "__init__.py").write_text("")
+    (schema_dir / "event_schema.py").write_text(
+        'EVENT_FIELD_REGISTRY = {"task_started": object()}\n'
+    )
+    # Plant a fake events.py that mentions emit() but is excluded.
+    (schema_dir / "events.py").write_text(
+        'events.emit("some_totally_unknown_thing", x=1)\n'
+    )
+    findings = arl.check_verification_contract([tmp_path / "plans"], repo_root=tmp_path)
+    assert not any(f.rule_id in {"VC4", "VC5"} for f in findings)
+
+
+def test_live_repo_has_no_vc4_vc5_findings() -> None:
+    """Regression guard: the live repo's emit() call-sites lint clean.
+
+    This catches accidental introductions of unregistered event_type
+    literals (VC4) or §9.7 IDs mis-routed through extra_fields (VC5).
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "plans" / "steward_platform"
+    if not target.exists():
+        pytest.skip(f"steward_platform tree not found at {target}")
+    findings = arl.check_verification_contract([target], repo_root=repo_root)
+    offenders = [f for f in findings if f.rule_id in {"VC4", "VC5"}]
+    assert not offenders, "VC4/VC5 findings on live repo:\n" + "\n".join(
+        f.format_line() for f in offenders
+    )

--- a/tests/unit/test_audit_event_emission.py
+++ b/tests/unit/test_audit_event_emission.py
@@ -1,0 +1,363 @@
+"""Unit tests for ``scripts/internal/audit_event_emission.py``.
+
+Covers Primitive A §8.2 step 8 acceptance: the audit walks scanned roots
++ native hook registry, classifies coverage into green/yellow/red, and
+prints/exits accordingly.
+
+Fixtures are seeded (in-memory JSON + tmp_path Python files); no
+dependency on the live repo tree so the tests remain deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the script importable as a module so internal helpers can be
+# exercised without re-invoking ``python`` for every test.
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "internal"
+    / "audit_event_emission.py"
+)
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+
+import audit_event_emission as audit  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# scan_emit_call_sites
+# ---------------------------------------------------------------------------
+
+
+class TestScanEmitCallSites:
+    def test_finds_events_emit_call(self, tmp_path: Path) -> None:
+        """``events.emit("<type>", ...)`` is picked up as a call-site."""
+        src = tmp_path / "example.py"
+        src.write_text('from foo import events\nevents.emit("task_started", x=1)\n')
+        found = audit.scan_emit_call_sites((tmp_path,))
+        assert "task_started" in found
+        assert src in found["task_started"]
+
+    def test_finds_bare_emit_alias(self, tmp_path: Path) -> None:
+        """``emit("<type>", ...)`` (bare name) is also picked up."""
+        src = tmp_path / "bare.py"
+        src.write_text('emit("task_completed", outcome="merged")\n')
+        found = audit.scan_emit_call_sites((tmp_path,))
+        assert "task_completed" in found
+
+    def test_finds_v1_emit_alias(self, tmp_path: Path) -> None:
+        """The ``v1_emit`` alias used in ops.py is also recognised."""
+        src = tmp_path / "ops_alias.py"
+        src.write_text('v1_emit("task_started", packet_id="x")\n')
+        found = audit.scan_emit_call_sites((tmp_path,))
+        assert "task_started" in found
+
+    def test_ignores_non_emit_lines(self, tmp_path: Path) -> None:
+        """Unrelated lines do not produce spurious matches."""
+        src = tmp_path / "quiet.py"
+        src.write_text(
+            "# events.emit is mentioned in a comment but has no parens\n"
+            'print("task_started")\n'
+        )
+        found = audit.scan_emit_call_sites((tmp_path,))
+        assert found == {}
+
+    def test_dedupes_same_file(self, tmp_path: Path) -> None:
+        """Multiple emit calls in one file → one path entry per type."""
+        src = tmp_path / "many.py"
+        src.write_text(
+            'events.emit("task_started", x=1)\n'
+            'events.emit("task_started", x=2)\n'
+            'events.emit("task_completed", outcome="x")\n'
+        )
+        found = audit.scan_emit_call_sites((tmp_path,))
+        assert found["task_started"] == [src]
+        assert found["task_completed"] == [src]
+
+    def test_excludes_audit_script_itself(self) -> None:
+        """Self-matches from the audit script are filtered (regex prevents
+        feedback-loop counting)."""
+        # By default the scanner excludes the audit module (it imports
+        # constants referencing event names). Using the real repo roots
+        # for this tests the live repo's audit.py exclusion.
+        repo_root = Path(__file__).resolve().parents[2]
+        found = audit.scan_emit_call_sites((repo_root / "scripts" / "internal",))
+        for paths in found.values():
+            assert audit.__file__ not in {
+                str(p.resolve()) for p in paths
+            }, "audit_event_emission.py should not appear as an emitter"
+
+
+# ---------------------------------------------------------------------------
+# scan_native_hook_registrations
+# ---------------------------------------------------------------------------
+
+
+class TestScanNativeHookRegistrations:
+    def test_detects_registered_hook(self, tmp_path: Path) -> None:
+        cfg = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/event_emit.sh pre_tool_use",
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps(cfg))
+        result = audit.scan_native_hook_registrations(settings)
+        assert result["pre_tool_use"] is True
+        # Unregistered types flagged False.
+        assert result["post_tool_use"] is False
+
+    def test_missing_settings_returns_all_false(self, tmp_path: Path) -> None:
+        """A nonexistent settings.json yields all-False (no crash)."""
+        result = audit.scan_native_hook_registrations(tmp_path / "missing.json")
+        assert all(v is False for v in result.values())
+
+    def test_malformed_settings_returns_all_false(self, tmp_path: Path) -> None:
+        """Malformed JSON does not crash the audit."""
+        bad = tmp_path / "settings.json"
+        bad.write_text("not-json {{{{")
+        result = audit.scan_native_hook_registrations(bad)
+        assert all(v is False for v in result.values())
+
+    def test_detects_all_15_native_hooks_in_live_settings(self) -> None:
+        """The live .claude/settings.json registers all 15 native hook types."""
+        repo_root = Path(__file__).resolve().parents[2]
+        settings = repo_root / ".claude" / "settings.json"
+        result = audit.scan_native_hook_registrations(settings)
+        # All 15 native types should now be registered (Step 6 completed).
+        missing = [t for t, ok in result.items() if not ok]
+        assert not missing, f"Missing native hook registrations: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# build_audit_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuditReport:
+    def test_green_when_all_classes_have_emitter(self) -> None:
+        """All classes covered → overall green."""
+        # Build a fake emit_sites dict that covers every class member.
+        emit_sites = {
+            t: [Path("fake/fake.py")]
+            for members in audit.STEWARD_OPERATIONAL_CLASSES.values()
+            for t in members
+        }
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        report = audit.build_audit_report(emit_sites, native_status)
+        assert report.overall == "green"
+        assert all(c.status == "green" for c in report.classes)
+        assert report.native_hooks_missing == []
+
+    def test_yellow_for_deferred_class(self) -> None:
+        """Class with no coverage but in DEFERRED_CLASSES → yellow."""
+        emit_sites = {
+            # Only task_lifecycle covered; others bare.
+            "task_started": [Path("fake.py")],
+            "task_completed": [Path("fake.py")],
+        }
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        report = audit.build_audit_report(emit_sites, native_status)
+        # task_lifecycle green, deferred classes yellow.
+        by_name = {c.class_name: c for c in report.classes}
+        assert by_name["task_lifecycle"].status == "green"
+        for deferred_class in audit.DEFERRED_CLASSES:
+            assert by_name[deferred_class].status == "yellow"
+            assert (
+                by_name[deferred_class].deferred_to
+                == (audit.DEFERRED_CLASSES[deferred_class])
+            )
+        # Overall yellow because deferred classes lack emitters (yet).
+        assert report.overall == "yellow"
+
+    def test_red_when_non_deferred_class_has_zero_coverage(self) -> None:
+        """If a class is missing coverage and NOT in DEFERRED_CLASSES, red."""
+        emit_sites: dict[str, list[Path]] = {}
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        # Stub DEFERRED_CLASSES to empty so task_lifecycle is not deferred.
+        import copy
+
+        original_deferred = copy.copy(audit.DEFERRED_CLASSES)
+        try:
+            audit.DEFERRED_CLASSES.clear()
+            report = audit.build_audit_report(emit_sites, native_status)
+            by_name = {c.class_name: c for c in report.classes}
+            assert by_name["task_lifecycle"].status == "red"
+            assert report.overall == "red"
+        finally:
+            audit.DEFERRED_CLASSES.update(original_deferred)
+
+    def test_native_hook_missing_promotes_green_to_yellow(self) -> None:
+        """Full class coverage but missing native hook → overall yellow."""
+        emit_sites = {
+            t: [Path("x.py")]
+            for members in audit.STEWARD_OPERATIONAL_CLASSES.values()
+            for t in members
+        }
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        native_status["pre_tool_use"] = False  # One missing.
+        report = audit.build_audit_report(emit_sites, native_status)
+        assert "pre_tool_use" in report.native_hooks_missing
+        assert report.overall == "yellow"
+
+    def test_registered_types_count_reflects_schema(self) -> None:
+        """registered_event_types matches EVENT_FIELD_REGISTRY."""
+        emit_sites: dict[str, list[Path]] = {}
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        report = audit.build_audit_report(emit_sites, native_status)
+        assert report.registered_event_types == len(audit.EVENT_FIELD_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# format_report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport:
+    def test_renders_green_banner(self) -> None:
+        emit_sites = {
+            t: [Path("f.py")]
+            for members in audit.STEWARD_OPERATIONAL_CLASSES.values()
+            for t in members
+        }
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        report = audit.build_audit_report(emit_sites, native_status)
+        out = audit.format_report(report)
+        assert "GREEN" in out
+        assert "all 15 native lifecycle hooks subscribed" in out
+        assert "all 7 steward operational classes" in out
+
+    def test_renders_yellow_summary_for_deferred(self) -> None:
+        emit_sites = {
+            "task_started": [Path("f.py")],
+            "task_completed": [Path("f.py")],
+        }
+        native_status = dict.fromkeys(audit.NATIVE_LIFECYCLE_EVENT_TYPES, True)
+        report = audit.build_audit_report(emit_sites, native_status)
+        out = audit.format_report(report)
+        assert "YELLOW" in out
+        assert "deferred → Primitive" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (subprocess) — verifies exit codes + arg parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCliIntegration:
+    def _run(self, *extra: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+        cmd = [sys.executable, str(SCRIPT_PATH), *extra]
+        return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, check=False)
+
+    def test_json_mode_parses(self) -> None:
+        """--json prints a parseable payload with required top-level keys."""
+        result = self._run("--json")
+        assert result.returncode in (0, 1)
+        payload = json.loads(result.stdout)
+        for key in (
+            "overall",
+            "native_hook_coverage_pct",
+            "native_hooks_missing",
+            "classes",
+            "emit_call_site_count",
+            "registered_event_types",
+            "covered_event_types",
+        ):
+            assert key in payload
+
+    def test_exit_zero_on_live_repo_green_or_yellow(self) -> None:
+        """Run against the actual repo — Phase 0 expects green or yellow."""
+        result = self._run()
+        # Exit 0 for green/yellow; exit 1 if any class is red.
+        assert result.returncode == 0, (
+            f"Audit failed on live repo (stdout below):\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+    def test_strict_mode_tightens_exit_code(self) -> None:
+        """--strict exits non-zero on yellow too."""
+        result = self._run("--strict", "--json")
+        # Current Phase 0 expected state is yellow (deferred classes);
+        # --strict should be non-zero.  If repo progresses to green, this
+        # becomes 0, which is also acceptable.
+        payload = json.loads(result.stdout)
+        if payload["overall"] == "yellow":
+            assert result.returncode == 1
+        elif payload["overall"] == "green":
+            assert result.returncode == 0
+        else:
+            assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Coverage invariants (regression guards)
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageInvariants:
+    def test_native_event_mapping_covers_all_15_types(self) -> None:
+        """NATIVE_EVENT_TO_HOOK_SECTION is exhaustive over native types."""
+        for t in audit.NATIVE_LIFECYCLE_EVENT_TYPES:
+            assert (
+                t in audit.NATIVE_EVENT_TO_HOOK_SECTION
+            ), f"Missing hook-section mapping for {t!r}"
+
+    def test_deferred_classes_are_real_classes(self) -> None:
+        """Every deferred class is a member of STEWARD_OPERATIONAL_CLASSES."""
+        for class_name in audit.DEFERRED_CLASSES:
+            assert class_name in audit.STEWARD_OPERATIONAL_CLASSES
+
+    def test_primitive_a_completion_deferral_labeled(self) -> None:
+        """latency_measurements is deferred to Primitive A completion.
+
+        This is the only within-Primitive-A deferral — audit yellow is
+        expected until the dashboard panel ships.
+        """
+        assert audit.DEFERRED_CLASSES.get("latency_measurements") == "A"
+
+
+def test_task_lifecycle_class_is_live_covered() -> None:
+    """Integration guard: task_lifecycle should be green after Step 7.
+
+    ops.py (step 7 dual-write) installs the emit call-sites; confirming
+    this test passes is a regression guard against future accidental
+    removal of the emitters.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    roots = (
+        repo_root / "src" / "bid_euchre",
+        repo_root / "scripts",
+        repo_root / "tests",
+    )
+    sites = audit.scan_emit_call_sites(roots)
+    assert "task_started" in sites, "task_started emitter missing"
+    assert "task_completed" in sites, "task_completed emitter missing"
+
+
+@pytest.mark.parametrize("class_name", list(audit.STEWARD_OPERATIONAL_CLASSES.keys()))
+def test_each_class_appears_in_live_report(class_name: str) -> None:
+    """Every class shows up in the report, regardless of green/yellow/red."""
+    repo_root = Path(__file__).resolve().parents[2]
+    emit_sites = audit.scan_emit_call_sites(
+        (repo_root / "src" / "bid_euchre", repo_root / "scripts", repo_root / "tests")
+    )
+    native_status = audit.scan_native_hook_registrations(
+        repo_root / ".claude" / "settings.json"
+    )
+    report = audit.build_audit_report(emit_sites, native_status)
+    names = [c.class_name for c in report.classes]
+    assert class_name in names

--- a/tests/unit/test_event_schema.py
+++ b/tests/unit/test_event_schema.py
@@ -1,0 +1,215 @@
+"""Unit tests for ``bid_euchre.ops.event_schema``.
+
+Covers registry completeness, §9.7 first-class ID discipline, version
+constants, and EventTypeSpec introspection helpers per Primitive A Phase 0
+Readiness (shaping §2 + §6).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bid_euchre.ops import event_schema as es
+
+# ---------------------------------------------------------------------------
+# Version + baseline
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_v1_0():
+    """Phase 0 Readiness target per shaping §2.1."""
+    assert es.SCHEMA_VERSION == "1.0"
+
+
+def test_first_class_id_fields_has_nine_entries():
+    """§9.7 first-class IDs per shaping §2.3."""
+    assert len(es.FIRST_CLASS_ID_FIELDS) == 9
+    assert set(es.FIRST_CLASS_ID_FIELDS) == {
+        "project_id",
+        "cell_id",
+        "session_id",
+        "task_id",
+        "lane_id",
+        "trace_id",
+        "incident_fingerprint",
+        "prompt_policy_version",
+        "schema_version",
+    }
+
+
+def test_correlation_fields_has_four_entries():
+    """ADR 007 adopted pattern per shaping §2.4."""
+    assert len(es.CORRELATION_FIELDS) == 4
+    assert set(es.CORRELATION_FIELDS) == {"seq", "pid", "timestamp_ns", "turn_id"}
+
+
+def test_verbosity_tiers_enumerated():
+    """Three tiers per ADR 007 / shaping §3.3."""
+    assert set(es.VERBOSITY_TIERS) == {"minimal", "summary", "full"}
+
+
+def test_baseline_fields_union_of_ids_and_correlation_and_event_type():
+    """Baseline fields populated by dispatcher on every record."""
+    expected = (
+        set(es.FIRST_CLASS_ID_FIELDS) | set(es.CORRELATION_FIELDS) | {"event_type"}
+    )
+    assert set(es.BASELINE_FIELDS) == expected
+    assert set(es.baseline_fields()) == expected
+
+
+# ---------------------------------------------------------------------------
+# EVENT_FIELD_REGISTRY completeness
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_at_least_35_event_types():
+    """Shaping §2.2 total: 18 native/lifecycle/task + 4 canary + 4 archivist
+    + 4 promotion + 3 rollback + 2 latency = 35 event types minimum."""
+    assert len(es.EVENT_FIELD_REGISTRY) >= 35
+
+
+def test_registry_includes_all_native_lifecycle_types():
+    """All 15 native lifecycle hook events absorbed at v1.0 per §4.1."""
+    for event_type in es.NATIVE_LIFECYCLE_EVENT_TYPES:
+        assert (
+            event_type in es.EVENT_FIELD_REGISTRY
+        ), f"missing native lifecycle event type: {event_type}"
+
+
+def test_registry_includes_all_steward_operational_classes():
+    """≥4 steward operational classes required per Phase 0 Readiness (§6.2)."""
+    # 7 classes declared in schema; Phase 0 requires ≥4.
+    assert len(es.STEWARD_OPERATIONAL_CLASSES) >= 4
+    for class_name, event_types in es.STEWARD_OPERATIONAL_CLASSES.items():
+        assert len(event_types) >= 1, f"class {class_name} has no event types"
+        for event_type in event_types:
+            assert (
+                event_type in es.EVENT_FIELD_REGISTRY
+            ), f"class {class_name} references unregistered type {event_type}"
+
+
+def test_registry_includes_canary_lifecycle_types():
+    """H.0 canary types registered at v1.0 per §4.3 coordination."""
+    canary_types = es.STEWARD_OPERATIONAL_CLASSES["canary_lifecycle"]
+    assert len(canary_types) == 4
+    for t in canary_types:
+        assert es.is_known_event_type(t)
+
+
+def test_registry_includes_worktree_types():
+    """Primitive G coupling per shaping §4.3 — schema registers, G emits."""
+    assert es.is_known_event_type("worktree_create")
+    assert es.is_known_event_type("worktree_remove")
+
+
+def test_all_event_type_specs_are_eventtype_spec_instances():
+    """Every registry value must be an EventTypeSpec."""
+    for event_type, spec in es.EVENT_FIELD_REGISTRY.items():
+        assert isinstance(
+            spec, es.EventTypeSpec
+        ), f"{event_type} spec is {type(spec)!r}, not EventTypeSpec"
+
+
+def test_all_verbosity_defaults_are_valid():
+    """Every registered type has a valid verbosity_default."""
+    for event_type, spec in es.EVENT_FIELD_REGISTRY.items():
+        assert (
+            spec.verbosity_default in es.VERBOSITY_TIERS
+        ), f"{event_type} has invalid verbosity_default {spec.verbosity_default!r}"
+
+
+def test_required_and_optional_fields_disjoint_per_event_type():
+    """A field may be either required or optional, not both."""
+    for event_type, spec in es.EVENT_FIELD_REGISTRY.items():
+        overlap = set(spec.required_fields) & set(spec.optional_fields)
+        assert (
+            not overlap
+        ), f"{event_type} has fields in both required and optional: {overlap}"
+
+
+def test_no_event_type_uses_baseline_field_as_required_or_optional():
+    """Registered slots must not collide with baseline fields — baseline
+    is populated by the dispatcher, not by the caller."""
+    baseline = set(es.BASELINE_FIELDS)
+    for event_type, spec in es.EVENT_FIELD_REGISTRY.items():
+        all_slots = set(spec.required_fields) | set(spec.optional_fields)
+        collision = all_slots & baseline
+        # `event_type` is a baseline key; it's fine for the string to
+        # collide as a bare token, but not as a registered slot.
+        assert not collision, f"{event_type} slot(s) collide with baseline: {collision}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_known_event_type_positive():
+    assert es.is_known_event_type("task_started")
+    assert es.is_known_event_type("pre_tool_use")
+    assert es.is_known_event_type("canary_run_complete")
+
+
+def test_is_known_event_type_negative():
+    assert not es.is_known_event_type("bogus_event_type")
+    assert not es.is_known_event_type("")
+    assert not es.is_known_event_type("recap_summary")  # Phase 1 deferral per §4.6
+
+
+def test_get_spec_returns_correct_spec():
+    spec = es.get_spec("task_started")
+    assert spec is not None
+    assert isinstance(spec, es.EventTypeSpec)
+    assert "packet_id" in spec.required_fields
+
+
+def test_get_spec_unknown_returns_none():
+    assert es.get_spec("definitely_not_registered") is None
+
+
+def test_registered_types_sorted_and_complete():
+    types = es.registered_types()
+    assert len(types) == len(es.EVENT_FIELD_REGISTRY)
+    assert list(types) == sorted(types)
+
+
+def test_known_field_for_event_recognizes_required():
+    assert es.known_field_for_event("task_started", "packet_id")
+    assert es.known_field_for_event("task_started", "dispatched_by")
+
+
+def test_known_field_for_event_recognizes_optional():
+    assert es.known_field_for_event("task_started", "effort_hint")
+
+
+def test_known_field_for_event_negative():
+    assert not es.known_field_for_event("task_started", "bogus_field")
+    assert not es.known_field_for_event("unknown_event", "any_field")
+
+
+def test_eventtype_spec_known_field_helper():
+    spec = es.EventTypeSpec(required_fields=("r1",), optional_fields=("o1",))
+    assert spec.known_field("r1")
+    assert spec.known_field("o1")
+    assert not spec.known_field("other")
+
+
+def test_eventtype_spec_is_frozen():
+    spec = es.EventTypeSpec()
+    with pytest.raises((AttributeError, Exception)):  # dataclass(frozen=True)
+        spec.required_fields = ("x",)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 deferral guard — recap absorption is not in v1.0
+# ---------------------------------------------------------------------------
+
+
+def test_recap_absorption_is_not_in_v1_0():
+    """Per shaping §4.6: recap absorption is Phase 1 work. Guard against
+    accidental Phase 0 registration."""
+    for event_type in es.EVENT_FIELD_REGISTRY:
+        assert "recap" not in event_type.lower(), (
+            f"recap event {event_type!r} is Phase 1 per §4.6 — must not "
+            f"appear in v1.0 registry"
+        )

--- a/tests/unit/test_event_taxonomy.py
+++ b/tests/unit/test_event_taxonomy.py
@@ -1,0 +1,423 @@
+"""Unit tests for ``bid_euchre.ops.event_taxonomy``.
+
+Covers:
+
+- :func:`categorize_error` — taxonomy coverage for all five buckets,
+  priority ordering, null/empty input handling.
+- :func:`build_status_message` — specialized formatters per event type,
+  generic fallback, no-newline invariant, defensive behavior.
+- :func:`incident_fingerprint` — determinism, normalization, null-input
+  ``None`` return, extra-kwargs order independence.
+
+Per shaping §6.2: taxonomy helpers must be demonstrable before Packet 3
+closes; this test file is the verification surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bid_euchre.ops import event_taxonomy as et
+
+# ---------------------------------------------------------------------------
+# categorize_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_str,expected",
+    [
+        ("KeyboardInterrupt", "interrupted"),
+        ("received SIGINT", "interrupted"),
+        ("aborted by user", "interrupted"),
+        ("Ctrl-C pressed", "interrupted"),
+        ("Operation timed out after 30s", "timeout"),
+        ("deadline exceeded", "timeout"),
+        ("task timeout", "timeout"),
+        ("Permission denied: /etc/shadow", "permission_denied"),
+        ("EACCES", "permission_denied"),
+        ("EPERM", "permission_denied"),
+        ("forbidden endpoint", "permission_denied"),
+        ("Access denied", "permission_denied"),
+        ("unauthorized request", "permission_denied"),
+        ("Traceback (most recent call last)", "execution_error"),
+        ("ValueError: bad x", "execution_error"),
+        ("exited with non-zero status", "execution_error"),
+        ("Exception in thread", "execution_error"),
+        ("Something unknown happened", "other"),
+        ("", "other"),
+    ],
+)
+def test_categorize_error_mapping(error_str: str, expected: str) -> None:
+    assert et.categorize_error(error_str) == expected
+
+
+def test_categorize_error_none_is_other() -> None:
+    assert et.categorize_error(None) == "other"
+
+
+def test_categorize_error_interrupted_beats_execution_error() -> None:
+    """'KeyboardInterrupt' contains 'error' in a traceback; interrupted wins."""
+    msg = "Traceback...\nKeyboardInterrupt"
+    assert et.categorize_error(msg) == "interrupted"
+
+
+def test_categorize_error_timeout_beats_execution_error() -> None:
+    """'timed out' wins over generic 'error' text."""
+    msg = "Error: operation timed out after 30s"
+    assert et.categorize_error(msg) == "timeout"
+
+
+def test_categorize_error_permission_denied_beats_execution_error() -> None:
+    msg = "OSError: Permission denied"
+    assert et.categorize_error(msg) == "permission_denied"
+
+
+def test_error_categories_is_closed_vocabulary() -> None:
+    assert et.ERROR_CATEGORIES == (
+        "interrupted",
+        "timeout",
+        "permission_denied",
+        "execution_error",
+        "other",
+    )
+
+
+def test_categorize_error_output_is_always_in_closed_vocab() -> None:
+    samples = [
+        "KeyboardInterrupt",
+        "timed out",
+        "Permission denied",
+        "ValueError: x",
+        "foo bar baz",
+        "",
+        None,
+    ]
+    for s in samples:
+        assert et.categorize_error(s) in et.ERROR_CATEGORIES
+
+
+def test_categorize_error_exported_private_alias_exists() -> None:
+    """Shaping §3.6 specifies the exact internal name `_categorize_error`."""
+    assert et._categorize_error is et.categorize_error
+
+
+# ---------------------------------------------------------------------------
+# build_status_message — specialized formatters
+# ---------------------------------------------------------------------------
+
+
+def test_status_message_task_started() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "task_started",
+            "packet_id": "abc123def456",
+            "title": "Implement feature X",
+            "dispatched_by": "orchestrator",
+        }
+    )
+    assert "abc123def456" in msg
+    assert "Implement feature X" in msg
+    assert "orchestrator" in msg
+
+
+def test_status_message_task_completed_with_pr() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "task_completed",
+            "packet_id": "xyz789",
+            "outcome": "success",
+            "pr_number": 9999,
+        }
+    )
+    assert "xyz789" in msg
+    assert "success" in msg
+    assert "9999" in msg
+
+
+def test_status_message_task_completed_without_pr() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "task_completed",
+            "packet_id": "xyz789",
+            "outcome": "failed",
+        }
+    )
+    assert "xyz789" in msg
+    assert "failed" in msg
+    assert "PR" not in msg
+
+
+def test_status_message_post_tool_use_failure() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "post_tool_use_failure",
+            "tool_name": "Bash",
+            "error_category": "timeout",
+        }
+    )
+    assert "Bash" in msg
+    assert "timeout" in msg
+
+
+def test_status_message_stop_failure() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "stop_failure",
+            "failure_category": "permission_denied",
+        }
+    )
+    assert "permission_denied" in msg
+
+
+def test_status_message_canary_run_complete() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "canary_run_complete",
+            "canary_run_id": "r-001",
+            "scenarios_passed": 8,
+            "scenarios_total": 10,
+        }
+    )
+    assert "r-001" in msg
+    assert "8/10" in msg
+
+
+def test_status_message_canary_run_fail() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "canary_run_fail",
+            "canary_run_id": "r-002",
+            "scenarios_failed": 3,
+        }
+    )
+    assert "FAILED" in msg
+    assert "r-002" in msg
+    assert "3" in msg
+
+
+def test_status_message_notification_with_severity() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "notification",
+            "severity": "error",
+            "message": "Lane author-a timed out during /start-task",
+        }
+    )
+    assert "[error]" in msg
+    assert "author-a" in msg
+
+
+def test_status_message_promotion_start_and_complete() -> None:
+    s = et.build_status_message(
+        {"event_type": "promotion_start", "surface_id": "primitive-a"}
+    )
+    assert "Promotion started" in s
+    assert "primitive-a" in s
+    c = et.build_status_message(
+        {"event_type": "promotion_complete", "surface_id": "primitive-a"}
+    )
+    assert "Promotion complete" in c
+
+
+def test_status_message_rollback_triggered() -> None:
+    msg = et.build_status_message(
+        {
+            "event_type": "rollback_triggered",
+            "surface_id": "review_driver",
+            "reason": "precheck regression",
+        }
+    )
+    assert "Rollback" in msg
+    assert "review_driver" in msg
+    assert "precheck regression" in msg
+
+
+def test_status_message_generic_fallback() -> None:
+    msg = et.build_status_message(
+        {"event_type": "unregistered_event", "lane_id": "author-a"}
+    )
+    assert "unregistered_event" in msg
+    assert "author-a" in msg
+
+
+def test_status_message_empty_event_type() -> None:
+    # No event_type → fallback; should not crash
+    msg = et.build_status_message({"lane_id": "author-a"})
+    assert "author-a" in msg
+
+
+def test_status_message_always_single_line() -> None:
+    """Embedded newlines must be stripped per shaping §3.7 one-line contract."""
+    msg = et.build_status_message(
+        {
+            "event_type": "notification",
+            "severity": "info",
+            "message": "multi\nline\nmessage",
+        }
+    )
+    assert "\n" not in msg
+
+
+def test_status_message_defensive_on_missing_fields() -> None:
+    """Formatter receives partial record; must not raise."""
+    # task_started with no packet_id, no title, no dispatched_by
+    msg = et.build_status_message({"event_type": "task_started"})
+    assert isinstance(msg, str)
+    assert len(msg) > 0
+
+
+def test_status_message_long_title_truncated() -> None:
+    long_title = "x" * 200
+    msg = et.build_status_message(
+        {
+            "event_type": "task_started",
+            "packet_id": "abc",
+            "title": long_title,
+        }
+    )
+    # Ellipsis inserted at ~80 chars
+    assert "…" in msg
+
+
+def test_status_message_exported_private_alias_exists() -> None:
+    """Shaping §3.7 specifies exact internal name `_build_status_message`."""
+    assert et._build_status_message is et.build_status_message
+
+
+# ---------------------------------------------------------------------------
+# incident_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_none_for_empty_inputs() -> None:
+    assert et.incident_fingerprint() is None
+    assert (
+        et.incident_fingerprint(event_type=None, error_category=None, signature=None)
+        is None
+    )
+    assert (
+        et.incident_fingerprint(event_type="", error_category="", signature="") is None
+    )
+
+
+def test_fingerprint_deterministic_for_same_input() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="Operation timed out after 30s",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="Operation timed out after 30s",
+    )
+    assert a == b
+
+
+def test_fingerprint_normalization_collapses_whitespace() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="Operation timed out after 30s",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="  Operation   timed out    after 30s  ",
+    )
+    assert a == b
+
+
+def test_fingerprint_normalization_masks_absolute_paths() -> None:
+    a = et.incident_fingerprint(
+        event_type="post_tool_use_failure",
+        error_category="execution_error",
+        signature="Error reading /tmp/pytest-of-alice/worktree-123/foo.py",
+    )
+    b = et.incident_fingerprint(
+        event_type="post_tool_use_failure",
+        error_category="execution_error",
+        signature="Error reading /tmp/pytest-of-bob/worktree-999/foo.py",
+    )
+    assert a == b  # Different paths hash to same fingerprint
+
+
+def test_fingerprint_differs_on_different_signature() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="A timed out",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="B timed out",
+    )
+    assert a != b
+
+
+def test_fingerprint_differs_on_different_category() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="execution_error",
+        signature="x",
+    )
+    assert a != b
+
+
+def test_fingerprint_extra_fields_order_independent() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+        tool_name="Bash",
+        lane_id="author-a",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+        lane_id="author-a",
+        tool_name="Bash",
+    )
+    assert a == b
+
+
+def test_fingerprint_extra_fields_affect_hash() -> None:
+    a = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+        tool_name="Bash",
+    )
+    b = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+        tool_name="Edit",
+    )
+    assert a != b
+
+
+def test_fingerprint_is_16_hex_chars() -> None:
+    fp = et.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="x",
+    )
+    assert fp is not None
+    assert len(fp) == 16
+    int(fp, 16)  # must be valid hex
+
+
+def test_fingerprint_only_extra_still_produces_hash() -> None:
+    """Rare case: no principal inputs but extra kwargs present."""
+    fp = et.incident_fingerprint(lane_id="author-a")
+    assert fp is not None
+    assert len(fp) == 16

--- a/tests/unit/test_event_writer.py
+++ b/tests/unit/test_event_writer.py
@@ -1,0 +1,380 @@
+"""Unit tests for ``bid_euchre.ops.event_writer``.
+
+Covers:
+
+- Happy-path write + sidecar population (§3.2 metadata contract)
+- Rotation at ``STEWARD_EVENTS_MAX_FILE_BYTES`` boundary
+- Corruption-safety: damaged sidecar is overwritten, not fatal
+- Seq + turn counters: monotonicity, fresh start behavior
+- Cross-process ordering via file lock (smoke: single-process concurrent
+  threads as a proxy — POSIX flock is re-entrant per-process anyway)
+- Introspection helpers: ``list_active_files``, ``iter_sidecars``,
+  ``read_sidecar``
+
+Per Phase 0 Readiness (shaping §6.2): JSONL round-trip + locking + sidecar
+schema must be demonstrable before Packet 3 closes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops import event_writer as ew
+from bid_euchre.ops.event_schema import SCHEMA_VERSION
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path) -> Path:
+    """Isolated events log dir per test."""
+    d = tmp_path / "events"
+    d.mkdir()
+    return d
+
+
+def _record(
+    event_type: str = "task_started",
+    *,
+    seq: int = 1,
+    timestamp_ns: int = 1_700_000_000_000_000_000,
+    **extra,
+) -> dict:
+    rec = {
+        "event_type": event_type,
+        "seq": seq,
+        "timestamp_ns": timestamp_ns,
+        "schema_version": SCHEMA_VERSION,
+        "lane_id": "author-a",
+    }
+    rec.update(extra)
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Happy-path write
+# ---------------------------------------------------------------------------
+
+
+def test_write_event_creates_jsonl_file(log_dir: Path) -> None:
+    path = ew.write_event(_record(), log_dir=log_dir)
+    assert path.exists()
+    assert path.suffix == ".jsonl"
+    assert path.parent == log_dir
+
+
+def test_write_event_appends_one_line_per_call(log_dir: Path) -> None:
+    p1 = ew.write_event(_record(event_type="task_started", seq=1), log_dir=log_dir)
+    p2 = ew.write_event(_record(event_type="task_completed", seq=2), log_dir=log_dir)
+    assert p1 == p2  # Same file (no rotation)
+    lines = p1.read_text().splitlines()
+    assert len(lines) == 2
+    # Each line is valid JSON
+    rec1 = json.loads(lines[0])
+    rec2 = json.loads(lines[1])
+    assert rec1["event_type"] == "task_started"
+    assert rec2["event_type"] == "task_completed"
+
+
+def test_write_event_filename_uses_utc_date_and_counter(log_dir: Path) -> None:
+    path = ew.write_event(_record(), log_dir=log_dir)
+    # events-YYYY-MM-DD-NNN.jsonl
+    parts = path.stem.split("-")
+    assert parts[0] == "events"
+    # Date portion has 3 hyphens inside: YYYY-MM-DD
+    assert len(parts) == 5
+    assert parts[-1] == "001"  # First rotation on a fresh day
+
+
+def test_write_event_jsonl_line_is_valid_json(log_dir: Path) -> None:
+    ew.write_event(_record(extra_token="hello"), log_dir=log_dir)
+    path = next(iter(log_dir.glob("*.jsonl")))
+    line = path.read_text().strip()
+    parsed = json.loads(line)
+    assert parsed["extra_token"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Sidecar metadata contract
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_populates_first_and_last_seq(log_dir: Path) -> None:
+    ew.write_event(
+        _record(seq=5, timestamp_ns=1_700_000_000_000_000_000), log_dir=log_dir
+    )
+    ew.write_event(
+        _record(seq=6, timestamp_ns=1_700_000_000_000_000_500), log_dir=log_dir
+    )
+    ew.write_event(
+        _record(seq=7, timestamp_ns=1_700_000_000_000_001_000), log_dir=log_dir
+    )
+    meta_path = next(iter(log_dir.glob("*.meta.json")))
+    meta = json.loads(meta_path.read_text())
+    assert meta["first_seq"] == 5
+    assert meta["last_seq"] == 7
+    assert meta["first_timestamp_ns"] == 1_700_000_000_000_000_000
+    assert meta["last_timestamp_ns"] == 1_700_000_000_000_001_000
+    assert meta["event_count"] == 3
+    assert meta["schema_version"] == SCHEMA_VERSION
+
+
+def test_sidecar_tracks_event_types_sorted(log_dir: Path) -> None:
+    ew.write_event(_record(event_type="task_started", seq=1), log_dir=log_dir)
+    ew.write_event(_record(event_type="task_completed", seq=2), log_dir=log_dir)
+    ew.write_event(_record(event_type="task_started", seq=3), log_dir=log_dir)
+    meta_path = next(iter(log_dir.glob("*.meta.json")))
+    meta = json.loads(meta_path.read_text())
+    assert meta["event_types"] == ["task_completed", "task_started"]
+
+
+def test_sidecar_corruption_is_recovered_not_raised(log_dir: Path) -> None:
+    """A damaged .meta.json file should be overwritten, not crash the writer."""
+    ew.write_event(_record(seq=1), log_dir=log_dir)
+    meta_path = next(iter(log_dir.glob("*.meta.json")))
+    # Corrupt the sidecar
+    meta_path.write_text("not valid json {{{")
+    # Next write should recover and produce valid JSON
+    ew.write_event(_record(seq=2), log_dir=log_dir)
+    meta = json.loads(meta_path.read_text())
+    # Recovered meta starts fresh from the second write
+    assert meta["event_count"] == 1
+    assert meta["first_seq"] == 2
+    assert meta["last_seq"] == 2
+
+
+def test_read_sidecar_returns_none_for_missing(log_dir: Path) -> None:
+    assert ew.read_sidecar(log_dir / "nonexistent.meta.json") is None
+
+
+def test_read_sidecar_returns_none_for_corrupt(log_dir: Path) -> None:
+    bad = log_dir / "bad.meta.json"
+    bad.write_text("{{{{")
+    assert ew.read_sidecar(bad) is None
+
+
+def test_read_sidecar_roundtrip(log_dir: Path) -> None:
+    ew.write_event(_record(seq=1), log_dir=log_dir)
+    meta_path = next(iter(log_dir.glob("*.meta.json")))
+    meta = ew.read_sidecar(meta_path)
+    assert meta is not None
+    assert meta["event_count"] == 1
+    assert meta["schema_version"] == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Rotation
+# ---------------------------------------------------------------------------
+
+
+def test_rotation_triggers_at_max_bytes(log_dir: Path, monkeypatch) -> None:
+    """When the active file exceeds max_bytes, next write goes to a new file."""
+    monkeypatch.setenv("STEWARD_EVENTS_MAX_FILE_BYTES", "1024")  # 1 KB floor
+
+    # Write a batch of ~2 KB to force rotation
+    for i in range(20):  # each record ~200 bytes
+        ew.write_event(_record(seq=i, extra_padding="x" * 100), log_dir=log_dir)
+
+    files = sorted(log_dir.glob("events-*.jsonl"))
+    assert len(files) >= 2, f"Expected rotation to produce multiple files, got {files}"
+    # Counters 001 and 002 must be distinct
+    stems = [f.stem for f in files]
+    assert any(s.endswith("-001") for s in stems)
+    assert any(s.endswith("-002") for s in stems)
+
+
+def test_rotation_preserves_per_file_sidecar(log_dir: Path, monkeypatch) -> None:
+    """Each rotated file gets its own sidecar."""
+    monkeypatch.setenv("STEWARD_EVENTS_MAX_FILE_BYTES", "1024")
+
+    for i in range(20):
+        ew.write_event(_record(seq=i, extra_padding="y" * 100), log_dir=log_dir)
+
+    jsonl_files = sorted(log_dir.glob("events-*.jsonl"))
+    for jsonl_path in jsonl_files:
+        sidecar = jsonl_path.with_suffix(".meta.json")
+        assert sidecar.exists(), f"missing sidecar for {jsonl_path}"
+        meta = json.loads(sidecar.read_text())
+        assert meta["event_count"] > 0
+        assert meta["first_seq"] <= meta["last_seq"]
+
+
+def test_no_rotation_when_under_max_bytes(log_dir: Path, monkeypatch) -> None:
+    """Default 50 MB max — one-shot writes should stay in counter 001."""
+    # Use default (~50 MB)
+    monkeypatch.delenv("STEWARD_EVENTS_MAX_FILE_BYTES", raising=False)
+    for i in range(5):
+        ew.write_event(_record(seq=i), log_dir=log_dir)
+    files = list(log_dir.glob("events-*.jsonl"))
+    assert len(files) == 1
+    assert files[0].stem.endswith("-001")
+
+
+def test_max_file_bytes_floor_prevents_pathological_rotation(
+    log_dir: Path, monkeypatch
+) -> None:
+    """Values under 1 KB are clamped to 1 KB floor (prevents DoS)."""
+    monkeypatch.setenv("STEWARD_EVENTS_MAX_FILE_BYTES", "1")
+    # Write 3 records (~200 bytes each) — all should land in counter 001
+    # because the effective floor is 1 KB.
+    for i in range(3):
+        ew.write_event(_record(seq=i), log_dir=log_dir)
+    files = list(log_dir.glob("events-*.jsonl"))
+    assert len(files) == 1  # Floor prevented rotation
+
+
+def test_invalid_max_file_bytes_falls_back_to_default(
+    log_dir: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("STEWARD_EVENTS_MAX_FILE_BYTES", "not-a-number")
+    # Should not raise
+    ew.write_event(_record(), log_dir=log_dir)
+    assert ew._env_max_file_bytes() == ew.DEFAULT_MAX_FILE_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Seq + turn counters
+# ---------------------------------------------------------------------------
+
+
+def test_next_seq_is_monotonic(log_dir: Path) -> None:
+    s1 = ew.next_seq(log_dir=log_dir)
+    s2 = ew.next_seq(log_dir=log_dir)
+    s3 = ew.next_seq(log_dir=log_dir)
+    assert s2 == s1 + 1
+    assert s3 == s2 + 1
+
+
+def test_next_seq_starts_at_one_for_fresh_dir(log_dir: Path) -> None:
+    assert ew.next_seq(log_dir=log_dir) == 1
+
+
+def test_next_seq_persists_across_calls(log_dir: Path) -> None:
+    ew.next_seq(log_dir=log_dir)
+    ew.next_seq(log_dir=log_dir)
+    seq_file = log_dir / ew.SEQ_FILE_NAME
+    assert seq_file.exists()
+    assert int(seq_file.read_text().strip()) == 2
+
+
+def test_get_turn_id_returns_zero_initially(log_dir: Path) -> None:
+    assert ew.get_turn_id(log_dir=log_dir) == 0
+
+
+def test_increment_turn_id_is_monotonic(log_dir: Path) -> None:
+    t1 = ew.increment_turn_id(log_dir=log_dir)
+    t2 = ew.increment_turn_id(log_dir=log_dir)
+    assert t1 == 1
+    assert t2 == 2
+    assert ew.get_turn_id(log_dir=log_dir) == 2
+
+
+def test_turn_id_recovers_from_corrupted_file(log_dir: Path) -> None:
+    turn_path = log_dir / ew.TURN_FILE_NAME
+    turn_path.write_text("not-a-number")
+    # Should recover to 0 and increment to 1
+    assert ew.increment_turn_id(log_dir=log_dir) == 1
+
+
+# ---------------------------------------------------------------------------
+# Env knob routing
+# ---------------------------------------------------------------------------
+
+
+def test_env_log_dir_override(tmp_path: Path, monkeypatch) -> None:
+    custom_dir = tmp_path / "custom-events"
+    monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(custom_dir))
+    path = ew.write_event(_record())
+    assert custom_dir in path.parents
+
+
+def test_env_log_dir_default_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("STEWARD_EVENTS_LOG_DIR", raising=False)
+    assert ew._env_log_dir() == ew.DEFAULT_LOG_DIR
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers
+# ---------------------------------------------------------------------------
+
+
+def test_list_active_files_returns_todays_files_only(log_dir: Path) -> None:
+    # Write today's event
+    ew.write_event(_record(), log_dir=log_dir)
+    # Create a stale file for a different date
+    stale = log_dir / "events-2020-01-01-001.jsonl"
+    stale.write_text('{"event_type":"old"}\n')
+    active = ew.list_active_files(log_dir=log_dir)
+    assert len(active) == 1
+    assert "2020-01-01" not in active[0].name
+
+
+def test_list_active_files_empty_dir(tmp_path: Path) -> None:
+    assert ew.list_active_files(log_dir=tmp_path / "nonexistent") == []
+
+
+def test_iter_sidecars_returns_all(log_dir: Path) -> None:
+    ew.write_event(_record(seq=1), log_dir=log_dir)
+    # Also create an arbitrary-date sidecar
+    extra_meta = log_dir / "events-2020-01-01-001.meta.json"
+    extra_meta.write_text(json.dumps({"event_count": 5}))
+    sidecars = ew.iter_sidecars(log_dir=log_dir)
+    assert len(sidecars) == 2
+
+
+def test_iter_sidecars_empty_dir(tmp_path: Path) -> None:
+    assert ew.iter_sidecars(log_dir=tmp_path / "nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# Concurrency (smoke)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_writers_produce_one_line_per_write(log_dir: Path) -> None:
+    """File lock ensures no interleaved partial lines.
+
+    We can't easily reproduce cross-process fcntl semantics in-process
+    (same PID re-enters the lock), but we can assert that each line
+    produced is valid JSON and that the total count matches.
+    """
+    n_threads = 8
+    n_per = 10
+
+    def worker(start_seq: int) -> None:
+        for i in range(n_per):
+            ew.write_event(
+                _record(seq=start_seq + i, event_type="task_started"),
+                log_dir=log_dir,
+            )
+
+    threads = [
+        threading.Thread(target=worker, args=(t * n_per,)) for t in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    path = next(iter(log_dir.glob("*.jsonl")))
+    lines = path.read_text().splitlines()
+    assert len(lines) == n_threads * n_per
+    # Every line parses as JSON
+    for line in lines:
+        json.loads(line)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar path helper
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_path_transforms_suffix(tmp_path: Path) -> None:
+    jsonl = tmp_path / "events-2026-01-01-001.jsonl"
+    assert ew._sidecar_path(jsonl).name == "events-2026-01-01-001.meta.json"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,549 @@
+"""Unit tests for ``bid_euchre.ops.events`` Primitive A dispatcher.
+
+Covers per shaping §8.3:
+
+- Happy-path emission with full baseline population.
+- Never-raise contract — dispatcher swallows all exceptions.
+- Verbosity tier override (kwarg + env var + registry default).
+- Unknown-event-type rejection (no JSONL write).
+- Missing-required-field rejection (no JSONL write).
+- ``extra_fields`` routing for unregistered slots (Pattern 8).
+- §9.7 first-class ID population from env vars + caller overrides.
+- Legacy ``append_event`` / ``read_events`` surface preserved.
+- Reexported taxonomy helpers available on ``events`` module.
+
+The Primitive A dispatcher writes to a configurable ``data/events/``
+directory via :func:`bid_euchre.ops.event_writer.write_event` — tests
+use ``tmp_path`` + ``STEWARD_EVENTS_LOG_DIR`` to isolate per test.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bid_euchre.ops import events
+from bid_euchre.ops.event_schema import SCHEMA_VERSION
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def events_dir(tmp_path: Path, monkeypatch) -> Iterator[Path]:
+    """Isolated v1.0 events dir + cached-session reset."""
+    d = tmp_path / "data" / "events"
+    d.mkdir(parents=True)
+    monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(d))
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session-xyz")
+    monkeypatch.setenv("CLAUDE_AGENT_NAME", "author-a")
+    events.reset_cached_session()
+    yield d
+    events.reset_cached_session()
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read all JSONL records from the events file in a log dir."""
+    files = sorted(path.glob("events-*.jsonl"))
+    records: list[dict] = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_emit_happy_path_writes_jsonl(events_dir: Path) -> None:
+    events.emit(
+        "task_started",
+        packet_id="abc123",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    records = _read_jsonl(events_dir)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["event_type"] == "task_started"
+    assert rec["packet_id"] == "abc123"
+    assert rec["dispatched_by"] == "orchestrator"
+
+
+def test_emit_populates_all_nine_first_class_ids(events_dir: Path) -> None:
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    # All nine §9.7 IDs present
+    for fld in (
+        "project_id",
+        "cell_id",
+        "session_id",
+        "task_id",
+        "lane_id",
+        "trace_id",
+        "incident_fingerprint",
+        "prompt_policy_version",
+        "schema_version",
+    ):
+        assert fld in rec, f"missing §9.7 field: {fld}"
+    assert rec["project_id"] == "bid-euchre"
+    assert rec["cell_id"] == "bid-euchre"
+    assert rec["session_id"] == "test-session-xyz"
+    assert rec["lane_id"] == "author-a"
+    assert rec["schema_version"] == SCHEMA_VERSION
+
+
+def test_emit_populates_correlation_fields(events_dir: Path) -> None:
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    for fld in ("seq", "pid", "timestamp_ns", "turn_id"):
+        assert fld in rec, f"missing correlation field: {fld}"
+    assert isinstance(rec["seq"], int) and rec["seq"] >= 1
+    assert isinstance(rec["pid"], int) and rec["pid"] > 0
+    assert isinstance(rec["timestamp_ns"], int) and rec["timestamp_ns"] > 0
+    assert isinstance(rec["turn_id"], int)
+
+
+def test_emit_sequence_is_monotonic(events_dir: Path) -> None:
+    for i in range(5):
+        events.emit(
+            "task_started",
+            packet_id=f"pkt-{i}",
+            dispatched_by="orchestrator",
+            priority="normal",
+            domain="platform",
+        )
+    records = _read_jsonl(events_dir)
+    seqs = [r["seq"] for r in records]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)  # no duplicates
+
+
+# ---------------------------------------------------------------------------
+# Never-raise contract (ADR 007)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_never_raises_on_unknown_event_type(events_dir: Path) -> None:
+    # Should not raise
+    events.emit("definitely_not_a_registered_event_type", foo="bar")
+    # No JSONL write
+    assert _read_jsonl(events_dir) == []
+
+
+def test_emit_never_raises_on_missing_required(events_dir: Path) -> None:
+    # task_started requires packet_id, dispatched_by, priority, domain — omit all
+    events.emit("task_started")
+    # No JSONL write
+    assert _read_jsonl(events_dir) == []
+
+
+def test_emit_never_raises_on_writer_failure(events_dir: Path, monkeypatch) -> None:
+    """Simulate writer failure — caller still doesn't see an exception."""
+
+    def _broken_writer(record, log_dir=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(events.event_writer, "write_event", _broken_writer)
+    # No exception should propagate
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+
+
+def test_emit_never_raises_on_next_seq_failure(events_dir: Path, monkeypatch) -> None:
+    """Simulate seq counter failure — dispatcher remains non-blocking."""
+
+    def _broken_seq(log_dir=None):
+        raise OSError("fs broken")
+
+    monkeypatch.setattr(events.event_writer, "next_seq", _broken_seq)
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verbosity tiers
+# ---------------------------------------------------------------------------
+
+
+def test_emit_verbosity_summary_default(events_dir: Path) -> None:
+    events.emit(
+        "task_completed",
+        packet_id="abc",
+        outcome="success",
+        summary="This is a regular-sized summary",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    # summary tier includes required fields
+    assert rec["packet_id"] == "abc"
+    assert rec["outcome"] == "success"
+    # summary also preserves optional fields that the caller passed
+    assert "summary" in rec or rec.get("outcome") == "success"
+
+
+def test_emit_verbosity_minimal_strips_payload(events_dir: Path) -> None:
+    events.emit(
+        "task_completed",
+        _verbosity="minimal",
+        packet_id="abc",
+        outcome="success",
+        summary="bulky text",
+        token_spend=12345,
+    )
+    rec = _read_jsonl(events_dir)[0]
+    # Baseline fields retained
+    assert rec["event_type"] == "task_completed"
+    assert rec["session_id"] == "test-session-xyz"
+    # Optional bulky fields stripped in minimal tier
+    assert "summary" not in rec
+    assert "token_spend" not in rec
+    # packet_id is a required field but minimal drops non-baseline; that's
+    # OK because minimal is for high-frequency grep only.
+    # However outcome (success/failure hint) is preserved
+    assert rec["outcome"] == "success"
+
+
+def test_emit_verbosity_full_keeps_everything(events_dir: Path) -> None:
+    events.emit(
+        "task_completed",
+        _verbosity="full",
+        packet_id="abc",
+        outcome="success",
+        summary="full bulk payload",
+        token_spend=12345,
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["summary"] == "full bulk payload"
+    assert rec["token_spend"] == 12345
+
+
+def test_emit_verbosity_env_var_override(events_dir: Path, monkeypatch) -> None:
+    monkeypatch.setenv("STEWARD_EVENTS_VERBOSITY", "full")
+    events.emit(
+        "task_completed",
+        packet_id="abc",
+        outcome="success",
+        summary="env-override payload",
+        token_spend=9999,
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["summary"] == "env-override payload"
+
+
+def test_emit_verbosity_invalid_falls_back_to_summary(events_dir: Path) -> None:
+    events.emit(
+        "task_completed",
+        _verbosity="not-a-real-tier",
+        packet_id="abc",
+        outcome="success",
+    )
+    # Should not raise and should still emit
+    assert len(_read_jsonl(events_dir)) == 1
+
+
+def test_emit_summary_truncates_very_long_strings(events_dir: Path) -> None:
+    bulk = "x" * 5000
+    events.emit(
+        "task_completed",
+        packet_id="abc",
+        outcome="success",
+        summary=bulk,
+    )
+    rec = _read_jsonl(events_dir)[0]
+    if "summary" in rec:
+        assert len(rec["summary"]) <= 2000
+
+
+# ---------------------------------------------------------------------------
+# extra_fields routing (Pattern 8 bug marker)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_unregistered_field_routed_to_extra_fields(
+    events_dir: Path,
+) -> None:
+    events.emit(
+        "task_started",
+        _verbosity="full",  # Keep extra_fields visible
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+        novel_slot="some_value",  # Not in registry
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert "extra_fields" in rec
+    assert rec["extra_fields"]["novel_slot"] == "some_value"
+    # Known fields not routed to extra
+    assert "dispatched_by" not in rec.get("extra_fields", {})
+
+
+def test_emit_registered_optional_field_lands_at_top_level(
+    events_dir: Path,
+) -> None:
+    """Registered optional slots stay top-level (not routed to extra_fields).
+
+    Note: summary-tier filters optional fields by design (§3.3); use
+    ``_verbosity="full"`` to observe the pass-through here.
+    """
+    events.emit(
+        "task_started",
+        _verbosity="full",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+        effort_hint="low",  # registered optional
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["effort_hint"] == "low"
+    # Not routed to extra_fields
+    assert "effort_hint" not in rec.get("extra_fields", {})
+
+
+# ---------------------------------------------------------------------------
+# Caller overrides of §9.7 IDs
+# ---------------------------------------------------------------------------
+
+
+def test_emit_caller_trace_id_override(events_dir: Path) -> None:
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+        trace_id="custom-trace-42",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["trace_id"] == "custom-trace-42"
+
+
+def test_emit_caller_task_id_override(events_dir: Path) -> None:
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        task_id="explicit-task-id",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["task_id"] == "explicit-task-id"
+
+
+def test_emit_caller_lane_id_override(events_dir: Path) -> None:
+    """worktree_create targets a different lane than the emitter."""
+    events.emit(
+        "worktree_create",
+        worktree_path="/tmp/Bid-Euchre-foo",
+        branch="feat/x",
+        protected=False,
+        lane_id="flex-b",  # target lane
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["lane_id"] == "flex-b"
+
+
+def test_emit_default_lane_id_from_env(events_dir: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_AGENT_NAME", "analyst-c")
+    events.reset_cached_session()
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["lane_id"] == "analyst-c"
+
+
+def test_emit_session_id_falls_back_to_uuid(tmp_path: Path, monkeypatch) -> None:
+    """When CLAUDE_SESSION_ID is unset, dispatcher generates a UUID."""
+    d = tmp_path / "data" / "events"
+    d.mkdir(parents=True)
+    monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(d))
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    events.reset_cached_session()
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = json.loads(next(d.glob("*.jsonl")).read_text().splitlines()[0])
+    # Not the test sentinel value; a real UUID has 4 hyphens
+    sid = rec["session_id"]
+    assert sid != "test-session-xyz"
+    assert sid.count("-") == 4
+
+
+def test_emit_prompt_policy_version_unset_default(events_dir: Path) -> None:
+    """Primitive B.3 registry hasn't shipped — default value is ``unset``."""
+    rec_fields = dict(
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    events.emit("task_started", **rec_fields)
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["prompt_policy_version"] == "unset"
+
+
+def test_emit_prompt_policy_version_env_override(events_dir: Path, monkeypatch) -> None:
+    monkeypatch.setenv("STEWARD_PROMPT_POLICY_VERSION", "v2.3")
+    events.reset_cached_session()
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["prompt_policy_version"] == "v2.3"
+
+
+# ---------------------------------------------------------------------------
+# Incident fingerprint re-export
+# ---------------------------------------------------------------------------
+
+
+def test_events_reexports_taxonomy_helpers() -> None:
+    assert events.categorize_error is not None
+    assert events.build_status_message is not None
+    assert events.incident_fingerprint is not None
+    # They are the real taxonomy helpers
+    from bid_euchre.ops import event_taxonomy
+
+    assert events.categorize_error is event_taxonomy.categorize_error
+    assert events.incident_fingerprint is event_taxonomy.incident_fingerprint
+
+
+def test_emit_populates_incident_fingerprint_when_provided(
+    events_dir: Path,
+) -> None:
+    fp = events.incident_fingerprint(
+        event_type="stop_failure",
+        error_category="timeout",
+        signature="Operation timed out",
+    )
+    events.emit(
+        "stop_failure",
+        stop_hook_active=True,
+        failure_category="timeout",
+        incident_fingerprint=fp,
+    )
+    rec = _read_jsonl(events_dir)[0]
+    assert rec["incident_fingerprint"] == fp
+
+
+# ---------------------------------------------------------------------------
+# Legacy API preservation
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_append_event_still_works(tmp_path: Path) -> None:
+    """The pre-existing append_event path must keep working for 25+ consumers."""
+    legacy_dir = tmp_path / "runtime-events"
+    events.append_event(
+        event_type="task_completed",
+        source="test",
+        lane_id="author-a",
+        payload={"packet_id": "abc"},
+        events_dir=legacy_dir,
+    )
+    legacy_file = legacy_dir / events.EVENTS_FILE
+    assert legacy_file.exists()
+    rec = json.loads(legacy_file.read_text().splitlines()[0])
+    assert rec["event_type"] == "task_completed"
+    assert rec["lane_id"] == "author-a"
+    assert rec["payload"]["packet_id"] == "abc"
+
+
+def test_legacy_valid_event_types_unchanged() -> None:
+    """Legacy VALID_EVENT_TYPES is distinct from v1.0 registry."""
+    assert "task_started" in events.VALID_EVENT_TYPES
+    assert "task_completed" in events.VALID_EVENT_TYPES
+    # Legacy has types that are intentionally not in v1.0 (e.g., heartbeat_stale)
+    assert "heartbeat_stale" in events.VALID_EVENT_TYPES
+
+
+def test_legacy_and_new_apis_write_to_different_dirs(
+    events_dir: Path, tmp_path: Path
+) -> None:
+    """Legacy writes to events_dir= param; new writes to STEWARD_EVENTS_LOG_DIR."""
+    legacy_dir = tmp_path / "runtime-events"
+    events.append_event(
+        event_type="task_started",
+        source="test",
+        lane_id="author-a",
+        payload={},
+        events_dir=legacy_dir,
+    )
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+    )
+    # Two distinct pipelines
+    assert (legacy_dir / events.EVENTS_FILE).exists()
+    assert any(events_dir.glob("events-*.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# Audit-helper contract (used by audit_event_emission.py later)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_record_json_round_trip(events_dir: Path) -> None:
+    """Every record round-trips cleanly through JSON."""
+    events.emit(
+        "task_started",
+        packet_id="abc",
+        dispatched_by="orchestrator",
+        priority="high",
+        domain="platform",
+        effort_hint="low",
+    )
+    f = next(events_dir.glob("events-*.jsonl"))
+    line = f.read_text().splitlines()[0]
+    # No trailing comma / malformed JSON
+    rec = json.loads(line)
+    # Re-encoding produces a canonical form (writer uses sort_keys=True)
+    assert json.dumps(rec, sort_keys=True) == line.strip()

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -3939,6 +3939,181 @@ class TestTaskComplete:
             )
 
 
+class TestTaskDualWriteV1Dispatcher:
+    """Phase 0 dual-write: ops.py emits through both legacy and v1.0 pipelines.
+
+    Primitive A §8.2 step 7 mandates that ``task accept`` / ``task complete``
+    call the new ``events.emit`` dispatcher alongside the legacy
+    ``append_event`` so the v1.0 event stream bootstraps under
+    ``data/events/`` without breaking the ~25 legacy consumers that read
+    from ``.claude/runtime/events/``.
+    """
+
+    @staticmethod
+    def _read_v1_events(
+        v1_dir: Path, event_type: str | None = None
+    ) -> list[dict[str, object]]:
+        """Read all JSONL lines from the v1 data/events/ directory."""
+        records: list[dict[str, object]] = []
+        if not v1_dir.exists():
+            return records
+        for path in sorted(v1_dir.glob("events-*.jsonl")):
+            for line in path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                rec = json.loads(line)
+                if event_type is None or rec.get("event_type") == event_type:
+                    records.append(rec)
+        return records
+
+    def test_task_accept_writes_to_both_legacy_and_v1(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``task accept`` emits task_started through both pipelines."""
+        import ops
+
+        v1_events_dir = tmp_path / "v1_events"
+        monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(v1_events_dir))
+        # Reset the cached session id so a fresh session_id lands in the
+        # v1 baseline.
+        from bid_euchre.ops.events import reset_cached_session
+
+        reset_cached_session()
+
+        # Create a packet owned by author-b.
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "create",
+                "--title",
+                "Dual-write accept test",
+                "--owner",
+                "author-b",
+            ]
+        )
+        assert rc == 0
+        created = json.loads(capsys.readouterr().out)
+        packet_id = created["packet_id"]
+
+        rc = ops.main(
+            [
+                "--json",
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "accept",
+                packet_id,
+                "--lane",
+                "author-b",
+            ]
+        )
+        assert rc == 0
+        capsys.readouterr()
+
+        # Legacy pipeline untouched.
+        from bid_euchre.ops.events import read_events
+
+        legacy = read_events(runtime_dir / "events", event_type="task_started")
+        assert legacy, "legacy task_started event missing"
+        assert legacy[-1]["payload"]["packet_id"] == packet_id
+
+        # v1.0 pipeline now has the same event with §9.7 IDs + required fields.
+        v1 = self._read_v1_events(v1_events_dir, event_type="task_started")
+        assert len(v1) == 1, f"Expected 1 v1 task_started event, got {len(v1)}"
+        rec = v1[0]
+        # First-class fields present per EVENT_FIELD_REGISTRY.
+        assert rec["packet_id"] == packet_id
+        assert rec["priority"] == "normal"
+        assert rec["dispatched_by"]
+        # §9.7 baseline IDs populated at top level (not routed via extra_fields).
+        assert rec["lane_id"] == "author-b"
+        assert "session_id" in rec
+        assert "project_id" in rec
+        assert "seq" in rec
+        assert rec["schema_version"] == "1.0"
+
+    def test_task_complete_writes_to_both_legacy_and_v1(
+        self,
+        runtime_dir: Path,
+        plans_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``task complete`` emits task_completed through both pipelines."""
+        import ops
+
+        v1_events_dir = tmp_path / "v1_events"
+        monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(v1_events_dir))
+        # Full verbosity so optional fields (pr_number, shipped_outcome, etc.)
+        # survive the tier filter — summary tier intentionally drops them.
+        monkeypatch.setenv("STEWARD_EVENTS_VERBOSITY", "full")
+        from bid_euchre.ops.events import reset_cached_session
+
+        reset_cached_session()
+
+        packet_id = TestTaskComplete._create_dispatched_packet(
+            runtime_dir, plans_dir, capsys
+        )
+
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "task",
+                "complete",
+                packet_id,
+                "--summary",
+                "Dual-write complete test",
+                "--pr",
+                "4242",
+                "--by",
+                "author-a",
+                "--shipped-outcome",
+                "merged",
+            ]
+        )
+        assert rc == 0
+        capsys.readouterr()
+
+        # Legacy pipeline still active.
+        from bid_euchre.ops.events import read_events
+
+        legacy = read_events(runtime_dir / "events", event_type="task_completed")
+        assert legacy, "legacy task_completed event missing"
+
+        # v1.0 event carries required + optional schema fields and §9.7 IDs.
+        v1 = self._read_v1_events(v1_events_dir, event_type="task_completed")
+        assert len(v1) == 1, f"Expected 1 v1 task_completed event, got {len(v1)}"
+        rec = v1[0]
+        assert rec["packet_id"] == packet_id
+        # outcome is required — must not be routed through extra_fields.
+        assert rec["outcome"] == "merged"
+        assert "outcome" not in rec.get("extra_fields", {})
+        assert rec["pr_number"] == 4242
+        assert rec["completed_by"] == "author-a"
+        assert rec["shipped_outcome"] == "merged"
+        # §9.7 baseline IDs at top level.
+        assert rec["lane_id"] == "author-a"
+        assert "session_id" in rec
+        assert "seq" in rec
+        assert rec["schema_version"] == "1.0"
+
+
 class TestTaskUpdateMetadata:
     """Verify ``task update-metadata`` CLI subcommand (#2701)."""
 

--- a/tests/unit/test_ops_dashboard.py
+++ b/tests/unit/test_ops_dashboard.py
@@ -1538,3 +1538,243 @@ class TestCanarySummary:
         assert "Canary" in text
         assert "streak: 2" in text
         assert "status: success" in text
+
+
+# ---------------------------------------------------------------------------
+# Primitive A — Latencies panel (shaping §8.2 step 10)
+# ---------------------------------------------------------------------------
+
+
+def _write_events_jsonl(
+    events_dir: Path,
+    filename: str,
+    records: list[dict],
+) -> Path:
+    """Helper: write one events-YYYY-MM-DD-NNN.jsonl file with given records."""
+    events_dir.mkdir(parents=True, exist_ok=True)
+    path = events_dir / filename
+    with open(path, "w") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    return path
+
+
+class TestLatenciesPanel:
+    """Tests for the Primitive A Latencies panel on the dashboard."""
+
+    def test_load_latency_summary_empty_when_dir_missing(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        assert _load_latency_summary(tmp_path / "nonexistent") == {}
+
+    def test_load_latency_summary_empty_when_no_jsonl(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        assert _load_latency_summary(events_dir) == {}
+
+    def test_load_latency_summary_ignores_non_latency_events(
+        self, tmp_path: Path
+    ) -> None:
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        events_dir = tmp_path / "events"
+        _write_events_jsonl(
+            events_dir,
+            "events-2026-04-23-001.jsonl",
+            [
+                {"event_type": "task_started", "packet_id": "abc"},
+                {"event_type": "task_completed", "packet_id": "abc"},
+            ],
+        )
+        assert _load_latency_summary(events_dir) == {}
+
+    def test_load_latency_summary_computes_p50_p95(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        events_dir = tmp_path / "events"
+        # 11 event_to_signal_latency samples: 1..11 ms.
+        records = [
+            {
+                "event_type": "event_to_signal_latency",
+                "source_event_id": f"e{i}",
+                "signal_type": "inbox",
+                "latency_ms": float(i),
+            }
+            for i in range(1, 12)
+        ]
+        # 5 bus_delivery_latency samples: 10, 20, 30, 40, 50.
+        records += [
+            {
+                "event_type": "bus_delivery_latency",
+                "message_id": f"m{i}",
+                "delivery_ms": float(v),
+            }
+            for i, v in enumerate([10.0, 20.0, 30.0, 40.0, 50.0])
+        ]
+        _write_events_jsonl(events_dir, "events-2026-04-23-001.jsonl", records)
+
+        summary = _load_latency_summary(events_dir)
+        assert set(summary.keys()) == {"event_to_signal", "bus_delivery"}
+
+        ets = summary["event_to_signal"]
+        assert ets["count"] == 11
+        # p50 of 1..11 = 6; p95 of 1..11 = 10.5 (linear interp)
+        assert ets["p50_ms"] == 6.0
+        assert ets["p95_ms"] == 10.5
+
+        bd = summary["bus_delivery"]
+        assert bd["count"] == 5
+        assert bd["p50_ms"] == 30.0
+        # p95 of [10,20,30,40,50] = linear interp between index 3.8: 40 + 0.8*(50-40)=48
+        assert bd["p95_ms"] == 48.0
+
+    def test_load_latency_summary_skips_malformed_lines(self, tmp_path: Path) -> None:
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        path = events_dir / "events-2026-04-23-001.jsonl"
+        with open(path, "w") as f:
+            f.write("not json\n")
+            f.write(
+                json.dumps(
+                    {
+                        "event_type": "event_to_signal_latency",
+                        "source_event_id": "a",
+                        "signal_type": "x",
+                        "latency_ms": 100.0,
+                    }
+                )
+                + "\n"
+            )
+            f.write("\n")  # empty line
+            f.write('{"event_type": "event_to_signal_latency"}\n')  # missing field
+        summary = _load_latency_summary(events_dir)
+        assert summary["event_to_signal"]["count"] == 1
+        assert summary["event_to_signal"]["p50_ms"] == 100.0
+
+    def test_load_latency_summary_caps_file_count(self, tmp_path: Path) -> None:
+        """Only the most recent ``max_files`` JSONLs are scanned."""
+        from bid_euchre.ops.dashboard import _load_latency_summary
+
+        events_dir = tmp_path / "events"
+        # 3 older files each with one sample=1.0 (these should be skipped when
+        # max_files=2 and a newer file carries sample=99.0).
+        for i in range(1, 4):
+            _write_events_jsonl(
+                events_dir,
+                f"events-2026-04-2{i}-001.jsonl",
+                [
+                    {
+                        "event_type": "event_to_signal_latency",
+                        "source_event_id": "a",
+                        "signal_type": "x",
+                        "latency_ms": 1.0,
+                    }
+                ],
+            )
+        # Newest file has a distinctive value.
+        _write_events_jsonl(
+            events_dir,
+            "events-2026-04-24-001.jsonl",
+            [
+                {
+                    "event_type": "event_to_signal_latency",
+                    "source_event_id": "b",
+                    "signal_type": "x",
+                    "latency_ms": 99.0,
+                }
+            ],
+        )
+        summary = _load_latency_summary(events_dir, max_files=2)
+        # With max_files=2 we pick the 2 most recent (2026-04-23 and 24):
+        # count=2 (sample 1.0 + sample 99.0).
+        assert summary["event_to_signal"]["count"] == 2
+
+    def test_format_dashboard_text_hides_panel_when_empty(self) -> None:
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        view = DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            latencies={},
+        )
+        text = format_dashboard_text(view, now=now)
+        assert "Latencies" not in text
+
+    def test_format_dashboard_text_renders_populated_panel(self) -> None:
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        view = DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            latencies={
+                "event_to_signal": {"count": 42, "p50_ms": 12.5, "p95_ms": 88.0},
+                "bus_delivery": {"count": 7, "p50_ms": 3.2, "p95_ms": 9.9},
+            },
+        )
+        text = format_dashboard_text(view, now=now)
+        assert "Latencies" in text
+        # Panel shows both metrics with their stats.
+        assert "event_to_signal" in text
+        assert "bus_delivery" in text
+        assert "p50=12.5ms" in text
+        assert "p95=88.0ms" in text
+        assert "n=42" in text
+        assert "n=7" in text
+
+    def test_format_dashboard_json_includes_latencies(self) -> None:
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        payload = {"event_to_signal": {"count": 3, "p50_ms": 1.0, "p95_ms": 2.0}}
+        view = DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            latencies=payload,
+        )
+        result = format_dashboard_json(view)
+        assert result["latencies"] == payload
+
+    def test_format_dashboard_json_latencies_null_when_empty(self) -> None:
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        view = DashboardView(
+            generated_at=now.isoformat(),
+            foreground=DashboardSection(title="Foreground Lanes", lanes=[]),
+            background=DashboardSection(title="Background Lanes", lanes=[]),
+            latencies={},
+        )
+        result = format_dashboard_json(view)
+        assert result["latencies"] is None
+
+    def test_build_dashboard_view_wires_latencies_field(
+        self, runtime_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Integration: build_dashboard_view picks up STEWARD_EVENTS_LOG_DIR."""
+        events_dir = tmp_path / "events_pool"
+        _write_events_jsonl(
+            events_dir,
+            "events-2026-04-23-001.jsonl",
+            [
+                {
+                    "event_type": "event_to_signal_latency",
+                    "source_event_id": "a",
+                    "signal_type": "x",
+                    "latency_ms": 50.0,
+                },
+                {
+                    "event_type": "event_to_signal_latency",
+                    "source_event_id": "b",
+                    "signal_type": "x",
+                    "latency_ms": 150.0,
+                },
+            ],
+        )
+        monkeypatch.setenv("STEWARD_EVENTS_LOG_DIR", str(events_dir))
+
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        view = build_dashboard_view(runtime_dir, now=now)
+
+        assert view.latencies.get("event_to_signal", {}).get("count") == 2
+        assert view.latencies["event_to_signal"]["p50_ms"] == 100.0

--- a/tests/unit/test_portability_audit.py
+++ b/tests/unit/test_portability_audit.py
@@ -61,21 +61,26 @@ def _load_audit_module():
 # They should only decrease as decoupling work proceeds.  If a PR increases
 # coupling, either fix the regression or update the threshold with justification.
 
-NON_COSMETIC_THRESHOLD = 264  # hard-block + soft-coupling
+NON_COSMETIC_THRESHOLD = 265  # hard-block + soft-coupling
 # Baseline was 253; main drifted to 257 before Slice D landed (pre-existing,
 # unrelated to token-economy work). Slice D added 2 more hits because the
 # `lane-name-in-code` regex matches the string literals `"ops"` and `"review"`
 # in LANE_DEFAULT_POLICY — those are task_type taxonomy keys (#2169 Slice D),
 # not lane identifiers, so this is a known audit false positive.
-
+#
 # Primitive B-exec.α (B.10 effort policy, shaping §7) adds 4 more hits for
 # the same reason — `"ops"` and `"review"` appear in both `_VALID_ARCHETYPES`
 # and `POLICY_TABLE` of `src/bid_euchre/ops/effort_policy.py` as archetype
 # taxonomy keys. Primitive B-exec.β (B.1 adaptive dispatch, shaping §6)
 # adds 1 more hit — `_archetype_for_lane` in `src/bid_euchre/ops/learning.py`
 # enumerates `("orchestrator", "ops", "review")` as archetype names per the
-# §G13 8-archetype taxonomy. Downstream portability cleanup will narrow the
-# regex or formalize archetype/task_type as Enums.
+# §G13 8-archetype taxonomy. Primitive A Phase 0 (event schema v1.0,
+# shaping §8) adds 1 more hit for the same category of false positive —
+# the `tmux-session-default` regex matches the literal `"steward"` embedded
+# in an inline comment on `src/bid_euchre/ops/event_schema.py:196` (the
+# `"source"` optional field's comment reads `"steward" | "native"`,
+# documenting §2.2 of the schema spec). Downstream portability cleanup
+# will narrow the regex or formalize archetype/task_type as Enums.
 HARD_BLOCK_THRESHOLD = 130  # hard-block only (pinned to baseline)
 
 

--- a/tests/unit/test_portability_audit.py
+++ b/tests/unit/test_portability_audit.py
@@ -67,20 +67,22 @@ NON_COSMETIC_THRESHOLD = 265  # hard-block + soft-coupling
 # `lane-name-in-code` regex matches the string literals `"ops"` and `"review"`
 # in LANE_DEFAULT_POLICY — those are task_type taxonomy keys (#2169 Slice D),
 # not lane identifiers, so this is a known audit false positive.
-#
+
 # Primitive B-exec.α (B.10 effort policy, shaping §7) adds 4 more hits for
 # the same reason — `"ops"` and `"review"` appear in both `_VALID_ARCHETYPES`
 # and `POLICY_TABLE` of `src/bid_euchre/ops/effort_policy.py` as archetype
 # taxonomy keys. Primitive B-exec.β (B.1 adaptive dispatch, shaping §6)
 # adds 1 more hit — `_archetype_for_lane` in `src/bid_euchre/ops/learning.py`
 # enumerates `("orchestrator", "ops", "review")` as archetype names per the
-# §G13 8-archetype taxonomy. Primitive A Phase 0 (event schema v1.0,
-# shaping §8) adds 1 more hit for the same category of false positive —
-# the `tmux-session-default` regex matches the literal `"steward"` embedded
-# in an inline comment on `src/bid_euchre/ops/event_schema.py:196` (the
-# `"source"` optional field's comment reads `"steward" | "native"`,
-# documenting §2.2 of the schema spec). Downstream portability cleanup
-# will narrow the regex or formalize archetype/task_type as Enums.
+# §G13 8-archetype taxonomy.
+
+# Primitive A Phase 0 (event schema v1.0, shaping §8) adds 1 more hit for
+# the same category of false positive — the `tmux-session-default` regex
+# matches the literal `"steward"` embedded in an inline comment on
+# `src/bid_euchre/ops/event_schema.py:196` (the `"source"` optional field's
+# comment reads `"steward" | "native"`, documenting §2.2 of the schema spec).
+# Downstream portability cleanup will narrow the regex or formalize
+# archetype/task_type as Enums.
 HARD_BLOCK_THRESHOLD = 130  # hard-block only (pinned to baseline)
 
 


### PR DESCRIPTION
## Plan

`plans/steward_platform/1_primitive_A/shaping.md` §8 Packet 3

## Summary

Implements the Event Schema v1.0 surface called out by
`plans/steward_platform/1_primitive_A/shaping.md` §8 (Packet 3). This is
the upstream half of the event-to-signal latency contract (Pattern 10
row A.5) that every downstream primitive (B.1 dispatch, D.1 archivist,
E.2 active triage, H.1 replay lab) consumes.

- **Schema + emission:** `event_schema.py` (`SCHEMA_VERSION = "1.0"`,
  35-type `EVENT_FIELD_REGISTRY`), `event_writer.py` (JSONL with daily
  rotation, paired `.meta.json` sidecar, cross-process flock, §2.4
  correlation fields), `event_taxonomy.py` (error categorization, status
  normalization, incident fingerprint), and `events.py` `emit()`
  dispatcher (never-raises envelope) alongside the legacy `append_event`
  path for Phase 0 dual-write safety.
- **Task-lifecycle migration:** `scripts/internal/ops.py`
  `task_started` / `task_completed` dispatched through `events.emit()`
  while still writing legacy records.
- **Hook integration:** `.claude/hooks/event_emit.sh` +
  `.claude/settings.json` registration for session-level lifecycle
  turns (no classifier blocking).
- **Audit + lint:** `scripts/internal/audit_event_emission.py`
  (green/yellow/red coverage across the 7
  `STEWARD_OPERATIONAL_CLASSES`); `agent_readability_lint.py check
  verification-contract` (V1–V6 rules for Pattern 10 surface
  discipline).
- **Dashboard + observability:** `src/bid_euchre/ops/dashboard.py`
  `Latencies` panel (p50/p95/count) reading last N JSONL files; hidden
  when empty; JSON emits null.
- **Rollback (Pattern 7):** `STEWARD_EVENTS_POLLING_FALLBACK` flag
  registered in `.claude/rules/feature_flags.md` with a 1-minute SLO;
  `tests/integration/test_polling_fallback.py` is the flag-shape smoke
  that Primitive E expands once the live consumer lands.
- **Docs:** `docs/01_core/event_schema_v1.md` (operator catalog for the
  v1.0 schema: file layout, §9.7 IDs, §2.4 correlation, verbosity
  tiers, env vars, `extra_fields` bug marker, versioning, rollback
  path); `docs/ops/phoenix.md` (runbook stub for the deferred Phoenix
  deployment); `docs/01_core/ARCHITECTURE.md` adds
  `audit_event_emission.py` entry.
- **Data policy:** `.gitignore` now excludes `data/events/` raw JSONL.
- **Threshold bump:** `tests/unit/test_portability_audit.py` 263 → 265
  combining a tmux-session-default regex false positive on the
  `"steward"` string embedded in an inline comment of
  `event_schema.py:196` (Primitive A, +1) with the existing B-exec.β +1
  drift. Threshold comment carries the rationale.

## Test plan

- [x] `uv run python -m pytest tests/reliability/test_replay_compat.py`
      → 11 passed (Pattern 10 row A.4). v1.0 records emit with
      first-class IDs and correlation fields, round-trip through JSON,
      monotonic `seq`, `extra_fields` routing, never-raises on missing
      required / unknown types.
- [x] `uv run python -m pytest tests/integration/test_event_to_signal.py`
      → 3 passed (Pattern 10 row A.5). Emission lands in JSONL stream,
      latency events visible on dashboard pipeline (p50=63.0 for events
      42/84), audit script sees live emitters
      (`task_lifecycle=green`).
- [x] `uv run python -m pytest tests/integration/test_polling_fallback.py`
      → 4 passed (Pattern 7 row A.5). Flag documented in registry,
      parse convention honored, upstream emission unaffected by flag
      state.
- [x] `uv run python scripts/internal/audit_event_emission.py --json`
      → exit 0, YELLOW overall (expected for Phase 0 — deferred classes
      canary/archivist/promotion/rollback have no emitters yet);
      `task_lifecycle=green`, `latency_measurements=yellow`,
      `worktree=yellow`.
- [x] `uv run python scripts/internal/agent_readability_lint.py check
      verification-contract` → 0 findings (Pattern 10 V1–V6).
- [x] `make check-gated` → All checks passed (410s); 12447 passed,
      60 skipped.

## Verification Performed

| Row | Surface | Command | Pass signal |
|---|---|---|---|
| A.4 | `tests/reliability/test_replay_compat.py` | `uv run python -m pytest tests/reliability/test_replay_compat.py` | 11/11 passed |
| A.5 event-to-signal | `tests/integration/test_event_to_signal.py` | `uv run python -m pytest tests/integration/test_event_to_signal.py` | 3/3 passed |
| A.5 rollback | `tests/integration/test_polling_fallback.py` | `uv run python -m pytest tests/integration/test_polling_fallback.py` | 4/4 passed |
| Pattern 10 (audit) | `scripts/internal/audit_event_emission.py --json` | `uv run python scripts/internal/audit_event_emission.py --json` | exit 0, `"overall": "yellow"`, `task_lifecycle=green` |
| Pattern 10 (V1–V6 lint) | `agent_readability_lint.py check verification-contract` | `uv run python scripts/internal/agent_readability_lint.py check verification-contract` | 0 findings |
| Tier 2 | `make check-gated` | `make check-gated` | All checks passed (410s) |

## Worktree proof

- `pwd`: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author`
- `git rev-parse --show-toplevel`:
  `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author`
- `git rev-parse --abbrev-ref HEAD`: `feat/primitive-a-event-schema-v1`

## References

- Packet: `877f8f9c3f35`
- Plan: `plans/steward_platform/1_primitive_A/shaping.md` §8 Packet 3
- Verification contract: `plans/steward_platform/verification_contract/map.md`
  rows A.1–A.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
