### PR TITLE
fix(review): default skip_preflight=True in run_once (Fixes #2811)

### DIFF
--- a/scripts/internal/review_lane_runner.py
+++ b/scripts/internal/review_lane_runner.py
@@ -880,18 +880,31 @@ def run_once(
     *,
     dry_run: bool = False,
     events_dir: Path | None = None,
-    skip_preflight: bool = False,
+    skip_preflight: bool = True,
 ) -> list[ReviewVerdict]:
     """Scan the queue and process all pending requests.
 
-    Runs pre-flight health checks before processing to detect and recover
-    from common stall causes (detached HEAD, stale locks, expired auth).
+    Pre-flight health checks are **opt-in**: callers who want detached-HEAD
+    recovery, stale-lock cleanup, and auth checks must pass
+    ``skip_preflight=False`` explicitly. The production review loop
+    (``run_loop``) opts in on cycle 1 only; all other callers — including
+    ``--once`` CLI invocations and every test — skip preflight to avoid
+    mutating the worktree.
+
+    Rationale: preflight calls ``_check_worktree_health`` which on a
+    detached HEAD (e.g. CI's ``refs/pull/N/merge`` checkout, or any
+    transient state) runs ``git checkout main`` + ``git reset --hard
+    origin/main``. When tests reach ``run_once()`` through mocking holes,
+    that reset silently reverts working-tree changes mid-pytest, causing
+    cross-test contamination on the next shard (see Issue #2811).
 
     Args:
         queue_dir: Override for queue root directory.
         dry_run: Skip actual review invocation.
         events_dir: Override for events directory.
-        skip_preflight: Skip pre-flight health checks (for testing).
+        skip_preflight: Skip pre-flight health checks (default True — safe
+            for tests and one-shot invocations). Pass False only from the
+            production review loop on its first cycle.
 
     Returns:
         List of verdicts written during this cycle.
@@ -945,7 +958,9 @@ def run_loop(
 
     for cycle in range(1, max_cycles + 1):
         logger.debug("Poll cycle %d/%d", cycle, max_cycles)
-        # Pre-flight on first cycle only (worktree refresh, lock cleanup, auth)
+        # Pre-flight on first cycle only (worktree refresh, lock cleanup, auth).
+        # run_once() defaults to skip_preflight=True; the production loop is
+        # the sole caller that opts in, and only on cycle 1.
         verdicts = run_once(
             queue_dir,
             dry_run=dry_run,

--- a/tests/unit/test_review_lane_runner.py
+++ b/tests/unit/test_review_lane_runner.py
@@ -916,19 +916,41 @@ class TestRunOnceWithPreflight:
     """Verify run_once integrates pre-flight checks."""
 
     @patch("review_lane_runner.preflight_health_check")
-    def test_run_once_calls_preflight(
+    def test_run_once_calls_preflight_when_explicitly_opted_in(
         self,
         mock_preflight: MagicMock,
         queue_dir: Path,
     ) -> None:
-        """run_once calls preflight_health_check by default."""
+        """run_once runs preflight when caller passes skip_preflight=False.
+
+        Opting in is reserved for the production review loop on cycle 1;
+        all other callers (including tests and ``--once`` CLI) should rely
+        on the default skip_preflight=True. See Issue #2811.
+        """
         mock_preflight.return_value = [
             ("worktree_health", True, "OK"),
             ("lock_cleanup", True, "0 locks"),
             ("codex_auth", True, "OK"),
         ]
-        run_once(queue_dir, dry_run=True)
+        run_once(queue_dir, dry_run=True, skip_preflight=False)
         mock_preflight.assert_called_once()
+
+    @patch("review_lane_runner.preflight_health_check")
+    def test_run_once_skips_preflight_by_default(
+        self,
+        mock_preflight: MagicMock,
+        queue_dir: Path,
+    ) -> None:
+        """run_once skips preflight by default (Issue #2811).
+
+        The default was flipped from False to True so that tests reaching
+        ``run_once`` through mocking holes never trigger the detached-HEAD
+        recovery path (``git checkout main`` + ``git reset --hard``)
+        which silently mutates the worktree mid-pytest and causes
+        cross-shard contamination.
+        """
+        run_once(queue_dir, dry_run=True)
+        mock_preflight.assert_not_called()
 
     @patch("review_lane_runner.preflight_health_check")
     def test_run_once_skips_preflight(


### PR DESCRIPTION
## Summary

- Flip ``run_once()`` default ``skip_preflight`` from ``False`` → ``True``
  in ``scripts/internal/review_lane_runner.py`` so pre-flight health checks
  are **opt-in**. Only the production review loop (``run_loop``) passes
  ``skip_preflight=False`` on its first cycle.
- Rename the test that encoded the old default and add a new test locking
  in the flipped behavior.

## Why

Issue #2811. Shard-2 CI on PR #2798 was reverting ``.claude/settings.json``
and ``.claude/hooks/README.md`` to pre-PR state. Root cause:
``preflight_health_check`` calls ``_check_worktree_health(_REPO_ROOT)``
which, on a detached HEAD (CI's ``refs/pull/N/merge`` checkout), runs
``git checkout main`` followed by ``git reset --hard origin/main``.

When a test reaches ``run_once`` through a mocking hole (e.g.
``TestRunOnce::test_processes_pending_and_returns_verdicts`` mocks
``process_request`` but not ``preflight_health_check``), that worktree
reset silently mutates files mid-pytest, contaminating the next shard.

Option 1 fix per orchestrator directive: make pre-flight opt-in so the
mutation path can only be reached by the single production caller that
actually wants it. Future tests that hit ``run_once`` cannot trigger the
hazard accidentally.

## Scope

* ``scripts/internal/review_lane_runner.py`` — flip default, expand
  docstring with #2811 rationale. ``run_loop`` already passes
  ``skip_preflight`` explicitly so no behavior change there. The
  ``--once`` CLI path (``main()``) now defaults to skip, which is the
  correct behavior for one-shot invocations.
* ``tests/unit/test_review_lane_runner.py`` — rename
  ``test_run_once_calls_preflight`` →
  ``test_run_once_calls_preflight_when_explicitly_opted_in`` (now passes
  ``skip_preflight=False`` to exercise the opt-in path); add
  ``test_run_once_skips_preflight_by_default`` asserting the new default.

The rogue test ``test_processes_pending_and_returns_verdicts`` **is not
modified** — it passes unchanged because ``run_once()`` no longer reaches
``preflight_health_check`` by default.

## Verification Performed

- ``uv run python -m pytest tests/unit/test_review_lane_runner.py -q``
  → **68 passed** (including the unmodified rogue test).
- ``uv run python -m pytest tests/unit/test_review_lane_runner.py -v -k
  \"test_processes_pending_and_returns_verdicts or
  test_run_once_skips_preflight or test_run_once_calls_preflight\"``
  → **4 passed** (rogue test + all three preflight behavioral tests).
- ``make check-gated`` → **all checks passed** (logs
  ``/tmp/make-check-fiflT4``).

Worktree proof:
```
pwd: /Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre-steward-author-d
branch: fix/review-skip-preflight-default
base: origin/main @ c16224a0
```

## Followup

After this PR merges, PR #2798 (Primitive E Phase 0 Packet E1) will be
rebased on top; shard-2 contamination should stop.

## Test plan

- [x] ``test_processes_pending_and_returns_verdicts`` passes unmodified
- [x] New ``test_run_once_skips_preflight_by_default`` passes
- [x] Renamed ``test_run_once_calls_preflight_when_explicitly_opted_in``
      passes with explicit ``skip_preflight=False``
- [x] Full ``test_review_lane_runner.py`` (68 tests) green
- [x] ``make check-gated`` green
- [ ] CI green on this PR (all shards)
- [ ] PR #2798 rebased on top; shard-2 no longer reverts working tree

## Idempotency

- [x] I reviewed ``.claude/rules/idempotency_checklist.md`` and confirmed
      my changes are idempotent, retry-safe, and observable.

Row-by-row audit (crossed ``[~]`` rows = no matching surface in this diff):
- [~] Row 1 (message send): no ``message_bus.py`` edits
- [~] Row 2 (task status update): no ``task_queue.py`` edits
- [~] Row 3 (event emission): no ``ops/events.py`` edits
- [~] Row 4 (file write — state files): no state-file writes
- [~] Row 5 (hook invocation): no ``.claude/hooks/`` edits
- [~] Row 6 (cron/loop registration): no ``/loop`` state edits
- [~] Row 7 (KB promotion): no ``knowledge/_promoted/`` edits
- [~] Row 8 (branch/worktree creation): no ``git worktree`` writes
      (and this PR eliminates the implicit worktree reset that #2811
      exposed, which is itself an idempotency improvement)
- [~] Row 9 (GitHub API writes): no ``gh`` writes
- [~] Row 10 (Claude Code slash-command from hook): n/a

Fixes #2811