### PR TITLE
fix(ops): strip parenthetical annotations from --scope (#2820)

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -85,6 +85,23 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
+# Scope annotation stripping
+# ---------------------------------------------------------------------------
+
+
+def _strip_scope_annotation(s: str) -> str:
+    """Return *s* with any trailing parenthetical annotation removed.
+
+    ``"src/foo/*.py (WRITE — NEW)"`` → ``"src/foo/*.py"``
+    ``"src/foo/*.py"`` → ``"src/foo/*.py"``  (unchanged)
+
+    Only the first `` (`` occurrence is used as the split point so that
+    patterns containing ``{`` or other glob meta-characters are unaffected.
+    """
+    idx = s.find(" (")
+    return s[:idx] if idx != -1 else s
+
+
 # Filesystem boundary enforcement
 # ---------------------------------------------------------------------------
 
@@ -1745,7 +1762,11 @@ def cmd_task(args: argparse.Namespace) -> int:
             owner=args.owner,
             priority=args.priority,
             domain=getattr(args, "domain", None),
-            scope_declared=args.scope_declared,
+            scope_declared=(
+                [_strip_scope_annotation(s) for s in args.scope_declared]
+                if args.scope_declared
+                else args.scope_declared
+            ),
             validation=args.validation,
             metadata=routing_metadata or None,
         )

--- a/tests/unit/test_ops_task_queue.py
+++ b/tests/unit/test_ops_task_queue.py
@@ -2,12 +2,13 @@
 
 Covers: TaskPacket/TaskAck/TaskResult creation, validation, serialization,
 queue I/O, lifecycle transitions, ack handling (approve/edit/redirect/reject),
-queue summary, and concurrent write safety.
+queue summary, concurrent write safety, and --scope annotation stripping.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 import threading
 from pathlib import Path
 
@@ -1040,3 +1041,131 @@ class TestValidateRoutingMetadata:
         # so unknowns are errors, not warnings.
         errors, _ = validate_routing_metadata({"effort_hint": "yolo"})
         assert any("effort_hint" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# _strip_scope_annotation + task create --scope integration (Issue #2820)
+# ---------------------------------------------------------------------------
+
+
+class TestStripScopeAnnotation:
+    """Unit tests for the _strip_scope_annotation helper in scripts/internal/ops.py."""
+
+    @staticmethod
+    def _import_helper():
+        scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from ops import _strip_scope_annotation  # type: ignore[import]
+
+        return _strip_scope_annotation
+
+    def test_annotated_single_write(self) -> None:
+        fn = self._import_helper()
+        assert fn("src/foo/*.py (WRITE — NEW)") == "src/foo/*.py"
+
+    def test_annotated_read(self) -> None:
+        fn = self._import_helper()
+        assert fn("tests/unit/test_bar.py (READ)") == "tests/unit/test_bar.py"
+
+    def test_bare_unchanged(self) -> None:
+        fn = self._import_helper()
+        assert fn("src/bar/**/*.py") == "src/bar/**/*.py"
+
+    def test_multiple_parens_only_first_split(self) -> None:
+        fn = self._import_helper()
+        # The ` (` inside the suffix should not corrupt the bare prefix.
+        assert fn("src/foo.py (A (nested))") == "src/foo.py"
+
+    def test_empty_string(self) -> None:
+        fn = self._import_helper()
+        assert fn("") == ""
+
+    def test_no_space_before_paren_unchanged(self) -> None:
+        """A bare `(` not preceded by a space is NOT stripped."""
+        fn = self._import_helper()
+        assert fn("src/foo(bar).py") == "src/foo(bar).py"
+
+
+class TestTaskCreateScopeStripping:
+    """Integration tests for --scope annotation stripping via ops.py main()."""
+
+    @staticmethod
+    def _main():
+        scripts_dir = Path(__file__).resolve().parents[2] / "scripts" / "internal"
+        if str(scripts_dir) not in sys.path:
+            sys.path.insert(0, str(scripts_dir))
+        from ops import main  # type: ignore[import]
+
+        return main
+
+    def test_single_annotated_scope_persists_bare(self, tmp_path: Path) -> None:
+        main = self._main()
+        rc = main(
+            [
+                "--runtime-dir",
+                str(tmp_path),
+                "task",
+                "create",
+                "--title",
+                "T",
+                "--scope",
+                "src/foo/*.py (WRITE — NEW)",
+            ]
+        )
+        assert rc == 0
+        from bid_euchre.ops.task_queue import list_packets
+
+        packets = list_packets(root=tmp_path / "task_queue")
+        assert len(packets) == 1
+        assert packets[0].scope_declared == ["src/foo/*.py"]
+
+    def test_mixed_annotated_and_bare_scopes(self, tmp_path: Path) -> None:
+        main = self._main()
+        rc = main(
+            [
+                "--runtime-dir",
+                str(tmp_path),
+                "task",
+                "create",
+                "--title",
+                "Mixed",
+                "--scope",
+                "src/foo/*.py (WRITE — NEW)",
+                "--scope",
+                "tests/unit/test_bar.py",
+                "--scope",
+                "docs/README.md (READ)",
+            ]
+        )
+        assert rc == 0
+        from bid_euchre.ops.task_queue import list_packets
+
+        packets = list_packets(root=tmp_path / "task_queue")
+        assert len(packets) == 1
+        assert packets[0].scope_declared == [
+            "src/foo/*.py",
+            "tests/unit/test_bar.py",
+            "docs/README.md",
+        ]
+
+    def test_bare_only_scope_unchanged(self, tmp_path: Path) -> None:
+        main = self._main()
+        rc = main(
+            [
+                "--runtime-dir",
+                str(tmp_path),
+                "task",
+                "create",
+                "--title",
+                "Bare",
+                "--scope",
+                "src/**/*.py",
+            ]
+        )
+        assert rc == 0
+        from bid_euchre.ops.task_queue import list_packets
+
+        packets = list_packets(root=tmp_path / "task_queue")
+        assert len(packets) == 1
+        assert packets[0].scope_declared == ["src/**/*.py"]


### PR DESCRIPTION
## Summary
- Adds `_strip_scope_annotation()` helper in `scripts/internal/ops.py` that removes trailing ` (...)` suffixes from each `--scope` value before the TaskPacket is persisted.
- Bare patterns pass through unchanged.
- Fixes scope-drift-guard.sh fnmatch failures caused by annotations like `(WRITE — NEW)` in scope globs.

This is a re-implementation of the run-5 #2820 fix that was lost when the original branch was reset before merge (see agent-platform Bid-Euchre lessons.md L-001 for the durability lesson).

## Test plan
- [x] Existing `tests/unit/test_ops_task_queue.py` extended with 131 lines of coverage for the new helper.
- [x] Worker exited done with exit_code=0; agent-platform review round 2 returned validation_pass=true with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)