### PR TITLE
fix(ops): record PR headRefOid in post-pr-review hook (#2706)

### DIFF
--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -34,8 +34,8 @@ if [[ "$COMMAND" == *"gh pr create"* ]] && [[ "$EXIT_CODE" == "0" ]]; then
   # Enqueue a durable review request via the queue substrate.
   # Pass values via environment variables to avoid shell injection
   # from branch names containing quotes or special characters.
-  SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
-  BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+  SHA=$(gh pr view "$PR_NUM" --json headRefOid --jq .headRefOid 2>/dev/null || git rev-parse HEAD 2>/dev/null || echo "unknown")
+  BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq .headRefName 2>/dev/null || git branch --show-current 2>/dev/null || echo "unknown")
   PR_REVIEW_NUM="$PR_NUM" PR_REVIEW_SHA="$SHA" PR_REVIEW_BRANCH="$BRANCH" \
     uv run python -c "
 import os

--- a/tests/unit/test_review_driver.py
+++ b/tests/unit/test_review_driver.py
@@ -1853,6 +1853,67 @@ class TestCapturePRHeadSha:
 
 
 # ---------------------------------------------------------------------------
+# main() entry point — SHA capture and no git-rev-parse regression (#2706)
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntryPoint:
+    """Verify main() chains through _capture_pr_head_sha, not git rev-parse.
+
+    Guards the integration path so a future refactor cannot silently bypass
+    _capture_pr_head_sha and reintroduce the local-worktree SHA bug (#2706).
+    """
+
+    def test_main_calls_capture_pr_head_sha_not_git_rev_parse(self) -> None:
+        """main() must call _capture_pr_head_sha(pr) and must not invoke
+        ``git rev-parse HEAD`` directly (which was the original #2706 bug).
+        """
+        from review_driver import main
+        from review_state import ReviewLoopState, ReviewState
+
+        pr_sha = "9ff9639eaa6884e194132fe11f54ad29c0c85c43"
+        terminal_state = ReviewLoopState(
+            pr_number=2661,
+            branch="b",
+            state=ReviewState.STOPPED_MAX_ITERATIONS.value,
+        )
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "review_driver",
+                    "--pr",
+                    "2661",
+                    "--trigger",
+                    "manual",
+                    "--branch",
+                    "b",
+                ],
+            ),
+            patch(
+                "review_driver._capture_pr_head_sha", return_value=pr_sha
+            ) as mock_capture,
+            patch("review_driver.load_state", return_value=terminal_state),
+            patch("review_driver._write_failure_sentinel"),
+            patch("review_driver.subprocess.run") as mock_run,
+        ):
+            result = main()
+
+        assert result == 0
+        mock_capture.assert_called_once_with(2661)
+        git_rev_parse_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and c.args[0][:3] == ["git", "rev-parse", "HEAD"]
+        ]
+        assert git_rev_parse_calls == [], (
+            "main() must not shell out to ``git rev-parse HEAD`` — "
+            "that was exactly the #2706 bug"
+        )
+
+
+# ---------------------------------------------------------------------------
 # V7: commit-policy precheck (Primitive C §4.6 / ADR 010 binding)
 #
 # See ``plans/steward_platform/3_primitive_C/shaping.md`` §4.6.  V7 is


### PR DESCRIPTION
## Summary
- Replace `git rev-parse HEAD` / `git branch --show-current` with `gh pr view --json headRefOid / headRefName` in `.claude/hooks/post-pr-review.sh` so `ReviewRequest.head_sha` always reflects the PR's GitHub-authoritative SHA, not the caller's local worktree HEAD.
- Add `TestMainEntryPoint.test_main_calls_capture_pr_head_sha_not_git_rev_parse` regression test verifying `main()` chains through `_capture_pr_head_sha`.

Refs #2706.

## Test plan
- [x] `make lint` clean (verified at branch HEAD)
- [x] `make test` clean (verified at branch HEAD)
- [x] New regression test asserts `main()` does not shell out to `git rev-parse HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)