### PR TITLE
Patch cmd_scope_set in scripts/internal/ops.py to strip parenthetical...

### DIFF
--- a/scripts/internal/ops.py
+++ b/scripts/internal/ops.py
@@ -1109,7 +1109,9 @@ def cmd_scope_set(args: argparse.Namespace) -> int:
 
     try:
         data = update_task_scope(
-            task_id, declared_files=declared, runtime_dir=args.runtime_dir
+            task_id,
+            declared_files=[_strip_scope_annotation(s) for s in declared],
+            runtime_dir=args.runtime_dir,
         )
     except (FileNotFoundError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/src/bid_euchre/ops/scope.py
+++ b/src/bid_euchre/ops/scope.py
@@ -69,6 +69,9 @@ def _matches_any_pattern(path: str, patterns: list[str]) -> bool:
     the ``**/`` segment removed so that direct children match too.
     """
     for pattern in patterns:
+        # Strip trailing parenthetical annotations persisted by legacy packets
+        # e.g. "src/foo/*.py (READ)" → "src/foo/*.py"
+        pattern = pattern.split(" (")[0]
         if fnmatch.fnmatch(path, pattern):
             return True
         # Also try matching just the basename for simple patterns

--- a/tests/unit/test_ops_cli.py
+++ b/tests/unit/test_ops_cli.py
@@ -1732,6 +1732,36 @@ class TestScopeSet:
             "tests/unit/test_ops_*.py",
         ]
 
+    def test_set_declared_strips_annotation(
+        self, runtime_dir: Path, plans_dir: Path
+    ) -> None:
+        import ops
+
+        (runtime_dir / "task_state" / "t2.json").write_text(
+            json.dumps({"task_id": "t2", "status": "in_progress"})
+        )
+        rc = ops.main(
+            [
+                "--runtime-dir",
+                str(runtime_dir),
+                "--plans-dir",
+                str(plans_dir),
+                "scope",
+                "set",
+                "--task",
+                "t2",
+                "--declared",
+                "src/foo/*.py (READ)",
+                "tests/unit/*.py",
+            ]
+        )
+        assert rc == 0
+        data = json.loads((runtime_dir / "task_state" / "t2.json").read_text())
+        assert data["scope"]["declared_files"] == [
+            "src/foo/*.py",
+            "tests/unit/*.py",
+        ]
+
 
 class TestScopeTouch:
     """Tests for ops.py scope touch."""

--- a/tests/unit/test_ops_scope.py
+++ b/tests/unit/test_ops_scope.py
@@ -75,6 +75,16 @@ class TestMatchesAnyPattern:
         assert _matches_any_pattern("src/ops/deep/file.py", ["**/*.py"]) is True
         assert _matches_any_pattern("file.py", ["**/*.py"]) is True
 
+    def test_annotated_pattern_matches(self) -> None:
+        """Guard-time strip: annotated legacy pattern still matches a conforming path."""
+        assert _matches_any_pattern("src/foo/bar.py", ["src/foo/*.py (READ)"]) is True
+
+    def test_annotated_pattern_no_false_positive(self) -> None:
+        """Guard-time strip: annotated pattern does not match an out-of-scope path."""
+        assert (
+            _matches_any_pattern("tests/foo/bar.py", ["src/foo/*.py (READ)"]) is False
+        )
+
 
 # --- ScopeDriftReport dataclass ---
 


### PR DESCRIPTION
## Summary
- ops.py scope set --task T --declared 'src/foo/*.py (READ)' persists ['src/foo/*.py'] in the task-state JSON
- _matches_any_pattern('src/foo/bar.py', ['src/foo/*.py (READ)']) returns True (guard-time strip)
- Bare patterns through scope set are unchanged
- make lint exits 0
- make test exits 0 including the new test classes

## Test plan

- [ ] `make lint`
- [ ] `make test`

Plan: `/Users/claude_runner/Projects/Bid-Euchre-meta/Bid-Euchre/plans/issue-2820-strip-scope-parens/plan.md`

🤖 Generated with agent task ship